### PR TITLE
SK-295: Fix autoupdate with two-phase marker

### DIFF
--- a/cmd/sx/main.go
+++ b/cmd/sx/main.go
@@ -58,7 +58,9 @@ func main() {
 	// Apply any pending update from a previous background check that didn't complete.
 	// If an update was applied, re-exec so the new binary handles this invocation.
 	if autoupdate.ApplyPendingUpdate() && exe != "" {
-		_ = syscall.Exec(exe, os.Args, os.Environ())
+		if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+			log.Error("failed to re-exec after update", "error", err)
+		}
 	}
 
 	// Check for updates in the background (non-blocking, once per day)

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	githubOwner       = "sleuth-io"
-	githubRepo        = "sx"
+	GithubOwner       = "sleuth-io"
+	GithubRepo        = "sx"
 	checkInterval     = 24 * time.Hour
 	updateCacheFile   = "last-update-check"
 	pendingUpdateFile = "pending-update.json"
@@ -119,10 +119,10 @@ func ApplyPendingUpdate() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
 	defer cancel()
 
-	// Suppress stdout during update
+	// Suppress stdout during update (deferred to guarantee restoration on panic)
 	restoreStdout := suppressStdout()
+	defer restoreStdout()
 	err = selfupdate.UpdateTo(ctx, pending.AssetURL, pending.AssetName, execPath)
-	restoreStdout()
 
 	// Always remove the marker — if the update failed, the next background check
 	// will detect a newer version and create a new marker
@@ -189,7 +189,7 @@ func checkAndUpdate() error {
 	})
 
 	// Detect latest release
