### PR TITLE
[SK-442] Add kiro client-specific inclusion logic and tests for RuleHandler

### DIFF
--- a/internal/clients/kiro/handlers/rule.go
+++ b/internal/clients/kiro/handlers/rule.go
@@ -112,8 +112,14 @@ func (h *RuleHandler) buildSteeringContent(content string) string {
 			}
 		}
 	} else {
-		// Default to always apply if no globs
-		sb.WriteString("inclusion: always\n")
+		// Check for client-specific inclusion override from [rule.kiro]
+		inclusion := "always"
+		if h.metadata.Rule != nil && h.metadata.Rule.Kiro != nil {
+			if inc, ok := h.metadata.Rule.Kiro["inclusion"].(string); ok {
+				inclusion = inc
+			}
+		}
+		fmt.Fprintf(&sb, "inclusion: %s\n", inclusion)
 	}
 
 	sb.WriteString("---\n\n")

--- a/internal/clients/kiro/handlers/rule_test.go
+++ b/internal/clients/kiro/handlers/rule_test.go
@@ -1,0 +1,195 @@
+package handlers
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/metadata"
+)
+
+func createTestRuleZip(t *testing.T, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.Create("RULE.md")
+	if err != nil {
+		t.Fatalf("Failed to create zip entry: %v", err)
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		t.Fatalf("Failed to write zip content: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Failed to close zip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestBuildSteeringContent_DefaultInclusion(t *testing.T) {
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "test-rule", Description: "A test rule"},
+		Rule:  &metadata.RuleConfig{},
+	}
+	handler := NewRuleHandler(meta, "")
+	content := handler.buildSteeringContent("Some rule content.")
+
+	if !strings.Contains(content, "inclusion: always") {
+		t.Errorf("expected inclusion: always, got:\n%s", content)
+	}
+}
+
+func TestBuildSteeringContent_KiroInclusionOverride(t *testing.T) {
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "my-rule", Description: "Manual rule"},
+		Rule: &metadata.RuleConfig{
+			Description: "Manual rule",
+			Kiro: map[string]any{
+				"inclusion": "manual",
+			},
+		},
+	}
+	handler := NewRuleHandler(meta, "")
+	content := handler.buildSteeringContent("Manual content.")
+
+	if !strings.Contains(content, "inclusion: manual") {
+		t.Errorf("expected inclusion: manual from [rule.kiro], got:\n%s", content)
+	}
+	if strings.Contains(content, "inclusion: always") {
+		t.Errorf("should not contain inclusion: always, got:\n%s", content)
+	}
+}
+
+func TestBuildSteeringContent_KiroInclusionAuto(t *testing.T) {
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "auto-rule", Description: "Auto rule"},
+		Rule: &metadata.RuleConfig{
+			Description: "Auto rule",
+			Kiro: map[string]any{
+				"inclusion": "auto",
+			},
+		},
+	}
+	handler := NewRuleHandler(meta, "")
+	content := handler.buildSteeringContent("Auto content.")
+
+	if !strings.Contains(content, "inclusion: auto") {
+		t.Errorf("expected inclusion: auto from [rule.kiro], got:\n%s", content)
+	}
+	if strings.Contains(content, "inclusion: always") {
+		t.Errorf("should not contain inclusion: always, got:\n%s", content)
+	}
+}
+
+func TestBuildSteeringContent_GlobsOverrideKiroInclusion(t *testing.T) {
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "glob-rule"},
+		Rule: &metadata.RuleConfig{
+			Globs: []string{"**/*.go"},
+			Kiro: map[string]any{
+				"inclusion": "manual",
+			},
+		},
+	}
+	handler := NewRuleHandler(meta, "")
+	content := handler.buildSteeringContent("Go content.")
+
+	if !strings.Contains(content, "inclusion: fileMatch") {
+		t.Errorf("globs should force fileMatch, got:\n%s", content)
+	}
+}
+
+func TestBuildSteeringContent_Description(t *testing.T) {
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "desc-rule", Description: "Asset desc"},
+		Rule: &metadata.RuleConfig{
+			Description: "Rule desc",
+		},
+	}
+	handler := NewRuleHandler(meta, "")
+	content := handler.buildSteeringContent("Content.")
+
+	if !strings.Contains(content, `description: "Rule desc"`) {
+		t.Errorf("expected rule-level description, got:\n%s", content)
+	}
+}
+
+func TestBuildSteeringContent_FallbackDescription(t *testing.T) {
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "desc-rule", Description: "Asset desc"},
+		Rule:  &metadata.RuleConfig{},
+	}
+	handler := NewRuleHandler(meta, "")
+	content := handler.buildSteeringContent("Content.")
+
+	if !strings.Contains(content, `description: "Asset desc"`) {
+		t.Errorf("expected asset-level description fallback, got:\n%s", content)
+	}
+}
+
+func TestRuleHandler_Install(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "install-test"},
+		Rule: &metadata.RuleConfig{
+			PromptFile: "RULE.md",
+			Kiro: map[string]any{
+				"inclusion": "manual",
+			},
+		},
+	}
+	handler := NewRuleHandler(meta, "")
+	zipData := createTestRuleZip(t, "Install test content.")
+
+	err := handler.Install(context.Background(), zipData, targetBase)
+	if err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	filePath := filepath.Join(targetBase, DirSteering, "install-test.md")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read installed file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "inclusion: manual") {
+		t.Errorf("installed file should have inclusion: manual, got:\n%s", content)
+	}
+	if !strings.Contains(content, "Install test content.") {
+		t.Errorf("installed file should contain rule body, got:\n%s", content)
+	}
+}
+
+func TestRuleHandler_Remove(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "remove-test"},
+		Rule:  &metadata.RuleConfig{PromptFile: "RULE.md"},
+	}
+	handler := NewRuleHandler(meta, "")
+
+	// Install first
+	zipData := createTestRuleZip(t, "To be removed.")
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// Verify exists
+	filePath := filepath.Join(targetBase, DirSteering, "remove-test.md")
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Fatal("File should exist after install")
+	}
+
+	// Remove
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Error("File should not exist after remove")
+	}
+}


### PR DESCRIPTION
Addresses https://github.com/sleuth-io/sx/issues/92 and [SK-442](https://linear.app/sleuth/issue/SK-442/bug-rulekiro-inclusion-override-not-applied-during-sx-install)

## Fix Summary

Updated `buildSteeringContent()` in `handlers/rule.go` to check `h.metadata.Rule.Kiro["inclusion"]` before defaulting, matching the logic already in `rule_caps.go`. Globs still take priority (force `fileMatch`).

Added `rule_test.go` with coverage for:
- Default `inclusion: always` (no `[rule.kiro]` section)
- `inclusion: manual` override from `[rule.kiro]`
- `inclusion: auto` override from `[rule.kiro]`
- Globs overriding `[rule.kiro]` (globs win -> `fileMatch`)
- Description from rule-level and asset-level fallback
- Full install round-trip
- Remove cleanup

## Files Changed

- `internal/clients/kiro/handlers/rule.go` — read `[rule.kiro]` inclusion in `buildSteeringContent()`
- `internal/clients/kiro/handlers/rule_test.go` — new test file