### PR TITLE
SK-329: Search external_plugins in marketplace

### DIFF
--- a/internal/clients/claude_code/handlers/claude_code_plugin_util.go
+++ b/internal/clients/claude_code/handlers/claude_code_plugin_util.go
@@ -367,6 +367,7 @@ func ResolveMarketplacePluginPathFromFile(knownMarketsPath, marketplaceName, plu
 
 	pluginPaths := []string{
 		filepath.Join(marketplace.InstallLocation, "plugins", pluginName),
+		filepath.Join(marketplace.InstallLocation, "external_plugins", pluginName),
 		filepath.Join(marketplace.InstallLocation, pluginName),
 	}
 
@@ -377,20 +378,25 @@ func ResolveMarketplacePluginPathFromFile(knownMarketsPath, marketplaceName, plu
 		}
 	}
 
-	pluginsDir := filepath.Join(marketplace.InstallLocation, "plugins")
-	if utils.IsDirectory(pluginsDir) {
-		entries, _ := os.ReadDir(pluginsDir)
-		var available []string
-		for _, entry := range entries {
-			if entry.IsDir() && entry.Name() != "." && entry.Name() != ".." {
-				if utils.FileExists(filepath.Join(pluginsDir, entry.Name(), ".claude-plugin", "plugin.json")) {
-					available = append(available, entry.Name())
+	searchDirs := []string{
+		filepath.Join(marketplace.InstallLocation, "plugins"),
+		filepath.Join(marketplace.InstallLocation, "external_plugins"),
+	}
+	var available []string
+	for _, dir := range searchDirs {
+		if utils.IsDirectory(dir) {
+			entries, _ := os.ReadDir(dir)
+			for _, entry := range entries {
+				if entry.IsDir() && entry.Name() != "." && entry.Name() != ".." {
+					if utils.FileExists(filepath.Join(dir, entry.Name(), ".claude-plugin", "plugin.json")) {
+						available = append(available, entry.Name())
+					}
 				}
 			}
 		}
-		if len(available) > 0 {
-			return "", fmt.Errorf("plugin %q not found in marketplace %q. Available plugins: %s", pluginName, marketplaceName, strings.Join(available, ", "))
-		}
+	}
+	if len(available) > 0 {
+		return "", fmt.Errorf("plugin %q not found in marketplace %q. Available plugins: %s", pluginName, marketplaceName, strings.Join(available, ", "))
 	}
 
 	return "", fmt.Errorf("plugin %q not found in marketplace %q", pluginName, marketplaceName)

--- a/internal/clients/claude_code/handlers/claude_code_plugin_util_test.go
+++ b/internal/clients/claude_code/handlers/claude_code_plugin_util_test.go
@@ -55,6 +55,47 @@ func TestResolveMarketplacePluginPathFromFile(t *testing.T) {
 			t.Fatal("expected error for nonexistent plugin")
 		}
 	})
+
+	t.Run("found plugin in external_plugins", func(t *testing.T) {
+		extPluginDir := filepath.Join(marketplaceDir, "external_plugins", "ext-plugin", ".claude-plugin")
+		if err := os.MkdirAll(extPluginDir, 0755); err != nil {
+			t.Fatalf("failed to create external plugin dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(extPluginDir, "plugin.json"), []byte(`{}`), 0644); err != nil {
+			t.Fatalf("failed to write plugin.json: %v", err)
+		}
+
+		path, err := ResolveMarketplacePluginPathFromFile(knownMarketsPath, "my-market", "ext-plugin")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := filepath.Join(marketplaceDir, "external_plugins", "ext-plugin")
+		if path != expected {
+			t.Errorf("expected %q, got %q", expected, path)
+		}
+	})
+
+	t.Run("plugins dir takes precedence over external_plugins", func(t *testing.T) {
+		// Create plugin in both plugins/ and external_plugins/
+		for _, subdir := range []string{"plugins", "external_plugins"} {
+			dir := filepath.Join(marketplaceDir, subdir, "dual-plugin", ".claude-plugin")
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("failed to create dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(`{}`), 0644); err != nil {
+				t.Fatalf("failed to write plugin.json: %v", err)
+			}
+		}
+
+		path, err := ResolveMarketplacePluginPathFromFile(knownMarketsPath, "my-market", "dual-plugin")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := filepath.Join(marketplaceDir, "plugins", "dual-plugin")
+		if path != expected {
+			t.Errorf("expected plugins/ to win, got %q", path)
+		}
+	})
 }
 
 func TestResolveMarketplaceNameFromFile(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `external_plugins/` as a search path for marketplace plugin resolution
- Update available plugins error listing to scan both `plugins/` and `external_plugins/`
- Add tests for external_plugins discovery and plugins/ precedence

Fixes `sx add slack@claude-plugins-official` failing because Claude Code's official marketplace puts third-party MCP plugins under `external_plugins/`.

**Security implications of changes have been considered**