-	release, found, err := updater.DetectLatest(ctx, selfupdate.ParseSlug(fmt.Sprintf("%s/%s", githubOwner, githubRepo)))
+	release, found, err := updater.DetectLatest(ctx, selfupdate.ParseSlug(fmt.Sprintf("%s/%s", GithubOwner, GithubRepo)))
 	if err != nil {
 		// Don't update timestamp on error — allow retry next time
 		return err
@@ -215,13 +215,12 @@ func checkAndUpdate() error {
 	// Update check timestamp — we successfully checked
 	_ = updateCheckTimestamp()
 
-	// Suppress stdout during update
+	// Suppress stdout during update (deferred to guarantee restoration on panic)
 	restoreStdout := suppressStdout()
+	defer restoreStdout()
 
 	// Attempt the update — may not complete if process exits
 	err = updater.UpdateTo(ctx, release, "")
-
-	restoreStdout()
 
 	if err != nil {
 		// Marker remains for Phase 2 to retry

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -8,18 +8,21 @@ import (
 	"time"
 
 	"github.com/sleuth-io/sx/internal/buildinfo"
-	"github.com/sleuth-io/sx/internal/cache"
 )
 
+// useTempCache isolates the test from the real cache directory
+func useTempCache(t *testing.T) {
+	t.Helper()
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+}
+
 func TestShouldCheckDevBuild(t *testing.T) {
-	// Save original version
+	useTempCache(t)
 	originalVersion := buildinfo.Version
 	defer func() { buildinfo.Version = originalVersion }()
 
-	// Set version to "dev"
 	buildinfo.Version = "dev"
 
-	// Should return early for dev builds
 	err := checkAndUpdate()
 	if err != nil {
 		t.Errorf("Expected no error for dev build, got: %v", err)
@@ -27,104 +30,62 @@ func TestShouldCheckDevBuild(t *testing.T) {
 }
 
 func TestShouldCheckWithNoCache(t *testing.T) {
-	// Clean up any existing cache
-	cacheDir, err := cache.GetCacheDir()
-	if err != nil {
-		t.Fatalf("Failed to get cache dir: %v", err)
-	}
-	lastCheckFile := filepath.Join(cacheDir, updateCacheFile)
-	_ = os.Remove(lastCheckFile)
+	useTempCache(t)
 
-	// Should check when there's no cache file
 	if !shouldCheck() {
 		t.Error("Expected shouldCheck to return true when cache file doesn't exist")
 	}
 }
 
 func TestShouldCheckWithRecentCache(t *testing.T) {
-	// Create a recent cache file
-	cacheDir, err := cache.GetCacheDir()
-	if err != nil {
-		t.Fatalf("Failed to get cache dir: %v", err)
-	}
+	useTempCache(t)
 
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		t.Fatalf("Failed to create cache dir: %v", err)
-	}
-
-	lastCheckFile := filepath.Join(cacheDir, updateCacheFile)
-
-	// Create cache file with current timestamp
 	if err := updateCheckTimestamp(); err != nil {
 		t.Fatalf("Failed to update timestamp: %v", err)
 	}
 
-	// Should not check when cache is recent
 	if shouldCheck() {
 		t.Error("Expected shouldCheck to return false when cache is recent")
 	}
-
-	// Clean up
-	_ = os.Remove(lastCheckFile)
 }
 
 func TestShouldCheckWithOldCache(t *testing.T) {
-	// Create an old cache file
-	cacheDir, err := cache.GetCacheDir()
-	if err != nil {
-		t.Fatalf("Failed to get cache dir: %v", err)
-	}
+	useTempCache(t)
 
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		t.Fatalf("Failed to create cache dir: %v", err)
+	if err := updateCheckTimestamp(); err != nil {
+		t.Fatalf("Failed to update timestamp: %v", err)
 	}
-
-	lastCheckFile := filepath.Join(cacheDir, updateCacheFile)
-
-	// Create file and set old modification time
-	f, err := os.Create(lastCheckFile)
-	if err != nil {
-		t.Fatalf("Failed to create cache file: %v", err)
-	}
-	f.Close()
 
 	// Set modification time to 25 hours ago (past the 24 hour threshold)
+	cacheDir := os.Getenv("SX_CACHE_DIR")
+	lastCheckFile := filepath.Join(cacheDir, updateCacheFile)
 	oldTime := time.Now().Add(-25 * time.Hour)
 	if err := os.Chtimes(lastCheckFile, oldTime, oldTime); err != nil {
 		t.Fatalf("Failed to set file time: %v", err)
 	}
 
-	// Should check when cache is old
 	if !shouldCheck() {
 		t.Error("Expected shouldCheck to return true when cache is old")
 	}
-
-	// Clean up
-	_ = os.Remove(lastCheckFile)
 }
 
 func TestUpdateCheckTimestamp(t *testing.T) {
-	// Create timestamp
+	useTempCache(t)
+
 	if err := updateCheckTimestamp(); err != nil {
 		t.Fatalf("Failed to update timestamp: %v", err)
 	}
 
-	// Verify file exists
-	cacheDir, err := cache.GetCacheDir()
-	if err != nil {
-		t.Fatalf("Failed to get cache dir: %v", err)
-	}
-
+	cacheDir := os.Getenv("SX_CACHE_DIR")
 	lastCheckFile := filepath.Join(cacheDir, updateCacheFile)
 	if _, err := os.Stat(lastCheckFile); os.IsNotExist(err) {
 		t.Error("Expected cache file to exist after updateCheckTimestamp")
 	}
-
-	// Clean up
-	_ = os.Remove(lastCheckFile)
 }
 
 func TestPendingUpdatePath(t *testing.T) {
+	useTempCache(t)
+
 	path, err := pendingUpdatePath()
 	if err != nil {
 		t.Fatalf("Failed to get pending update path: %v", err)
@@ -136,7 +97,8 @@ func TestPendingUpdatePath(t *testing.T) {
 }
 
 func TestClearPendingUpdate(t *testing.T) {
-	// Write a marker file
+	useTempCache(t)
+
 	markerPath, err := pendingUpdatePath()
 	if err != nil {
 		t.Fatalf("Failed to get marker path: %v", err)
@@ -150,51 +112,41 @@ func TestClearPendingUpdate(t *testing.T) {
 		t.Fatalf("Failed to write marker: %v", err)
 	}
 
-	// Verify it exists
 	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
 		t.Fatal("Marker file should exist before clear")
 	}
 
-	// Clear it
 	ClearPendingUpdate()
 
-	// Verify it's gone
 	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
 		t.Error("Marker file should not exist after ClearPendingUpdate")
 	}
 }
 
 func TestClearPendingUpdateNoFile(t *testing.T) {
-	// Should not panic when no marker exists
+	useTempCache(t)
 	ClearPendingUpdate()
 }
 
 func TestApplyPendingUpdateNoMarker(t *testing.T) {
+	useTempCache(t)
 	originalVersion := buildinfo.Version
 	defer func() { buildinfo.Version = originalVersion }()
 
 	buildinfo.Version = "0.10.0"
 
-	// Make sure no marker exists
-	markerPath, err := pendingUpdatePath()
-	if err != nil {
-		t.Fatalf("Failed to get marker path: %v", err)
-	}
-	_ = os.Remove(markerPath)
-
-	// Should return false (no update applied)
 	if ApplyPendingUpdate() {
 		t.Error("Expected false when no marker exists")
 	}
 }
 
 func TestApplyPendingUpdateDevBuild(t *testing.T) {
+	useTempCache(t)
 	originalVersion := buildinfo.Version
 	defer func() { buildinfo.Version = originalVersion }()
 
 	buildinfo.Version = "dev"
 
-	// Write a marker that should be ignored for dev builds
 	markerPath, err := pendingUpdatePath()
 	if err != nil {
 		t.Fatalf("Failed to get marker path: %v", err)
@@ -208,7 +160,6 @@ func TestApplyPendingUpdateDevBuild(t *testing.T) {
 		t.Fatalf("Failed to write marker: %v", err)
 	}
 
-	// Should skip for dev builds without removing marker
 	if ApplyPendingUpdate() {
 		t.Error("Expected false for dev build")
 	}
@@ -217,19 +168,16 @@ func TestApplyPendingUpdateDevBuild(t *testing.T) {
 	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
 		t.Error("Marker should still exist for dev builds")
 	}
-
-	// Clean up
-	_ = os.Remove(markerPath)
 }
 
 func TestApplyPendingUpdateDisabled(t *testing.T) {
+	useTempCache(t)
 	originalVersion := buildinfo.Version
 	defer func() { buildinfo.Version = originalVersion }()
 
 	buildinfo.Version = "0.10.0"
 	t.Setenv("DISABLE_AUTOUPDATER", "1")
 
-	// Write a marker
 	markerPath, err := pendingUpdatePath()
 	if err != nil {
 		t.Fatalf("Failed to get marker path: %v", err)
@@ -243,7 +191,6 @@ func TestApplyPendingUpdateDisabled(t *testing.T) {
 		t.Fatalf("Failed to write marker: %v", err)
 	}
 
-	// Should skip when disabled
 	if ApplyPendingUpdate() {
 		t.Error("Expected false when disabled")
 	}
@@ -252,16 +199,13 @@ func TestApplyPendingUpdateDisabled(t *testing.T) {
 	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
 		t.Error("Marker should still exist when autoupdater is disabled")
 	}
-
-	// Clean up
-	_ = os.Remove(markerPath)
 }
 
 func TestApplyPendingUpdateAlreadyUpToDate(t *testing.T) {
+	useTempCache(t)
 	originalVersion := buildinfo.Version
 	defer func() { buildinfo.Version = originalVersion }()
 
-	// Set current version ahead of pending version
 	buildinfo.Version = "2.0.0"
 
 	markerPath, err := pendingUpdatePath()
@@ -284,18 +228,17 @@ func TestApplyPendingUpdateAlreadyUpToDate(t *testing.T) {
 		t.Fatalf("Failed to write marker: %v", err)
 	}
 
-	// Should skip and remove marker since we're already ahead
 	if ApplyPendingUpdate() {
 		t.Error("Expected false when already up to date")
 	}
 
-	// Marker should be removed
 	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
 		t.Error("Marker should be removed when version is already at or ahead")
 	}
 }
 
 func TestApplyPendingUpdateInvalidJSON(t *testing.T) {
+	useTempCache(t)
 	originalVersion := buildinfo.Version
 	defer func() { buildinfo.Version = originalVersion }()
 
@@ -310,23 +253,22 @@ func TestApplyPendingUpdateInvalidJSON(t *testing.T) {
 		t.Fatalf("Failed to create dir: %v", err)
 	}
 
-	// Write invalid JSON
 	if err := os.WriteFile(markerPath, []byte(`not json`), 0644); err != nil {
 		t.Fatalf("Failed to write marker: %v", err)
 	}
 
-	// Should handle gracefully and remove bad marker
 	if ApplyPendingUpdate() {
 		t.Error("Expected false for invalid JSON")
 	}
 
-	// Marker should be removed
 	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
 		t.Error("Invalid marker should be removed")
 	}
 }
 
 func TestMarkerFileFormat(t *testing.T) {
+	useTempCache(t)
+
 	markerPath, err := pendingUpdatePath()
 	if err != nil {
 		t.Fatalf("Failed to get marker path: %v", err)
@@ -351,7 +293,6 @@ func TestMarkerFileFormat(t *testing.T) {
 		t.Fatalf("Failed to write: %v", err)
 	}
 
-	// Read it back
 	readData, err := os.ReadFile(markerPath)
 	if err != nil {
 		t.Fatalf("Failed to read: %v", err)
@@ -371,7 +312,4 @@ func TestMarkerFileFormat(t *testing.T) {
 	if readPending.AssetName != pending.AssetName {
 		t.Errorf("AssetName = %q, want %q", readPending.AssetName, pending.AssetName)
 	}
-
-	// Clean up
-	_ = os.Remove(markerPath)
 }

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -13,11 +13,6 @@ import (
 	"github.com/sleuth-io/sx/internal/ui/components"
 )
 
-const (
-	githubOwner = "sleuth-io"
-	githubRepo  = "sx"
-)
-
 // NewUpdateCommand creates the update command
 func NewUpdateCommand() *cobra.Command {
 	var checkOnly bool
@@ -56,7 +51,7 @@ func runUpdate(cmd *cobra.Command, checkOnly bool) error {
 
 	out.printf("Current version: %s\n", buildinfo.Version)
 
-	repository := selfupdate.ParseSlug(fmt.Sprintf("%s/%s", githubOwner, githubRepo))
+	repository := selfupdate.ParseSlug(fmt.Sprintf("%s/%s", autoupdate.GithubOwner, autoupdate.GithubRepo))
 
 	if checkOnly {
 		// Just check for latest version without updating


### PR DESCRIPTION
## Summary
- Fix background autoupdate goroutine getting killed before download completes on short-lived commands
- Add two-phase marker approach: Phase 1 writes pending-update.json marker, Phase 2 applies on next startup with re-exec
- Fix check timestamp being set on GitHub API errors, preventing retries for 24 hours
- Clear pending update marker after manual `sx update`

**Security implications of changes have been considered**