### PR TITLE
SK-253: Fix MCP config written to wrong path

### DIFF
--- a/internal/clients/claude_code/hooks.go
+++ b/internal/clients/claude_code/hooks.go
@@ -43,7 +43,7 @@ func installBootstrap(opts []bootstrap.Option) error {
 	// Install MCP servers from options that have MCPConfig
 	for _, opt := range opts {
 		if opt.MCPConfig != nil {
-			if err := installMCPServerFromConfig(home, opt.MCPConfig); err != nil {
+			if err := installMCPServerFromConfig(claudeDir, opt.MCPConfig); err != nil {
 				log.Error("failed to install MCP server", "server", opt.MCPConfig.Name, "error", err)
 				return fmt.Errorf("failed to install MCP server %s: %w", opt.MCPConfig.Name, err)
 			}
@@ -54,7 +54,7 @@ func installBootstrap(opts []bootstrap.Option) error {
 }
 
 // installMCPServerFromConfig installs an MCP server from a bootstrap.MCPServerConfig
-func installMCPServerFromConfig(homeDir string, config *bootstrap.MCPServerConfig) error {
+func installMCPServerFromConfig(claudeDir string, config *bootstrap.MCPServerConfig) error {
 	log := logger.Get()
 
 	serverConfig := map[string]any{
@@ -74,7 +74,7 @@ func installMCPServerFromConfig(homeDir string, config *bootstrap.MCPServerConfi
 		serverConfig["env"] = map[string]any{}
 	}
 
-	if err := handlers.AddMCPServer(homeDir, config.Name, serverConfig); err != nil {
+	if err := handlers.AddMCPServer(claudeDir, config.Name, serverConfig); err != nil {
 		return err
 	}
 
@@ -278,7 +278,7 @@ func uninstallBootstrap(opts []bootstrap.Option) error {
 
 	// Remove MCP servers
 	for _, name := range mcpToUninstall {
-		if err := uninstallMCPServerByName(home, name); err != nil {
+		if err := uninstallMCPServerByName(claudeDir, name); err != nil {
 			log.Error("failed to uninstall MCP server", "server", name, "error", err)
 			return fmt.Errorf("failed to uninstall MCP server %s: %w", name, err)
 		}
@@ -429,10 +429,10 @@ func installUsageReportingHook(claudeDir string) error {
 }
 
 // uninstallMCPServerByName removes an MCP server by name from ~/.claude.json
-func uninstallMCPServerByName(homeDir, name string) error {
+func uninstallMCPServerByName(claudeDir, name string) error {
 	log := logger.Get()
 
-	if err := handlers.RemoveMCPServer(homeDir, name); err != nil {
+	if err := handlers.RemoveMCPServer(claudeDir, name); err != nil {
 		return err
 	}
 

--- a/internal/clients/claude_code/hooks_test.go
+++ b/internal/clients/claude_code/hooks_test.go
@@ -1,0 +1,132 @@
+package claude_code
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/bootstrap"
+)
+
+// TestInstallBootstrapMCP_WritesToClaudeJSON verifies that bootstrap MCP install
+// writes to ~/.claude.json (global scope), not {parent}/.mcp.json.
+// Regression test: previously homeDir was passed instead of claudeDir to
+// AddMCPServer, causing mcpConfigPath to resolve filepath.Dir(homeDir)/.mcp.json
+// (e.g., /Users/.mcp.json) instead of ~/.claude.json.
+func TestInstallBootstrapMCP_WritesToClaudeJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home", "testuser")
+	claudeDir := filepath.Join(homeDir, ".claude")
+
+	t.Setenv("HOME", homeDir)
+
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("Failed to create .claude directory: %v", err)
+	}
+
+	mcpOpt := bootstrap.Option{
+		Key:         bootstrap.SleuthAIQueryMCPKey,
+		Description: "Test MCP",
+		MCPConfig: &bootstrap.MCPServerConfig{
+			Name:    "sx",
+			Command: "test-sx",
+			Args:    []string{"serve"},
+		},
+	}
+
+	if err := installBootstrap([]bootstrap.Option{mcpOpt}); err != nil {
+		t.Fatalf("installBootstrap failed: %v", err)
+	}
+
+	// The MCP server should be written to ~/.claude.json (global scope)
+	claudeJSON := filepath.Join(homeDir, ".claude.json")
+	if _, err := os.Stat(claudeJSON); os.IsNotExist(err) {
+		parentMCP := filepath.Join(filepath.Dir(homeDir), ".mcp.json")
+		if _, err := os.Stat(parentMCP); err == nil {
+			t.Fatalf("MCP config written to %s instead of %s — homeDir passed instead of claudeDir", parentMCP, claudeJSON)
+		}
+		t.Fatalf("Expected %s to exist after bootstrap MCP install", claudeJSON)
+	}
+
+	data, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatalf("Failed to read .claude.json: %v", err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse .claude.json: %v", err)
+	}
+
+	mcpServers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers section not found in .claude.json")
+	}
+
+	if _, ok := mcpServers["sx"].(map[string]any); !ok {
+		t.Fatal("sx server not found in mcpServers")
+	}
+}
+
+// TestUninstallBootstrapMCP_RemovesFromClaudeJSON verifies that bootstrap MCP
+// uninstall removes from ~/.claude.json (global scope).
+func TestUninstallBootstrapMCP_RemovesFromClaudeJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home", "testuser")
+	claudeDir := filepath.Join(homeDir, ".claude")
+
+	t.Setenv("HOME", homeDir)
+
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("Failed to create .claude directory: %v", err)
+	}
+
+	// Pre-populate ~/.claude.json with an MCP server
+	claudeJSON := filepath.Join(homeDir, ".claude.json")
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			"sx": map[string]any{
+				"command": "test-sx",
+				"args":    []any{"serve"},
+				"type":    "stdio",
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	if err := os.WriteFile(claudeJSON, data, 0644); err != nil {
+		t.Fatalf("Failed to write .claude.json: %v", err)
+	}
+
+	mcpOpt := bootstrap.Option{
+		Key:         bootstrap.SleuthAIQueryMCPKey,
+		Description: "Test MCP",
+		MCPConfig: &bootstrap.MCPServerConfig{
+			Name:    "sx",
+			Command: "test-sx",
+			Args:    []string{"serve"},
+		},
+	}
+
+	if err := uninstallBootstrap([]bootstrap.Option{mcpOpt}); err != nil {
+		t.Fatalf("uninstallBootstrap failed: %v", err)
+	}
+
+	data, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatalf("Failed to read .claude.json: %v", err)
+	}
+
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse .claude.json: %v", err)
+	}
+
+	mcpServers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers section not found")
+	}
+
+	if _, exists := mcpServers["sx"]; exists {
+		t.Error("sx server should have been removed from .claude.json")
+	}
+}


### PR DESCRIPTION
- Pass claudeDir instead of homeDir to MCP install/uninstall
- Add regression tests for bootstrap MCP path resolution