### PR TITLE
SK-406: Use $HOME-relative paths in hook commands

### DIFF
--- a/internal/clients/claude_code/handlers/hook.go
+++ b/internal/clients/claude_code/handlers/hook.go
@@ -299,7 +299,7 @@ func (h *HookHandler) buildHookConfig(targetBase string) map[string]any {
 
 	installDir := filepath.Join(targetBase, h.GetInstallPath())
 	resolved := hook.ResolveCommand(h.metadata.Hook, installDir, h.zipFiles)
-	hookHandler["command"] = resolved.Command
+	hookHandler["command"] = utils.Portabilize(resolved.Command)
 
 	if h.metadata.Hook.Timeout > 0 {
 		hookHandler["timeout"] = h.metadata.Hook.Timeout

--- a/internal/clients/claude_code/handlers/hook_test.go
+++ b/internal/clients/claude_code/handlers/hook_test.go
@@ -414,6 +414,36 @@ func TestHookHandler_VerifyInstalled_CommandMode(t *testing.T) {
 	}
 }
 
+func TestHookHandler_BuildConfig_PortabilizesCommand(t *testing.T) {
+	homeDir, _ := os.UserHomeDir()
+	targetBase := filepath.Join(homeDir, ".claude")
+
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "test-hook", Version: "1.0.0", Type: asset.TypeHook},
+		Hook: &metadata.HookConfig{
+			Event:      "pre-tool-use",
+			ScriptFile: "hook.sh",
+		},
+	}
+	handler := NewHookHandler(meta)
+	config := handler.buildHookConfig(targetBase)
+
+	hooksArray := config["hooks"].([]any)
+	hookHandler := hooksArray[0].(map[string]any)
+	command := hookHandler["command"].(string)
+
+	if !strings.HasPrefix(command, "$HOME/") {
+		t.Errorf("command should use $HOME prefix for portability, got: %s", command)
+	}
+	if strings.Contains(command, homeDir) {
+		t.Errorf("command should not contain absolute home dir %s, got: %s", homeDir, command)
+	}
+	expected := "$HOME/.claude/hooks/test-hook/hook.sh"
+	if command != expected {
+		t.Errorf("command = %q, want %q", command, expected)
+	}
+}
+
 func TestHookHandler_BuildConfig_WithMatcher(t *testing.T) {
 	meta := &metadata.Metadata{
 		Asset: metadata.Asset{Name: "test", Version: "1.0.0", Type: asset.TypeHook},

--- a/internal/utils/paths.go
+++ b/internal/utils/paths.go
@@ -100,6 +100,23 @@ func IsDirectory(path string) bool {
 	return info.IsDir()
 }
 
+// Portabilize replaces the user's home directory prefix with $HOME
+// so paths remain valid across different environments.
+func Portabilize(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == home {
+		return "$HOME"
+	}
+	prefix := home + string(os.PathSeparator)
+	if after, found := strings.CutPrefix(path, prefix); found {
+		return "$HOME" + string(os.PathSeparator) + after
+	}
+	return path
+}
+
 // ResolveCommand resolves a command for a packaged MCP server.
 // Bare command names (e.g. "node", "uv", "python") are left as-is to be resolved via PATH.
 // Relative paths containing a directory separator (e.g. "./bin/server") are made absolute

--- a/internal/utils/paths_test.go
+++ b/internal/utils/paths_test.go
@@ -106,6 +106,31 @@ func TestEnsureDir(t *testing.T) {
 	}
 }
 
+func TestPortabilize(t *testing.T) {
+	homeDir, _ := os.UserHomeDir()
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"path under home", filepath.Join(homeDir, ".claude", "hooks", "test"), "$HOME/.claude/hooks/test"},
+		{"path equals home", homeDir, "$HOME"},
+		{"path not under home", "/opt/other/path", "/opt/other/path"},
+		{"empty path", "", ""},
+		{"relative path", "relative/path", "relative/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Portabilize(tt.path)
+			if got != tt.want {
+				t.Errorf("Portabilize(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveCommand(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- Add `Portabilize()` utility that replaces the user's home directory prefix with `$HOME` for portable paths
- Apply portabilization in Claude Code's `buildHookConfig()` so hook commands in `settings.json` use `$HOME/...` instead of absolute paths
- Scoped to Claude Code only — other clients unchanged since we're not confident they expand `$HOME`

Fixes #84

**Security implications of changes have been considered**