### PR TITLE
SK-249: Hide `role` command from help output

### DIFF
--- a/internal/commands/role.go
+++ b/internal/commands/role.go
@@ -17,9 +17,10 @@ import (
 // NewRoleCommand creates the role command with subcommands
 func NewRoleCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "role",
-		Short: "Manage roles",
-		Long:  "Manage roles for the current profile. Roles control which skills are available.",
+		Use:    "role",
+		Short:  "Manage roles",
+		Long:   "Manage roles for the current profile. Roles control which skills are available.",
+		Hidden: true,
 	}
 
 	cmd.AddCommand(newRoleListCommand())

--- a/internal/commands/role_test.go
+++ b/internal/commands/role_test.go
@@ -73,7 +73,7 @@ func TestRoleCommandRejectsLocalProfile(t *testing.T) {
 				t.Fatal("Expected error for local profile, got nil")
 			}
 			if !strings.Contains(err.Error(), "only supported for remote") {
-				t.Errorf("Expected 'only supported for remote' error, got: %v", err)
+				t.Errorf("Expected 'only supported for remote' in error, got: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
Excludes the recently added command from the help output, it's a feature we're just testing out and we don't want to advertise it yet.