### PR TITLE
Allow missing hashes in HTTP sources

### DIFF
--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -49,6 +49,48 @@ hashes = {sha256 = "abc123"}
 	}
 }
 
+func TestParseAssetWithNoHashes(t *testing.T) {
+	lockFileData := []byte(`
+lock-version = "1.0"
+version = "abc123"
+created-by = "test"
+
+[[assets]]
+name = "my-rule"
+version = "1"
+type = "rule"
+
+[assets.source-http]
+url = "https://example.com/my-rule-1.zip"
+`)
+
+	lockFile, err := Parse(lockFileData)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(lockFile.Assets) != 1 {
+		t.Fatalf("Expected 1 asset, got %d", len(lockFile.Assets))
+	}
+
+	lockAsset := &lockFile.Assets[0]
+	if lockAsset.SourceHTTP == nil {
+		t.Fatal("Expected source-http to be present")
+	}
+
+	if lockAsset.SourceHTTP.URL != "https://example.com/my-rule-1.zip" {
+		t.Errorf("Expected URL https://example.com/my-rule-1.zip, got %s", lockAsset.SourceHTTP.URL)
+	}
+
+	if len(lockAsset.SourceHTTP.Hashes) != 0 {
+		t.Errorf("Expected empty hashes, got %v", lockAsset.SourceHTTP.Hashes)
+	}
+
+	if lockAsset.SourceHTTP.Size != 0 {
+		t.Errorf("Expected size 0, got %d", lockAsset.SourceHTTP.Size)
+	}
+}
+
 func TestValidateLockFile(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/vault/http.go
+++ b/internal/vault/http.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sleuth-io/sx/internal/buildinfo"
 	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/utils"
 )
 
@@ -91,7 +92,9 @@ func (h *HTTPSourceHandler) Fetch(ctx context.Context, asset *lockfile.Asset) ([
 // verifyHashes verifies the downloaded data against provided hashes
 func (h *HTTPSourceHandler) verifyHashes(data []byte, hashes map[string]string) error {
 	if len(hashes) == 0 {
-		return errors.New("no hashes provided for verification")
+		log := logger.Get()
+		log.Debug("skipping hash verification, no hashes provided")
+		return nil
 	}
 
 	for algo, expected := range hashes {

--- a/internal/vault/http_test.go
+++ b/internal/vault/http_test.go
@@ -1,0 +1,40 @@
+package vault
+
+import (
+	"testing"
+)
+
+func TestVerifyHashesEmpty(t *testing.T) {
+	handler := NewHTTPSourceHandler("")
+
+	tests := []struct {
+		name    string
+		hashes  map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "nil hashes skips verification",
+			hashes:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty hashes skips verification",
+			hashes:  map[string]string{},
+			wantErr: false,
+		},
+		{
+			name:    "invalid hash fails verification",
+			hashes:  map[string]string{"sha256": "badhash"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.verifyHashes([]byte("test data"), tt.hashes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("verifyHashes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix bug where `verifyHashes` hard-errors when no hashes are provided, even though the lock spec says hashes are optional (SHOULD, not MUST)
- Add debug log when skipping hash verification for traceability
- Add tests for lockfile parsing and hash verification with missing hashes

Closes #87

**Security implications of changes have been considered**