### PR TITLE
SK-90: Fix lock validation requiring hashes

### DIFF
--- a/internal/lockfile/validation.go
+++ b/internal/lockfile/validation.go
@@ -148,12 +148,7 @@ func (s *SourceHTTP) Validate() error {
 		return errors.New("url is required")
 	}
 
-	// Hashes are required for HTTP sources
-	if len(s.Hashes) == 0 {
-		return errors.New("hashes are required for HTTP sources")
-	}
-
-	// Validate hash algorithms
+	// Validate hash algorithms if provided
 	for algo := range s.Hashes {
 		if algo != "sha256" && algo != "sha512" {
 			return fmt.Errorf("unsupported hash algorithm: %s (must be sha256 or sha512)", algo)


### PR DESCRIPTION
## Summary
- Remove mandatory hash check from `SourceHTTP.Validate()` in lock file validation
- Commit 6ebaf83 made hashes optional in the HTTP fetch path but missed the validation path, causing `sx install` to reject lock files with hashless HTTP sources

Fixes #90

**Security implications of changes have been considered**