### PR TITLE
SK-461: support claudeai and chatgptcom for local and git vaults for sx

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Your best developers have figured out how to make AI assistants incredibly produ
 - **Instant onboarding** - New devs inherit the team's AI playbook on day one
 - **Central updates** - Change once in your vault, everyone gets the update
 - **Scoped installation** - Right assets for each repo, no context bloat
-- **Works with any AI client** - Claude Code, Cursor, GitHub Copilot, Gemini, Kiro, and more
+- **Works with any AI client** - Claude Code, Cursor, GitHub Copilot, Gemini, Kiro, and more, plus claude.ai and chatgpt.com via the cloud relay
 
 ## Quickstart
 
@@ -105,6 +105,18 @@ Teams have at least one admin at all times; mutations that would leave a
 team admin-less are rejected. User-scoped installs can only target the
 caller (prevents write-access holders from silently promoting an asset
 for teammates).
+
+**Use your vault from claude.ai or chatgpt.com** — expose it as an MCP
+endpoint via the skills.new relay:
+
+```bash
+sx cloud connect       # opens skills.new, paste back the attach line
+sx cloud serve         # keep this running — Ctrl+C exits
+sx cloud status        # prints the MCP URL to paste into claude.ai / chatgpt.com
+```
+
+The relay forwards requests over a WebSocket your machine opens — vault
+content stays local. See [docs/cloud-relay.md](docs/cloud-relay.md).
 
 **Usage analytics & audit**:
 
@@ -212,6 +224,8 @@ everyone gets the same tools automatically.
 | Gemini (JetBrains)      | ✅ Supported   | Rules, MCP servers only (no commands/hooks)               |
 | Gemini (Android Studio) | ✅ Supported   | Rules, MCP-remote only (HTTP, no stdio)                   |
 | Kiro                    | ✅ Supported   | Skills, rules, commands, MCP servers                      |
+| claude.ai (web)         | ✅ Supported   | Via the [skills.new cloud relay](docs/cloud-relay.md)     |
+| chatgpt.com (web)       | ✅ Supported   | Via the [skills.new cloud relay](docs/cloud-relay.md)     |
 
 
 ## Roadmap
@@ -223,6 +237,7 @@ everyone gets the same tools automatically.
 - ✅ Gemini support
 - ✅ Codex support
 - ✅ Kiro support
+- ✅ claude.ai and chatgpt.com support via the skills.new cloud relay
 - ✅ Skill discovery - Use Skills.new to discover relevant skills from your code and architecture
 - **Analytics** - Track skill usage and impact
 
@@ -250,6 +265,7 @@ See LICENSE file for details.
 - [MCP Spec](docs/mcp-spec.md) - MCP server and query tool
 - [Profiles](docs/profiles.md) - Multiple configuration profiles
 - [Clients](docs/clients.md) - Client support model and IDE vs CLI limitations
+- [Cloud relay](docs/cloud-relay.md) - Expose your vault to claude.ai and chatgpt.com via skills.new
 
 
 ### Prerequisites

--- a/cmd/sx/main.go
+++ b/cmd/sx/main.go
@@ -168,6 +168,7 @@ Use "{{muted (printf "%s [command] --help" .CommandPath)}}" for more information
 	rootCmd.AddCommand(commands.NewTeamCommand())
 	rootCmd.AddCommand(commands.NewStatsCommand())
 	rootCmd.AddCommand(commands.NewAuditCommand())
+	rootCmd.AddCommand(commands.NewCloudCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		// Print error with styling

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,8 +1,13 @@
 # Client Support
 
-sx works by writing asset files into well-known directories that AI clients read from (e.g. `.claude/`, `.kiro/`, `.cursor/`). This means sx support is inherently tied to the **file-based layer** of each client.
+sx supports two kinds of AI clients:
 
-## How sx installs assets
+1. **File-based clients** (Claude Code, Cursor, Codex, Copilot, Gemini, Kiro, Cline) — sx writes asset files into well-known directories the client reads on startup. This is the default `sx install` flow.
+2. **Web clients** (claude.ai, chatgpt.com) — sx exposes the vault as an MCP endpoint through the skills.new cloud relay. See [cloud-relay.md](cloud-relay.md).
+
+The two paths are independent. A vault can serve both; the same assets are reachable from a CLI tool reading `.claude/skills/` and from claude.ai talking to the relay.
+
+## How sx installs assets (file-based clients)
 
 sx writes files to disk. The client then reads those files when it starts or when it scans its config directories. sx does not interact with any client's UI, plugin system, or internal database.
 
@@ -19,6 +24,17 @@ Many AI tools ship in two forms: a **desktop IDE** and a **CLI**. These often ha
 | Gemini         | CLI/IDE | Full support for CLI/VS Code; rules and MCP only (JetBrains); MCP-remote only (Android Studio) |
 | GitHub Copilot | IDE ext | Full support                                                                                   |
 | Kiro           | CLI+IDE | Full support. See [Kiro-specific docs](kiro.md) for hook setup.                                |
+
+## Web clients (cloud relay)
+
+claude.ai and chatgpt.com can't read your filesystem, so sx exposes the vault as a custom MCP connector through a relay hosted at skills.new. The relay forwards JSON-RPC over a WebSocket your local `sx cloud serve` process opens — vault content stays on your machine.
+
+| Client      | Form | Notes                                                                                          |
+|-------------|------|------------------------------------------------------------------------------------------------|
+| claude.ai   | Web  | Via skills.new relay. Exposes `list_my_assets` / `load_my_asset` / `load_my_asset_file` tools. |
+| chatgpt.com | Web  | Via skills.new relay. Exposes `list_my_assets` / `load_my_asset` / `load_my_asset_file` tools. |
+
+See [cloud-relay.md](cloud-relay.md) for setup, security model, and troubleshooting.
 
 ## What "Experimental" means
 

--- a/docs/cloud-relay.md
+++ b/docs/cloud-relay.md
@@ -1,0 +1,176 @@
+# Cloud relay (claude.ai and chatgpt.com)
+
+Most AI clients sx supports — Claude Code, Cursor, Codex, Copilot,
+Gemini, Kiro, Cline — are file-based: sx writes assets to a directory
+the client reads on startup. Web clients like **claude.ai** and
+**chatgpt.com** can't read your filesystem, so sx exposes the same vault
+through a relay hosted at skills.new.
+
+The vault content stays on your machine. The relay only forwards MCP
+JSON-RPC requests over a WebSocket that your local sx process initiates.
+
+## How the relay works
+
+```
+┌──────────────────────┐     HTTPS      ┌──────────────────┐    WebSocket    ┌────────────────┐
+│  claude.ai /         │◄──────────────►│  skills.new      │◄───────────────►│  sx cloud      │
+│  chatgpt.com         │   MCP request  │  relay endpoint  │   MCP forward   │  serve         │
+└──────────────────────┘                └──────────────────┘                 └───────┬────────┘
+                                                                                     │
+                                                                                     ▼
+                                                                              ┌──────────────┐
+                                                                              │ local vault  │
+                                                                              │ (path / git  │
+                                                                              │  / sleuth)   │
+                                                                              └──────────────┘
+```
+
+1. The user pastes a public MCP endpoint URL (printed by `sx cloud
+   status`) into claude.ai or chatgpt.com as a custom MCP connector.
+2. When the chat client invokes a tool, the relay forwards the
+   JSON-RPC envelope down the persistent WebSocket your `sx cloud
+   serve` process holds open.
+3. sx runs the call against the local vault and returns the response
+   back through the same WebSocket.
+
+The relay never sees vault contents at rest. It only proxies live
+request/response pairs while `sx cloud serve` is running.
+
+## Quickstart
+
+```bash
+sx cloud connect       # opens skills.new, paste back the attach line
+sx cloud serve         # keep this running — Ctrl+C exits
+sx cloud status        # prints the MCP endpoint URL to paste into the chat client
+```
+
+Then in claude.ai or chatgpt.com, add a custom MCP connector pointing
+at the URL printed by `sx cloud status` (the line labelled `MCP
+endpoint`).
+
+## Commands
+
+### `sx cloud connect`
+
+Opens the skills.new signup page (`https://app.skills.new/relay/connect`
+by default; override with `SX_CLOUD_URL`). After you confirm your email
+the page prints an `sx cloud attach --url=... --token=...` line; paste
+it back into the terminal and `connect` parses it and persists the
+credential.
+
+| Flag           | Effect                                                                        |
+|----------------|-------------------------------------------------------------------------------|
+| `--no-browser` | Print the signup URL instead of launching a browser (useful over SSH).        |
+| `--force`      | Allow swapping to a different relay when one is already attached.             |
+
+### `sx cloud attach --url=... --token=...`
+
+Persists the machine token directly without going through the browser
+flow. Used by paste-back from the signup page, but also runnable on its
+own (e.g. on a headless machine after copying the values from another
+host).
+
+Before saving, `attach` runs a 10-second probe against the relay and
+fails with a clear message if the token is rejected — a typo otherwise
+only surfaces later when `serve` can't connect.
+
+### `sx cloud serve`
+
+Holds the WebSocket open and dispatches inbound MCP calls against the
+vault that `sx init` configured for this directory. Runs in the
+foreground; Ctrl+C exits cleanly. Reconnects automatically with
+exponential backoff; a connection that ran longer than 60 seconds
+resets the backoff so a long-lived session that drops once doesn't
+retry at the max delay forever.
+
+`serve` requires a credential — run `sx cloud connect` (or `sx cloud
+attach`) first.
+
+### `sx cloud status`
+
+Prints the attached relay's metadata, the WebSocket URL, a masked
+preview of the machine token, the credential file location, and the
+**MCP endpoint URL** to paste into claude.ai or chatgpt.com.
+
+### `sx cloud revoke`
+
+Removes the local credential. The relay is **not** revoked
+server-side; skills.new still considers the token active until you
+re-run `sx cloud connect` (which rotates it) or invalidate it from the
+skills.new UI. Use `revoke` for hygiene; use the skills.new UI to kill
+a leaked token.
+
+## What the chat client sees
+
+`sx cloud serve` builds a fresh MCP server per reconnect from the
+local vault. The exposed tool set depends on the vault type:
+
+| Vault type | Tools exposed                                                                  |
+|------------|--------------------------------------------------------------------------------|
+| Path       | `list_my_assets`, `load_my_asset`, `load_my_asset_file`                        |
+| Git        | `list_my_assets`, `load_my_asset`, `load_my_asset_file`                        |
+| Sleuth     | Vault-defined tool list (see [mcp-spec.md](mcp-spec.md))                       |
+
+Path and git vaults use the same asset shim, so claude.ai and
+chatgpt.com see identical surfaces regardless of how the vault is
+backed.
+
+## Credential storage
+
+Non-secret metadata (relay base URL, relay GID) is written to a TOML
+file at `<config-dir>/cloud.toml` with `0600` permissions. The machine
+token itself is held in the OS keyring:
+
+- macOS Keychain
+- Windows Credential Manager
+- freedesktop Secret Service (Linux desktops)
+
+If no keyring is reachable (headless Linux, containerized CI runners,
+etc.) sx falls back to writing the token into the same `0600` TOML
+file and prints a warning. Better than refusing to work, but worth
+knowing about for shared hosts.
+
+The keyring entry is keyed by the relay GID, so multiple relays on one
+machine coexist without collision (only one is active at a time, but
+revoking a stale entry from the OS keychain UI works for any of them).
+
+## Token rotation and multiple machines
+
+Running `sx cloud connect` from a second machine mints a new token and
+invalidates the previous one. The first sx instance stops serving on
+its next frame. This is intentional: one relay = one active machine
+token. To run sx from multiple machines simultaneously, attach each
+machine to a different relay via separate skills.new signups.
+
+Re-running `connect` against the **same** relay rotates the token in
+place and is always allowed. Pointing sx at a **different** relay when
+one is already attached requires `--force`.
+
+## Troubleshooting
+
+**"relay rejected the machine token"** — the token has been rotated or
+revoked. Run `sx cloud connect` again to mint a fresh one.
+
+**"could not reach relay to verify credential"** — DNS / TLS / proxy
+issue talking to skills.new. The 10s probe timed out before the
+handshake completed.
+
+**`serve` keeps reconnecting** — check `sx cloud status` for the right
+relay GID and confirm skills.new shows the relay as active. A
+revoked-server-side token will refuse the WebSocket handshake on every
+attempt.
+
+**No tools visible in claude.ai/chatgpt.com** — confirm the MCP
+endpoint URL was pasted into the chat client's custom connector slot
+(not a generic web search/URL field), and that `sx cloud serve` is
+running in a terminal somewhere.
+
+## Limits
+
+- The chat client must support custom MCP connectors. Both claude.ai
+  and chatgpt.com do, with their respective UI flows.
+- Per-call timeout is 25 seconds. Tool calls that take longer surface
+  a timeout to the chat client rather than hanging indefinitely.
+- `sx cloud serve` is a foreground process. Wrap it in your shell's
+  preferred service runner (`launchd`, `systemd --user`, `pm2`,
+  `tmux`) if you want it to survive reboots.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/coder/websocket v1.8.12
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
@@ -18,6 +19,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.19.0
 	github.com/spf13/cobra v1.10.2
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
+	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/sys v0.41.0
 	golang.org/x/term v0.40.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -27,6 +29,7 @@ require (
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
+	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	code.gitea.io/sdk/gitea v0.23.2 // indirect
 	codeberg.org/chavacava/garif v0.2.0 // indirect
 	codeberg.org/polyfloyd/go-errorlint v1.9.0 // indirect
@@ -77,6 +80,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.7 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dave/dst v0.27.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
@@ -102,6 +106,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@
 4d63.com/gocheckcompilerdirectives v1.3.0/go.mod h1:ofsJ4zx2QAuIP/NO/NAh1ig6R1Fb18/GI7RVMwz7kAY=
 4d63.com/gochecknoglobals v0.2.2 h1:H1vdnwnMaZdQW/N+NrkT1SZMTBmcwHe9Vq8lJcYYTtU=
 4d63.com/gochecknoglobals v0.2.2/go.mod h1:lLxwTQjL5eIesRbvnzIP3jZtG140FnTdz+AlMa+ogt0=
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -164,6 +166,8 @@ github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creativeprojects/go-selfupdate v1.5.2 h1:3KR3JLrq70oplb9yZzbmJ89qRP78D1AN/9u+l3k0LJ4=
 github.com/creativeprojects/go-selfupdate v1.5.2/go.mod h1:BCOuwIl1dRRCmPNRPH0amULeZqayhKyY2mH/h4va7Dk=
@@ -171,6 +175,8 @@ github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+f
 github.com/curioswitch/go-reassign v0.3.0/go.mod h1:nApPCCTtqLJN/s8HfItCcKV0jIPwluBOvZP+dsJGA88=
 github.com/daixiang0/gci v0.13.7 h1:+0bG5eK9vlI08J+J/NWGbWPTNiXPG4WhNLJOkSxWITQ=
 github.com/daixiang0/gci v0.13.7/go.mod h1:812WVN6JLFY9S6Tv76twqmNqevN0pa3SX3nih0brVzQ=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/dave/dst v0.27.3 h1:P1HPoMza3cMEquVf9kKy8yXsFirry4zEnWOdYPOoIzY=
 github.com/dave/dst v0.27.3/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
@@ -251,6 +257,8 @@ github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUW
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/godoc-lint/godoc-lint v0.11.2 h1:Bp0FkJWoSdNsBikdNgIcgtaoo+xz6I/Y9s5WSBQUeeM=
 github.com/godoc-lint/godoc-lint v0.11.2/go.mod h1:iVpGdL1JCikNH2gGeAn3Hh+AgN5Gx/I/cxV+91L41jo=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
@@ -344,6 +352,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -679,6 +689,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 gitlab.com/bosi/decorder v0.4.2 h1:qbQaV3zgwnBZ4zPMhGLW4KZe7A7NwxEhJx39R3shffo=
 gitlab.com/bosi/decorder v0.4.2/go.mod h1:muuhHoaJkA9QLcYHq4Mj8FJUwDZ+EirSHRiaTcTf6T8=
 gitlab.com/gitlab-org/api/client-go v1.43.0 h1:550UcwW3Q4Z9yTUr5elDorqacfof2tt2tgf5LmBtNSs=

--- a/internal/cloud/bridge.go
+++ b/internal/cloud/bridge.go
@@ -462,11 +462,18 @@ func writeError(ctx context.Context, ws *websocket.Conn, env inboundEnvelope, co
 	})
 }
 
-// sendEnvelope writes an envelope on the WebSocket with a fresh
-// timeout. Uses “context.Background“ as the parent so a cancelled
-// outer context (shutdown, ping failure) doesn't starve us of our last
-// chance to tell pulse the request failed.
-func sendEnvelope(_ context.Context, ws *websocket.Conn, env outboundEnvelope) error {
+// sendEnvelope writes an envelope on the WebSocket with a fresh timeout.
+//
+// The outer context is intentionally discarded (named ``_outerCtx`` to make
+// that obvious at the call site) and replaced with ``context.Background``.
+// The reason: this function is the last write that tells pulse a request
+// failed or completed, and the most common reason ``_outerCtx`` is cancelled
+// at this point is that we're tearing down the connection or just received
+// an interrupt — exactly the moments when we still need to flush a final
+// frame to the server. A short ``writeEnvelopeTimeout`` is plenty to bound
+// the write itself, so we don't risk hanging shutdown.
+func sendEnvelope(_outerCtx context.Context, ws *websocket.Conn, env outboundEnvelope) error {
+	_ = _outerCtx
 	buf, err := json.Marshal(env)
 	if err != nil {
 		return fmt.Errorf("marshal envelope: %w", err)

--- a/internal/cloud/bridge.go
+++ b/internal/cloud/bridge.go
@@ -464,13 +464,13 @@ func writeError(ctx context.Context, ws *websocket.Conn, env inboundEnvelope, co
 
 // sendEnvelope writes an envelope on the WebSocket with a fresh timeout.
 //
-// The outer context is intentionally discarded (named ``_outerCtx`` to make
-// that obvious at the call site) and replaced with ``context.Background``.
+// The outer context is intentionally discarded (named “_outerCtx“ to make
+// that obvious at the call site) and replaced with “context.Background“.
 // The reason: this function is the last write that tells pulse a request
-// failed or completed, and the most common reason ``_outerCtx`` is cancelled
+// failed or completed, and the most common reason “_outerCtx“ is cancelled
 // at this point is that we're tearing down the connection or just received
 // an interrupt — exactly the moments when we still need to flush a final
-// frame to the server. A short ``writeEnvelopeTimeout`` is plenty to bound
+// frame to the server. A short “writeEnvelopeTimeout“ is plenty to bound
 // the write itself, so we don't risk hanging shutdown.
 func sendEnvelope(_outerCtx context.Context, ws *websocket.Conn, env outboundEnvelope) error {
 	_ = _outerCtx

--- a/internal/cloud/bridge.go
+++ b/internal/cloud/bridge.go
@@ -1,0 +1,477 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/sleuth-io/sx/internal/logger"
+)
+
+// Backoff bounds for automatic WebSocket reconnection. A disconnected
+// serve loop retries with exponential backoff so a flaky network doesn't
+// require manual restarts. If a connection ran longer than
+// “reconnectResetThreshold“ we treat it as healthy and reset the
+// backoff on the next disconnect — otherwise a long-lived session that
+// drops once would reconnect at the max delay forever.
+const (
+	initialReconnectDelay   = 1 * time.Second
+	maxReconnectDelay       = 30 * time.Second
+	reconnectResetThreshold = 60 * time.Second
+
+	// readFrameTimeout bounds how long we'll wait for an inbound frame
+	// before sending a client-side ping to keep the WebSocket alive.
+	// Pulse's nginx + pushpin have their own timeouts (typically 60s);
+	// pinging well under that prevents idle disconnects.
+	readFrameTimeout = 45 * time.Second
+
+	// mcpCallTimeout bounds how long we'll wait for the in-process MCP
+	// server to answer a single tools/call. Must be shorter than
+	// pulse's 30s caller-side timeout so we can surface a useful error
+	// instead of the chat client hanging.
+	mcpCallTimeout = 25 * time.Second
+
+	// writeEnvelopeTimeout bounds one outbound WebSocket write. Kept
+	// short so a stuck peer can't wedge a handler forever.
+	writeEnvelopeTimeout = 10 * time.Second
+)
+
+// ServeOptions collects the knobs for “sx cloud serve“. The zero
+// value is NOT usable — Credential + MCPServerFactory must be set.
+type ServeOptions struct {
+	// Credential is the persisted relay credential (URL + machine
+	// token). Required.
+	Credential *Credential
+
+	// MCPServerFactory builds a freshly-initialized MCP server that
+	// exposes the local vault's tools. Each reconnect creates a new
+	// server + in-memory transport pair so stale state from a prior
+	// session can't leak across reconnects. Returning an error aborts
+	// the reconnect and surfaces it to the operator; a silent empty
+	// server would be indistinguishable from a healthy vault with no
+	// tools.
+	MCPServerFactory func() (*mcp.Server, error)
+
+	// HTTPClient, if set, overrides the HTTP client used for the
+	// WebSocket handshake. Tests inject a stub; production passes nil
+	// to use the default client.
+	HTTPClient *http.Client
+}
+
+// Serve runs the WebSocket dispatcher loop, returning only when “ctx“
+// is cancelled or a non-recoverable error occurs. Reconnect attempts are
+// made with exponential backoff; “ctx“ cancellation is observed at
+// each backoff step.
+func Serve(ctx context.Context, opts ServeOptions) error {
+	if opts.Credential == nil {
+		return errors.New("serve: credential is nil")
+	}
+	if opts.MCPServerFactory == nil {
+		return errors.New("serve: MCPServerFactory is nil")
+	}
+	if err := opts.Credential.Validate(); err != nil {
+		return fmt.Errorf("serve: invalid credential: %w", err)
+	}
+	wsURL, err := opts.Credential.WebSocketURL()
+	if err != nil {
+		return fmt.Errorf("serve: bad WebSocket URL: %w", err)
+	}
+
+	log := logger.Get()
+	delay := initialReconnectDelay
+	for {
+		start := time.Now()
+		connErr := runOneConnection(ctx, opts, wsURL)
+		duration := time.Since(start)
+
+		if connErr != nil && ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if connErr != nil {
+			log.Warn("sx cloud serve connection ended; will retry",
+				"error", connErr, "duration", duration, "delay", delay)
+		}
+
+		// If the session was healthy enough to live past the reset
+		// threshold, start the next backoff from scratch. Prevents the
+		// "maxed out forever after a long happy run" case.
+		if duration > reconnectResetThreshold {
+			delay = initialReconnectDelay
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+		// Exponential backoff, capped.
+		delay *= 2
+		if delay > maxReconnectDelay {
+			delay = maxReconnectDelay
+		}
+	}
+}
+
+// runOneConnection dials the WebSocket once, sets up the in-memory MCP
+// bridge, and runs until the WebSocket is closed or “ctx“ is cancelled.
+// Reconnect decisions live in “Serve“.
+func runOneConnection(ctx context.Context, opts ServeOptions, wsURL string) error {
+	log := logger.Get()
+
+	server, err := opts.MCPServerFactory()
+	if err != nil {
+		return fmt.Errorf("failed to build MCP server: %w", err)
+	}
+
+	dialOpts := &websocket.DialOptions{
+		HTTPClient: opts.HTTPClient,
+		HTTPHeader: http.Header{
+			"Authorization": []string{"Bearer " + opts.Credential.MachineToken},
+		},
+	}
+	conn, resp, err := websocket.Dial(ctx, wsURL, dialOpts)
+	if err != nil {
+		return fmt.Errorf("websocket dial %s: %w", wsURL, err)
+	}
+	// The HTTP response body isn't used after the handshake completes,
+	// but closing it satisfies the bodyclose linter and releases any
+	// HTTP/1.1 conn reader state.
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	defer func() {
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}()
+
+	// Generous message cap — MCP payloads fit in well under a MB in
+	// practice, but vault tool outputs can be large.
+	conn.SetReadLimit(4 << 20)
+
+	log.Info("sx cloud serve connected", "url", wsURL, "relay_gid", opts.Credential.RelayGID)
+
+	// Bring up an in-process MCP client + server pair via an in-memory
+	// transport. All JSON-RPC plumbing (ids, error envelopes, schema
+	// validation) lives in the SDK's Server; we just shuttle envelopes
+	// in and out.
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	serverCtx, serverCancel := context.WithCancel(ctx)
+	defer serverCancel()
+	go func() {
+		if err := server.Run(serverCtx, serverTransport); err != nil && !errors.Is(err, context.Canceled) {
+			log.Warn("in-process MCP server exited", "error", err)
+		}
+	}()
+
+	memConn, err := clientTransport.Connect(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to connect in-memory MCP transport: %w", err)
+	}
+	defer func() { _ = memConn.Close() }()
+
+	mux := newResponseMux(memConn)
+	muxCtx, muxCancel := context.WithCancel(ctx)
+	defer muxCancel()
+	go mux.readLoop(muxCtx)
+
+	return dispatchLoop(ctx, conn, mux)
+}
+
+// dispatchLoop runs until the WebSocket closes. Inbound envelopes are
+// handled concurrently so one slow MCP call can't block others. Ping
+// liveness happens in the same loop: if “readFrameTimeout“ elapses
+// with no frame we send a ping and keep going.
+func dispatchLoop(ctx context.Context, ws *websocket.Conn, mux *responseMux) error {
+	log := logger.Get()
+
+	// Wait for spawned handlers on exit so we don't leak goroutines
+	// across reconnects — each reconnect spawns a fresh mux + dispatch
+	// loop, so previous handlers must fully drain.
+	var handlers sync.WaitGroup
+	defer handlers.Wait()
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		readCtx, cancelRead := context.WithTimeout(ctx, readFrameTimeout)
+		kind, data, err := ws.Read(readCtx)
+		cancelRead()
+		if err != nil {
+			// Read deadline: send a ping and keep going.
+			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+				pingCtx, cancelPing := context.WithTimeout(ctx, 5*time.Second)
+				if pingErr := ws.Ping(pingCtx); pingErr != nil {
+					cancelPing()
+					return fmt.Errorf("ping failed: %w", pingErr)
+				}
+				cancelPing()
+				continue
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("ws read: %w", err)
+		}
+		if kind != websocket.MessageText {
+			log.Debug("ignoring non-text WebSocket frame", "kind", kind, "bytes", len(data))
+			continue
+		}
+
+		var env inboundEnvelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			log.Warn("malformed envelope from pulse", "error", err)
+			continue
+		}
+		if env.Type != "mcp-request" {
+			log.Debug("ignoring non-request envelope", "type", env.Type)
+			continue
+		}
+
+		handlers.Add(1)
+		go func(env inboundEnvelope) {
+			defer handlers.Done()
+			if err := handleOneRequest(ctx, ws, mux, env); err != nil {
+				log.Warn("request dispatch failed", "error", err, "request_id", env.RequestID)
+			}
+		}(env)
+	}
+}
+
+// inboundEnvelope is the wire shape pulse publishes on
+// “sx-relay:<gid>:in“. Matches “SxRequestEnvelope.to_json“ in
+// “sleuth/apps/sx_relay/service/relay_bus.py“.
+type inboundEnvelope struct {
+	Type      string          `json:"type"`
+	RequestID string          `json:"request_id"`
+	JSONRPCID json.RawMessage `json:"jsonrpc_id"`
+	Method    string          `json:"method"`
+	Params    json.RawMessage `json:"params"`
+}
+
+// outboundEnvelope is the wire shape we send back on each inbound
+// request. Must match the parser in
+// “sleuth/apps/sx_relay/views/websocket.py“.
+type outboundEnvelope struct {
+	Type      string         `json:"type"`
+	RequestID string         `json:"request_id"`
+	Body      map[string]any `json:"body"`
+}
+
+// responseMux owns the single reader on the in-memory MCP connection
+// and fans responses out by JSON-RPC id. Multiple concurrent handlers
+// can write requests into “memConn“; each registers a pending channel
+// under its id, waits for the reader to deliver, then unregisters.
+type responseMux struct {
+	memConn mcp.Connection
+	seq     atomic.Uint64
+	writeMu sync.Mutex
+
+	pendingMu sync.Mutex
+	pending   map[string]chan *jsonrpc.Response
+}
+
+func newResponseMux(memConn mcp.Connection) *responseMux {
+	return &responseMux{
+		memConn: memConn,
+		pending: make(map[string]chan *jsonrpc.Response),
+	}
+}
+
+// readLoop reads from “memConn“ until the context is cancelled or the
+// connection closes. Response frames are delivered to the waiter
+// registered under their id; server-originated requests (sampling /
+// elicitation) are dropped — the relay shape doesn't support them.
+func (m *responseMux) readLoop(ctx context.Context) {
+	log := logger.Get()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		msg, err := m.memConn.Read(ctx)
+		if err != nil {
+			if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+				log.Debug("response mux reader exited", "error", err)
+			}
+			m.shutdownPending()
+			return
+		}
+		resp, ok := msg.(*jsonrpc.Response)
+		if !ok {
+			log.Debug("response mux dropped non-response message")
+			continue
+		}
+		key := idKey(resp.ID)
+		m.pendingMu.Lock()
+		ch, present := m.pending[key]
+		if present {
+			delete(m.pending, key)
+		}
+		m.pendingMu.Unlock()
+		if present {
+			// Non-blocking send: the waiter always reads exactly once
+			// before unregistering, and the channel is buffered to 1.
+			ch <- resp
+		}
+	}
+}
+
+// shutdownPending unblocks every pending waiter when the reader exits.
+// Waiters see a nil response and surface an internal error upstream.
+func (m *responseMux) shutdownPending() {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	for k, ch := range m.pending {
+		close(ch)
+		delete(m.pending, k)
+	}
+}
+
+// dispatch writes a request to “memConn“ and returns the matched
+// response (or “nil“ with a non-nil error). Handlers call this once
+// per inbound envelope.
+func (m *responseMux) dispatch(ctx context.Context, method string, params json.RawMessage) (*jsonrpc.Response, error) {
+	id, err := jsonrpc.MakeID(float64(m.seq.Add(1)))
+	if err != nil {
+		return nil, fmt.Errorf("make internal id: %w", err)
+	}
+	key := idKey(id)
+	ch := make(chan *jsonrpc.Response, 1)
+
+	m.pendingMu.Lock()
+	m.pending[key] = ch
+	m.pendingMu.Unlock()
+
+	// Clean up the pending entry on any exit path — timeout, cancel, or
+	// successful receipt. The writer lock is held only around the
+	// single ``Write`` so concurrent handlers don't interleave frames.
+	cleanup := func() {
+		m.pendingMu.Lock()
+		if existing, ok := m.pending[key]; ok && existing == ch {
+			delete(m.pending, key)
+		}
+		m.pendingMu.Unlock()
+	}
+
+	p := params
+	if len(p) == 0 {
+		p = nil
+	}
+	req := &jsonrpc.Request{ID: id, Method: method, Params: p}
+
+	m.writeMu.Lock()
+	writeErr := m.memConn.Write(ctx, req)
+	m.writeMu.Unlock()
+	if writeErr != nil {
+		cleanup()
+		return nil, fmt.Errorf("mcp write: %w", writeErr)
+	}
+
+	select {
+	case resp, ok := <-ch:
+		if !ok {
+			// Channel closed by ``shutdownPending``: the transport
+			// went away mid-flight. Treat as an internal error so the
+			// caller produces a JSON-RPC -32603 for pulse.
+			cleanup()
+			return nil, errors.New("mcp transport closed before response")
+		}
+		return resp, nil
+	case <-ctx.Done():
+		cleanup()
+		return nil, ctx.Err()
+	}
+}
+
+// idKey turns an arbitrary jsonrpc.ID into a stable string we can use
+// as a map key. “jsonrpc.ID“ is an interface alias for jsonrpc2.ID
+// (not directly comparable), so we hash it via its wire form.
+func idKey(id jsonrpc.ID) string {
+	return fmt.Sprintf("%v", id)
+}
+
+// handleOneRequest forwards one inbound envelope to the in-memory MCP
+// server via the mux, then writes the response back on the WebSocket. A
+// response is always written (even on error) so pulse's await can
+// complete without hitting its 30s timeout.
+func handleOneRequest(ctx context.Context, ws *websocket.Conn, mux *responseMux, env inboundEnvelope) error {
+	callCtx, cancel := context.WithTimeout(ctx, mcpCallTimeout)
+	defer cancel()
+
+	resp, err := mux.dispatch(callCtx, env.Method, env.Params)
+	if err != nil {
+		return writeError(ctx, ws, env, jsonrpc.CodeInternalError, err.Error())
+	}
+	return writeResponse(ctx, ws, env, resp)
+}
+
+// writeResponse wraps a JSON-RPC response in the outbound envelope and
+// writes it on the WebSocket. Always carries exactly one of “result“
+// or “error“ so the chat client can't reject us for an incomplete
+// JSON-RPC reply.
+func writeResponse(ctx context.Context, ws *websocket.Conn, env inboundEnvelope, resp *jsonrpc.Response) error {
+	body := map[string]any{"jsonrpc": "2.0"}
+	if len(env.JSONRPCID) > 0 {
+		body["id"] = env.JSONRPCID
+	}
+	switch {
+	case resp.Error != nil:
+		body["error"] = resp.Error
+	case len(resp.Result) > 0:
+		body["result"] = json.RawMessage(resp.Result)
+	default:
+		// JSON-RPC §5: a successful response MUST contain "result". An
+		// empty/absent SDK-side result (void-returning handler) maps to
+		// ``null`` on the wire.
+		body["result"] = json.RawMessage("null")
+	}
+	return sendEnvelope(ctx, ws, outboundEnvelope{
+		Type:      "mcp-response",
+		RequestID: env.RequestID,
+		Body:      body,
+	})
+}
+
+// writeError produces a JSON-RPC error response and sends it. Used for
+// internal plumbing failures (mcp read/write, timeout) that the
+// in-process server didn't get a chance to report on its own.
+func writeError(ctx context.Context, ws *websocket.Conn, env inboundEnvelope, code int64, message string) error {
+	body := map[string]any{
+		"jsonrpc": "2.0",
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	}
+	if len(env.JSONRPCID) > 0 {
+		body["id"] = env.JSONRPCID
+	}
+	return sendEnvelope(ctx, ws, outboundEnvelope{
+		Type:      "mcp-response",
+		RequestID: env.RequestID,
+		Body:      body,
+	})
+}
+
+// sendEnvelope writes an envelope on the WebSocket with a fresh
+// timeout. Uses “context.Background“ as the parent so a cancelled
+// outer context (shutdown, ping failure) doesn't starve us of our last
+// chance to tell pulse the request failed.
+func sendEnvelope(_ context.Context, ws *websocket.Conn, env outboundEnvelope) error {
+	buf, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	writeCtx, cancel := context.WithTimeout(context.Background(), writeEnvelopeTimeout)
+	defer cancel()
+	return ws.Write(writeCtx, websocket.MessageText, buf)
+}

--- a/internal/cloud/bridge_test.go
+++ b/internal/cloud/bridge_test.go
@@ -1,0 +1,234 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestServe_EndToEnd stands up a pulse-side WebSocket test server, runs
+// “Serve“ against it, sends an MCP JSON-RPC request wrapped in the
+// relay envelope, and verifies the response body carries the
+// “initialize“ reply from the in-memory MCP server.
+//
+// This exercises the subscribe-before-publish invariant (the test would
+// hang if “Serve“ tried to publish before dialing), the envelope
+// round-trip, and the id translation (our internal monotonic id should
+// not leak; the chat client's “jsonrpc_id“ should be echoed).
+func TestServe_EndToEnd(t *testing.T) {
+	type outbound struct {
+		Type      string         `json:"type"`
+		RequestID string         `json:"request_id"`
+		Body      map[string]any `json:"body"`
+	}
+
+	respCh := make(chan outbound, 1)
+	reqID := "test-req-1"
+	jsonrpcID := 42 // chat-client-supplied id; must be echoed verbatim
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer machine-tok-abc" {
+			t.Errorf("missing/bad Authorization header: %q", auth)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		// Handler lives for the life of the test; ``Serve`` cancels
+		// ``ctx`` when the test ends.
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		// Send one MCP request envelope to the sx side.
+		envBytes, err := json.Marshal(map[string]any{
+			"type":       "mcp-request",
+			"request_id": reqID,
+			"jsonrpc_id": jsonrpcID,
+			"method":     "initialize",
+			"params": map[string]any{
+				"protocolVersion": "2025-06-18",
+				"capabilities":    map[string]any{},
+				"clientInfo": map[string]any{
+					"name":    "test-client",
+					"version": "0",
+				},
+			},
+		})
+		if err != nil {
+			t.Errorf("marshal envelope: %v", err)
+			return
+		}
+		writeCtx, writeCancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer writeCancel()
+		if err := ws.Write(writeCtx, websocket.MessageText, envBytes); err != nil {
+			t.Errorf("write req: %v", err)
+			return
+		}
+
+		// Read the reply.
+		readCtx, readCancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer readCancel()
+		_, data, err := ws.Read(readCtx)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("read resp: %v", err)
+			}
+			return
+		}
+		var out outbound
+		if err := json.Unmarshal(data, &out); err != nil {
+			t.Errorf("unmarshal resp: %v", err)
+			return
+		}
+		respCh <- out
+	}))
+	defer srv.Close()
+
+	cred := &Credential{
+		RelayBaseURL: strings.TrimSuffix(srv.URL, "/") + "/relay/SRtest/",
+		RelayGID:     "SRtest",
+		MachineToken: "machine-tok-abc",
+	}
+
+	// MCP server factory: empty server is fine for ``initialize`` —
+	// the SDK responds with server info + capabilities regardless of
+	// registered tools.
+	factory := func() (*mcp.Server, error) {
+		return mcp.NewServer(&mcp.Implementation{Name: "test-sx", Version: "0.1"}, nil), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- Serve(ctx, ServeOptions{
+			Credential:       cred,
+			MCPServerFactory: factory,
+		})
+	}()
+
+	select {
+	case out := <-respCh:
+		if out.Type != "mcp-response" {
+			t.Errorf("wrong envelope type: %q", out.Type)
+		}
+		if out.RequestID != reqID {
+			t.Errorf("request_id not echoed: got %q want %q", out.RequestID, reqID)
+		}
+		// The body must carry the chat-client's original jsonrpc id.
+		// JSON unmarshals numeric ids into float64, so compare against
+		// the number we sent.
+		gotID, ok := out.Body["id"].(float64)
+		if !ok {
+			t.Fatalf("response missing id: %+v", out.Body)
+		}
+		if int(gotID) != jsonrpcID {
+			t.Errorf("id not echoed: got %v want %v", gotID, jsonrpcID)
+		}
+		if _, ok := out.Body["result"]; !ok {
+			t.Errorf("response missing result: %+v", out.Body)
+		}
+		if errVal, has := out.Body["error"]; has {
+			t.Errorf("unexpected error in response: %v", errVal)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for MCP response envelope")
+	}
+
+	cancel()
+	if err := <-serveErr; err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("Serve returned non-cancel error: %v", err)
+	}
+}
+
+// TestServe_UnknownMethodReturnsJSONRPCError verifies that when the
+// in-process MCP server returns a method-not-found error, the envelope
+// carries a JSON-RPC error body (not a transport-level failure).
+func TestServe_UnknownMethodReturnsJSONRPCError(t *testing.T) {
+	type outbound struct {
+		Type      string         `json:"type"`
+		RequestID string         `json:"request_id"`
+		Body      map[string]any `json:"body"`
+	}
+	respCh := make(chan outbound, 1)
+	reqID := "unknown-1"
+	jsonrpcID := "client-id-7"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		envBytes, _ := json.Marshal(map[string]any{
+			"type":       "mcp-request",
+			"request_id": reqID,
+			"jsonrpc_id": jsonrpcID,
+			"method":     "this/does/not/exist",
+			"params":     map[string]any{},
+		})
+		writeCtx, writeCancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer writeCancel()
+		if err := ws.Write(writeCtx, websocket.MessageText, envBytes); err != nil {
+			return
+		}
+
+		readCtx, readCancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer readCancel()
+		_, data, err := ws.Read(readCtx)
+		if err != nil {
+			return
+		}
+		var out outbound
+		_ = json.Unmarshal(data, &out)
+		respCh <- out
+	}))
+	defer srv.Close()
+
+	cred := &Credential{
+		RelayBaseURL: strings.TrimSuffix(srv.URL, "/") + "/relay/SRtest/",
+		RelayGID:     "SRtest",
+		MachineToken: "tok",
+	}
+	factory := func() (*mcp.Server, error) {
+		return mcp.NewServer(&mcp.Implementation{Name: "t", Version: "0"}, nil), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go func() { _ = Serve(ctx, ServeOptions{Credential: cred, MCPServerFactory: factory}) }()
+
+	select {
+	case out := <-respCh:
+		if _, has := out.Body["error"]; !has {
+			t.Errorf("expected error in body, got %+v", out.Body)
+		}
+		if got, _ := out.Body["id"].(string); got != jsonrpcID {
+			t.Errorf("string id not echoed: got %v want %q", out.Body["id"], jsonrpcID)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for error envelope")
+	}
+}
+
+// TestParseErrorCode ensures we import jsonrpc correctly (compile-time
+// check). Acts as a smoke test for the error-code constants we rely on.
+func TestJSONRPCErrorCodesAreStable(t *testing.T) {
+	if jsonrpc.CodeInternalError != -32603 {
+		t.Errorf("CodeInternalError changed: %d", jsonrpc.CodeInternalError)
+	}
+}

--- a/internal/cloud/cloudtest/keyring.go
+++ b/internal/cloud/cloudtest/keyring.go
@@ -1,0 +1,78 @@
+// Package cloudtest exposes test-only helpers for the “cloud“
+// package. Lives in a sibling subpackage so the production-compiled
+// “internal/cloud“ package has no “testing“ import and doesn't
+// leak test flags (“-test.v“, “-test.run“, etc.) into the sx
+// binary.
+//
+// Only call site is test files in neighbouring packages (e.g.
+// “internal/commands“). Tests inside “internal/cloud“ itself use
+// the package-scoped helpers in “credential_test.go“ directly.
+package cloudtest
+
+import (
+	"maps"
+	"sync"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/cloud"
+)
+
+// Keyring is an in-memory “cloud.TokenStore“ for use in tests that
+// exercise the credential layer end-to-end. Methods mirror the
+// “cloud.TokenStore“ interface; “Entries“ returns a snapshot of
+// the current contents for assertions.
+type Keyring struct {
+	mu      sync.Mutex
+	entries map[string]string
+}
+
+// Entries returns a snapshot of the keyring contents. Safe to call
+// concurrently with the production code under test.
+func (k *Keyring) Entries() map[string]string {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	out := make(map[string]string, len(k.entries))
+	maps.Copy(out, k.entries)
+	return out
+}
+
+// Set implements “cloud.TokenStore“.
+func (k *Keyring) Set(account, token string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.entries == nil {
+		k.entries = make(map[string]string)
+	}
+	k.entries[account] = token
+	return nil
+}
+
+// Get implements “cloud.TokenStore“.
+func (k *Keyring) Get(account string) (string, error) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	v, ok := k.entries[account]
+	if !ok {
+		return "", cloud.ErrTokenNotFound
+	}
+	return v, nil
+}
+
+// Delete implements “cloud.TokenStore“.
+func (k *Keyring) Delete(account string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	delete(k.entries, account)
+	return nil
+}
+
+// InstallKeyring replaces the cloud package's active token store with
+// a fresh in-memory Keyring for the duration of one test, restoring
+// the previous store on cleanup.
+func InstallKeyring(t *testing.T) *Keyring {
+	t.Helper()
+	k := &Keyring{entries: make(map[string]string)}
+	restore := cloud.SetTokenStore(k)
+	t.Cleanup(restore)
+	return k
+}

--- a/internal/cloud/credential.go
+++ b/internal/cloud/credential.go
@@ -1,0 +1,407 @@
+// Package cloud holds the client-side state for the "sx cloud" relay
+// feature: credential storage, WebSocket dialing, and the MCP dispatcher
+// loop.
+//
+// A "relay" is an sx process (this one) serving a public MCP endpoint
+// hosted by skills.new. The credential persisted here is the machine
+// token minted during “sx cloud connect“ — it authenticates this sx
+// instance's long-lived WebSocket connection back to pulse.
+//
+// Storage layout:
+//
+//   - Non-secret metadata (relay base URL, GID) lives in a TOML file at
+//     “<config-dir>/cloud.toml“ with 0600 permissions.
+//   - The machine token itself is stored in the OS keyring (macOS
+//     Keychain, Windows Credential Manager, freedesktop Secret Service
+//     on Linux) so a full-disk backup or a misconfigured backup agent
+//     can't leak it. If the keyring is unavailable (headless Linux
+//     without a Secret Service, containerized envs, etc.) we fall back
+//     to storing the token in the same TOML file with a visible
+//     warning — better than refusing to work on CI runners.
+package cloud
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/zalando/go-keyring"
+
+	"github.com/sleuth-io/sx/internal/logger"
+	"github.com/sleuth-io/sx/internal/utils"
+)
+
+// CredentialFileName is the TOML file that holds the active relay's
+// metadata. Stored under the user's sx config dir with 0600 permissions
+// so nothing else on the machine can read even the fallback-mode token.
+const CredentialFileName = "cloud.toml"
+
+// keyringService is the logical "app" key we use when talking to the
+// OS keyring. “account“ is the relay GID so multiple relays on one
+// machine coexist (only one is active, but revoking a stale entry via
+// the OS keychain UI works even when that GID isn't the current one).
+const keyringService = "sx-cloud-relay"
+
+// ErrNoCredential is returned by Load when no cloud credential has been
+// persisted yet. Callers check with errors.Is so "not attached" can be
+// distinguished from genuine I/O failures.
+var ErrNoCredential = errors.New("no sx cloud credential; run `sx cloud connect`")
+
+// Credential is the full persisted state for an attached relay. The
+// RelayGID is derived from RelayBaseURL (“.../relay/<gid>/“) and stored
+// explicitly so we don't have to re-parse the URL every time.
+type Credential struct {
+	// RelayBaseURL is the base URL that includes the relay GID, e.g.
+	// ``https://app.skills.new/relay/SR.../``. The trailing slash is
+	// preserved when written but not required on read.
+	RelayBaseURL string `toml:"relay_base_url"`
+
+	// RelayGID is the URL-facing opaque id ("SR..."). Derived from
+	// RelayBaseURL but stored for convenience.
+	RelayGID string `toml:"relay_gid"`
+
+	// MachineToken is the plaintext bearer token. NEVER serialized to
+	// TOML in the normal path — it lives in the OS keyring. Only
+	// written to the TOML file when the keyring is unavailable, and
+	// even then the file is 0600.
+	MachineToken string `toml:"machine_token,omitempty"`
+}
+
+// TokenStore abstracts the OS keyring so tests can swap in an
+// in-memory implementation. Exported rather than unexported because
+// the sibling test-helper package (“internal/cloud/cloudtest“) needs
+// to implement it for tests in neighbouring packages (e.g.
+// “internal/commands“). Production code has no reason to install a
+// custom store; “SetTokenStore“ is the only hook.
+type TokenStore interface {
+	Set(account, token string) error
+	Get(account string) (string, error)
+	Delete(account string) error
+}
+
+// ErrTokenNotFound is returned by TokenStore.Get when no token is
+// stored for the account. Separate from ErrNoCredential so Load can
+// tell "TOML exists but keyring forgot the token" (bad state) from
+// "user never attached" (clean state).
+var ErrTokenNotFound = errors.New("token not found in keyring")
+
+// osKeyring is the production TokenStore backed by go-keyring.
+type osKeyring struct{}
+
+func (osKeyring) Set(account, token string) error {
+	return keyring.Set(keyringService, account, token)
+}
+
+func (osKeyring) Get(account string) (string, error) {
+	v, err := keyring.Get(keyringService, account)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return "", ErrTokenNotFound
+	}
+	return v, err
+}
+
+func (osKeyring) Delete(account string) error {
+	err := keyring.Delete(keyringService, account)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return nil
+	}
+	return err
+}
+
+// activeTokenStore is swapped out by tests via SetTokenStore.
+// Production callers never touch it directly.
+var activeTokenStore TokenStore = osKeyring{}
+
+// SetTokenStore replaces the active keyring backend and returns a
+// function that restores the previous one. Intended for test helpers
+// in “internal/cloud/cloudtest“ — production code has no reason to
+// call this.
+func SetTokenStore(ts TokenStore) (restore func()) {
+	prev := activeTokenStore
+	activeTokenStore = ts
+	return func() { activeTokenStore = prev }
+}
+
+// Path returns the absolute path to the credential metadata file,
+// creating the config dir if it doesn't already exist.
+func Path() (string, error) {
+	dir, err := utils.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("failed to create sx config dir: %w", err)
+	}
+	return filepath.Join(dir, CredentialFileName), nil
+}
+
+// Load reads the stored credential, looking up the machine token in the
+// OS keyring (or taking it from the TOML file when the keyring is
+// unavailable). Returns ErrNoCredential if nothing has been persisted.
+func Load() (*Credential, error) {
+	path, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path) // #nosec G304 -- path is derived from a fixed location under the sx config dir
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNoCredential
+		}
+		return nil, fmt.Errorf("failed to open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	var cred Credential
+	if err := toml.Unmarshal(data, &cred); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+
+	// Prefer the keyring. If the keyring has the token, use it. If
+	// it's specifically "not found" but the TOML has an inline token
+	// (fallback-mode install), honor that. Anything else from the
+	// keyring is a hard error so we don't accidentally authenticate
+	// with a stale fallback token while the keyring is healthy.
+	keyringToken, kerr := activeTokenStore.Get(cred.RelayGID)
+	switch {
+	case kerr == nil:
+		cred.MachineToken = keyringToken
+	case errors.Is(kerr, ErrTokenNotFound):
+		if cred.MachineToken == "" {
+			return nil, fmt.Errorf("credential metadata present at %s but token is missing from the keyring; "+
+				"re-run `sx cloud connect`", path)
+		}
+		// fallback-mode: TOML inline token is authoritative.
+	default:
+		return nil, fmt.Errorf("failed to read token from keyring: %w", kerr)
+	}
+	return &cred, nil
+}
+
+// Save writes the credential atomically: the token goes to the OS
+// keyring (with a TOML-file fallback on keyring failure), and the URL +
+// GID land in the TOML file with 0600 permissions. If the TOML rename
+// fails after the keyring write succeeded, we roll the keyring back so
+// the caller is never left with a keyring entry that points at a relay
+// the on-disk metadata doesn't know about.
+func Save(cred *Credential) error {
+	if cred == nil {
+		return errors.New("nil credential")
+	}
+	if err := cred.Validate(); err != nil {
+		return err
+	}
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+
+	log := logger.Get()
+	tomlCred := *cred
+	savedToKeyring := false
+	if kerr := activeTokenStore.Set(cred.RelayGID, cred.MachineToken); kerr != nil {
+		// Keyring unavailable — fall back to storing the token inline
+		// in the TOML file. 0600 still protects against other users on
+		// the same box, but we warn prominently so operators running
+		// on a headful laptop know something's off.
+		log.Warn("sx cloud: OS keyring unavailable; falling back to on-disk token storage. "+
+			"Backups of ~/.config/sx/cloud.toml will contain the token.",
+			"error", kerr)
+		// Fall through: tomlCred.MachineToken stays set, so the TOML
+		// encoder writes it.
+	} else {
+		// Keyring succeeded — never put the token in the TOML file.
+		tomlCred.MachineToken = ""
+		savedToKeyring = true
+	}
+
+	// Roll the keyring back if the on-disk metadata write fails. The
+	// defer fires only when ``returningErr`` is non-nil at the end of
+	// the function — keeping the happy path allocation-free.
+	var returningErr error
+	defer func() {
+		if returningErr != nil && savedToKeyring {
+			if derr := activeTokenStore.Delete(cred.RelayGID); derr != nil {
+				log.Warn("sx cloud: failed to roll back keyring after Save error",
+					"error", derr, "gid", cred.RelayGID)
+			}
+		}
+	}()
+
+	buf, err := marshalToml(&tomlCred)
+	if err != nil {
+		returningErr = fmt.Errorf("failed to encode credential: %w", err)
+		return returningErr
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".cloud.toml.tmp-*")
+	if err != nil {
+		returningErr = fmt.Errorf("failed to create temp file: %w", err)
+		return returningErr
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		_ = tmp.Close()
+		returningErr = fmt.Errorf("failed to chmod temp credential file: %w", err)
+		return returningErr
+	}
+	if _, err := tmp.Write(buf); err != nil {
+		_ = tmp.Close()
+		returningErr = fmt.Errorf("failed to write temp credential file: %w", err)
+		return returningErr
+	}
+	if err := tmp.Close(); err != nil {
+		returningErr = fmt.Errorf("failed to close temp credential file: %w", err)
+		return returningErr
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		returningErr = fmt.Errorf("failed to move credential into place: %w", err)
+		return returningErr
+	}
+	return nil
+}
+
+// RevokeKeyringEntry removes the keyring entry for a specific relay GID
+// without touching the on-disk metadata. Used by the “--force“ swap
+// path to clean up the old relay's token before saving the new one, so
+// an orphan doesn't accumulate in the user's OS keychain.
+//
+// No-op if the keyring doesn't know this GID. Errors are returned so
+// callers can log them, but the caller should continue regardless —
+// a stale keyring entry is a secret-hygiene regression, not a
+// correctness blocker.
+func RevokeKeyringEntry(relayGID string) error {
+	if relayGID == "" {
+		return errors.New("relay_gid is required")
+	}
+	return activeTokenStore.Delete(relayGID)
+}
+
+// Delete removes the persisted credential: TOML metadata file AND the
+// keyring entry for this relay's GID. Returns nil if nothing was stored.
+func Delete() error {
+	// Load first so we know the GID for the keyring entry; if the TOML
+	// is missing, there's nothing to delete on either side.
+	cred, err := Load()
+	if err != nil {
+		if errors.Is(err, ErrNoCredential) {
+			return nil
+		}
+		// Couldn't load cleanly (e.g. the keyring is down). Still make
+		// a best-effort attempt to delete the TOML so the next
+		// ``connect`` starts fresh; an orphaned keyring entry is not a
+		// correctness problem.
+		logger.Get().Warn("sx cloud revoke: failed to load credential before delete", "error", err)
+		return deleteMetadataFile()
+	}
+
+	// Delete keyring first so a crash after this line never leaves us
+	// with keyring-present / file-absent (which Load would then treat
+	// as "no credential" while the OS still shows a stale entry).
+	if kerr := activeTokenStore.Delete(cred.RelayGID); kerr != nil {
+		logger.Get().Warn("sx cloud revoke: failed to delete keyring entry", "error", kerr, "gid", cred.RelayGID)
+	}
+	return deleteMetadataFile()
+}
+
+func deleteMetadataFile() error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to remove %s: %w", path, err)
+	}
+	return nil
+}
+
+// Validate returns an error if required fields are missing.
+func (c *Credential) Validate() error {
+	if c.RelayBaseURL == "" {
+		return errors.New("relay_base_url is required")
+	}
+	if c.RelayGID == "" {
+		return errors.New("relay_gid is required")
+	}
+	if c.MachineToken == "" {
+		return errors.New("machine_token is required")
+	}
+	return nil
+}
+
+// WebSocketURL returns the URL sx dials to subscribe for inbound MCP
+// requests. Derived from “RelayBaseURL“ by swapping “http(s)“ for
+// “ws(s)“ and appending “ws/“.
+func (c *Credential) WebSocketURL() (string, error) {
+	u, err := url.Parse(c.RelayBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid relay_base_url: %w", err)
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("relay_base_url must be http(s): got scheme %q", u.Scheme)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/ws/"
+	return u.String(), nil
+}
+
+// ParseRelayURL takes a base URL like
+// “https://app.skills.new/relay/SR.../“ and returns the cleaned URL
+// and the relay GID segment. Used by “sx cloud attach“ to validate
+// what the user pasted.
+func ParseRelayURL(raw string) (baseURL string, relayGID string, err error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", "", fmt.Errorf("URL scheme must be http or https, got %q", u.Scheme)
+	}
+	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// Expect ``relay/<gid>`` possibly with extra trailing segments. We
+	// accept the canonical ``/relay/<gid>/`` base as well as
+	// ``/relay/<gid>/mcp/assets/`` (the URL shown on the success page).
+	idx := -1
+	for i, s := range segments {
+		if s == "relay" && i+1 < len(segments) {
+			idx = i + 1
+			break
+		}
+	}
+	if idx == -1 || segments[idx] == "" {
+		return "", "", errors.New("URL does not contain a /relay/<gid>/ segment")
+	}
+	relayGID = segments[idx]
+	u.Path = "/" + strings.Join(segments[:idx+1], "/") + "/"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), relayGID, nil
+}
+
+// marshalToml is separated so tests can exercise the full round-trip.
+func marshalToml(cred *Credential) ([]byte, error) {
+	var b strings.Builder
+	enc := toml.NewEncoder(&b)
+	if err := enc.Encode(cred); err != nil {
+		return nil, err
+	}
+	return []byte(b.String()), nil
+}

--- a/internal/cloud/credential.go
+++ b/internal/cloud/credential.go
@@ -99,10 +99,49 @@ func (osKeyring) Set(account, token string) error {
 
 func (osKeyring) Get(account string) (string, error) {
 	v, err := keyring.Get(keyringService, account)
+	if err == nil {
+		return v, nil
+	}
 	if errors.Is(err, keyring.ErrNotFound) {
 		return "", ErrTokenNotFound
 	}
+	if isKeyringUnavailable(err) {
+		// Headless Linux (no dbus, no org.freedesktop.secrets) returns a
+		// raw ``exec`` / ``dbus`` error here rather than ``ErrNotFound``.
+		// Treat that the same as "not found" so ``Load`` can fall back to
+		// the inline TOML token written by ``Save``'s fallback path.
+		// Without this, sx is unusable in containers / CI / minimal dev
+		// environments even though ``Save`` already handles the write-side.
+		return "", ErrTokenNotFound
+	}
 	return v, err
+}
+
+// isKeyringUnavailable returns true for the "no secret-service backend
+// installed" class of errors. Kept conservative on purpose — real
+// keyring failures (corrupt entry, permission denied on an existing
+// entry) still bubble up so operators notice.
+func isKeyringUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	markers := []string{
+		// Secret-service D-Bus name not registered (no gnome-keyring /
+		// KWallet / secret-service daemon running).
+		"org.freedesktop.secrets",
+		// go-keyring's Linux backend shells out to ``dbus-launch`` when
+		// no session bus is present. Missing binary → this error.
+		"dbus-launch",
+		// No session bus at all (container / minimal image).
+		"DBUS_SESSION_BUS_ADDRESS",
+	}
+	for _, m := range markers {
+		if strings.Contains(msg, m) {
+			return true
+		}
+	}
+	return false
 }
 
 func (osKeyring) Delete(account string) error {

--- a/internal/cloud/credential.go
+++ b/internal/cloud/credential.go
@@ -121,6 +121,14 @@ func (osKeyring) Get(account string) (string, error) {
 // installed" class of errors. Kept conservative on purpose — real
 // keyring failures (corrupt entry, permission denied on an existing
 // entry) still bubble up so operators notice.
+//
+// String matching is unfortunate but unavoidable: ``go-keyring``'s Linux
+// backend (``zalando/go-keyring``) doesn't expose a typed sentinel for "no
+// backend available" — it just returns whatever D-Bus surfaces. A library
+// or OS upgrade that reworded these messages would silently break the
+// fallback to on-disk storage; the unit tests for this function pin each
+// expected substring so we get a regression failure instead. If you add a
+// new marker, add a matching test case in credential_test.go.
 func isKeyringUnavailable(err error) bool {
 	if err == nil {
 		return false

--- a/internal/cloud/credential.go
+++ b/internal/cloud/credential.go
@@ -122,8 +122,8 @@ func (osKeyring) Get(account string) (string, error) {
 // keyring failures (corrupt entry, permission denied on an existing
 // entry) still bubble up so operators notice.
 //
-// String matching is unfortunate but unavoidable: ``go-keyring``'s Linux
-// backend (``zalando/go-keyring``) doesn't expose a typed sentinel for "no
+// String matching is unfortunate but unavoidable: “go-keyring“'s Linux
+// backend (“zalando/go-keyring“) doesn't expose a typed sentinel for "no
 // backend available" — it just returns whatever D-Bus surfaces. A library
 // or OS upgrade that reworded these messages would silently break the
 // fallback to on-disk storage; the unit tests for this function pin each

--- a/internal/cloud/credential_test.go
+++ b/internal/cloud/credential_test.go
@@ -1,0 +1,519 @@
+package cloud
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// fakeKeyring is an in-memory tokenStore for tests. The real keyring
+// is not reachable from CI; swapping this in via “withFakeKeyring“
+// keeps every test hermetic and lets us also exercise the "keyring
+// unavailable" fallback path without mucking with the OS keychain.
+type fakeKeyring struct {
+	mu      sync.Mutex
+	entries map[string]string
+	// setErr, if non-nil, is returned from set() — used to simulate
+	// "keyring unavailable so the caller should fall back to inline
+	// TOML storage."
+	setErr error
+}
+
+func newFakeKeyring() *fakeKeyring {
+	return &fakeKeyring{entries: make(map[string]string)}
+}
+
+func (f *fakeKeyring) Set(account, token string) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries[account] = token
+	return nil
+}
+
+func (f *fakeKeyring) Get(account string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.entries[account]
+	if !ok {
+		return "", ErrTokenNotFound
+	}
+	return v, nil
+}
+
+func (f *fakeKeyring) Delete(account string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.entries, account)
+	return nil
+}
+
+// withFakeKeyring swaps in a fresh in-memory tokenStore for the duration
+// of one test, restoring the previous store (real OS keyring in prod,
+// but in tests it can chain with another fake) on cleanup.
+func withFakeKeyring(t *testing.T) *fakeKeyring {
+	t.Helper()
+	prev := activeTokenStore
+	fake := newFakeKeyring()
+	activeTokenStore = fake
+	t.Cleanup(func() { activeTokenStore = prev })
+	return fake
+}
+
+func TestParseRelayURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantURL string
+		wantGID string
+		wantErr bool
+	}{
+		{
+			name:    "canonical base URL",
+			input:   "https://app.skills.new/relay/SRabc123/",
+			wantURL: "https://app.skills.new/relay/SRabc123/",
+			wantGID: "SRabc123",
+		},
+		{
+			name:    "trailing mcp path is trimmed to base",
+			input:   "https://app.skills.new/relay/SRabc123/mcp/assets/",
+			wantURL: "https://app.skills.new/relay/SRabc123/",
+			wantGID: "SRabc123",
+		},
+		{
+			name:    "http (dev) accepted",
+			input:   "http://dev.pulse.sleuth.io/relay/SRdev/",
+			wantURL: "http://dev.pulse.sleuth.io/relay/SRdev/",
+			wantGID: "SRdev",
+		},
+		{
+			name:    "query string stripped",
+			input:   "https://app.skills.new/relay/SRabc/mcp/assets/?foo=bar",
+			wantURL: "https://app.skills.new/relay/SRabc/",
+			wantGID: "SRabc",
+		},
+		{
+			name:    "missing relay segment",
+			input:   "https://app.skills.new/some/other/path/",
+			wantErr: true,
+		},
+		{
+			name:    "non-http scheme",
+			input:   "ftp://app.skills.new/relay/SRabc/",
+			wantErr: true,
+		},
+		{
+			name:    "empty GID",
+			input:   "https://app.skills.new/relay//",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, gotGID, err := ParseRelayURL(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got URL=%q GID=%q", gotURL, gotGID)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotURL != tc.wantURL {
+				t.Errorf("URL mismatch: got %q want %q", gotURL, tc.wantURL)
+			}
+			if gotGID != tc.wantGID {
+				t.Errorf("GID mismatch: got %q want %q", gotGID, tc.wantGID)
+			}
+		})
+	}
+}
+
+func TestWebSocketURL(t *testing.T) {
+	cases := []struct {
+		base string
+		want string
+	}{
+		{"https://app.skills.new/relay/SRabc/", "wss://app.skills.new/relay/SRabc/ws/"},
+		{"http://dev.pulse.sleuth.io/relay/SRdev/", "ws://dev.pulse.sleuth.io/relay/SRdev/ws/"},
+		// Trailing slash optional on input.
+		{"https://app.skills.new/relay/SRxyz", "wss://app.skills.new/relay/SRxyz/ws/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.base, func(t *testing.T) {
+			c := &Credential{RelayBaseURL: tc.base}
+			got, err := c.WebSocketURL()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadRoundTrip_UsesKeyring(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", tmp)
+	fake := withFakeKeyring(t)
+
+	cred := &Credential{
+		RelayBaseURL: "https://app.skills.new/relay/SRabc/",
+		RelayGID:     "SRabc",
+		MachineToken: "machine-secret-xyz",
+	}
+	if err := Save(cred); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Token should be in the keyring, NOT in the TOML file on disk.
+	path, err := Path()
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	diskBytes, err := os.ReadFile(path) // #nosec G304 -- path is the test-scoped config file
+	if err != nil {
+		t.Fatalf("read TOML: %v", err)
+	}
+	if contains(diskBytes, "machine-secret-xyz") {
+		t.Errorf("TOML file leaked the token: %s", diskBytes)
+	}
+	if fake.entries["SRabc"] != "machine-secret-xyz" {
+		t.Errorf("keyring missing token: %+v", fake.entries)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("expected 0600, got %o", info.Mode().Perm())
+		}
+	}
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Load returned nil")
+	}
+	if *got != *cred {
+		t.Errorf("round-trip mismatch: got %+v want %+v", got, cred)
+	}
+}
+
+func TestSave_KeyringFailure_FallsBackToTOML(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", tmp)
+	fake := withFakeKeyring(t)
+	fake.setErr = errors.New("no secret service available")
+
+	cred := &Credential{
+		RelayBaseURL: "https://app.skills.new/relay/SRabc/",
+		RelayGID:     "SRabc",
+		MachineToken: "fallback-token",
+	}
+	if err := Save(cred); err != nil {
+		t.Fatalf("Save should succeed even when keyring is down: %v", err)
+	}
+
+	// The TOML file should now contain the token (fallback mode).
+	path, _ := Path()
+	diskBytes, err := os.ReadFile(path) // #nosec G304 -- test-scoped config file
+	if err != nil {
+		t.Fatalf("read TOML: %v", err)
+	}
+	if !contains(diskBytes, "fallback-token") {
+		t.Errorf("TOML file missing fallback token: %s", diskBytes)
+	}
+
+	// Load should return the inline token since the keyring still says
+	// "not found".
+	fake.setErr = nil
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.MachineToken != "fallback-token" {
+		t.Errorf("token: got %q want %q", got.MachineToken, "fallback-token")
+	}
+}
+
+func TestLoad_InconsistentState_ReportsClearly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", tmp)
+	withFakeKeyring(t)
+
+	// Simulate a corrupt state: metadata file exists (no inline token)
+	// but the keyring knows nothing. Should surface a clear error.
+	path, err := Path()
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	// #nosec G306 -- 0600 is the sane default for secret-adjacent files
+	if err := os.WriteFile(path, []byte(
+		"relay_base_url = \"https://x/relay/SRghost/\"\nrelay_gid = \"SRghost\"\n",
+	), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err = Load()
+	if err == nil {
+		t.Fatal("expected error on metadata-without-keyring state")
+	}
+	if !contains([]byte(err.Error()), "missing from the keyring") {
+		t.Errorf("expected keyring-specific error, got: %v", err)
+	}
+}
+
+func TestLoadMissingReturnsSentinelError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", tmp)
+	withFakeKeyring(t)
+	got, err := Load()
+	if !errors.Is(err, ErrNoCredential) {
+		t.Fatalf("Load: want ErrNoCredential, got err=%v cred=%v", err, got)
+	}
+	if got != nil {
+		t.Errorf("expected nil credential with ErrNoCredential, got %+v", got)
+	}
+}
+
+func TestDeleteIsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", tmp)
+	fake := withFakeKeyring(t)
+	if err := Delete(); err != nil {
+		t.Fatalf("Delete missing: %v", err)
+	}
+	cred := &Credential{
+		RelayBaseURL: "https://app.skills.new/relay/SRabc/",
+		RelayGID:     "SRabc",
+		MachineToken: "x",
+	}
+	if err := Save(cred); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := Delete(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, still := fake.entries["SRabc"]; still {
+		t.Errorf("keyring entry not cleaned up on delete: %+v", fake.entries)
+	}
+	got, err := Load()
+	if !errors.Is(err, ErrNoCredential) {
+		t.Fatalf("Load after delete: want ErrNoCredential, got err=%v cred=%+v", err, got)
+	}
+	if got != nil {
+		t.Errorf("expected nil after delete, got %+v", got)
+	}
+}
+
+// writeOnlyFailKeyring lets tests simulate "keyring accepts set, then
+// we inspect whether rollback fired on a subsequent failure." The
+// fallback-set path shouldn't trigger rollback, so we track calls
+// instead of failing outright.
+type countingKeyring struct {
+	*fakeKeyring
+	setCalls    int
+	deleteCalls int
+}
+
+func (c *countingKeyring) Set(account, token string) error {
+	c.setCalls++
+	return c.fakeKeyring.Set(account, token)
+}
+
+func (c *countingKeyring) Delete(account string) error {
+	c.deleteCalls++
+	return c.fakeKeyring.Delete(account)
+}
+
+func TestSave_RollsBackKeyringOnDiskFailure(t *testing.T) {
+	// Point SX_CONFIG_DIR at a path that doesn't exist AND can't be
+	// created, so Path() → MkdirAll fails. The keyring write will
+	// never be attempted here because Path() fails first — which is
+	// not what we want to test. Instead, make the config dir a file
+	// so ``os.CreateTemp`` fails when Save tries to stage the TOML.
+	tmp := t.TempDir()
+	configAsFile := filepath.Join(tmp, "config-not-a-dir")
+	if err := os.WriteFile(configAsFile, []byte("nope"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// Inside the config dir, put another file with the exact name of
+	// what Path() would create a subdir for, so MkdirAll succeeds but
+	// CreateTemp fails because the parent isn't writable. The
+	// straightforward path: use a read-only directory as the config
+	// dir.
+	readonlyDir := filepath.Join(tmp, "readonly")
+	if err := os.Mkdir(readonlyDir, 0o500); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readonlyDir, 0o700) })
+	t.Setenv("SX_CONFIG_DIR", readonlyDir)
+
+	prev := activeTokenStore
+	fake := newFakeKeyring()
+	counting := &countingKeyring{fakeKeyring: fake}
+	activeTokenStore = counting
+	t.Cleanup(func() { activeTokenStore = prev })
+
+	cred := &Credential{
+		RelayBaseURL: "https://app.skills.new/relay/SRabc/",
+		RelayGID:     "SRabc",
+		MachineToken: "token-that-should-be-rolled-back",
+	}
+	err := Save(cred)
+	if err == nil {
+		t.Fatal("expected Save to fail on read-only config dir")
+	}
+	if counting.setCalls != 1 {
+		t.Errorf("expected 1 keyring set call, got %d", counting.setCalls)
+	}
+	if counting.deleteCalls != 1 {
+		t.Errorf("expected 1 keyring delete call (rollback), got %d", counting.deleteCalls)
+	}
+	if _, still := fake.entries["SRabc"]; still {
+		t.Errorf("keyring not rolled back: %+v", fake.entries)
+	}
+}
+
+func TestSave_SkipsRollbackWhenKeyringFallback(t *testing.T) {
+	// When the keyring is unavailable, Save falls back to writing the
+	// token inline in TOML. A subsequent disk failure must NOT
+	// ``delete`` the keyring, because the set() never succeeded — and
+	// calling delete on an unavailable keyring would either be a
+	// no-op or noisy.
+	tmp := t.TempDir()
+	readonlyDir := filepath.Join(tmp, "readonly")
+	if err := os.Mkdir(readonlyDir, 0o500); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readonlyDir, 0o700) })
+	t.Setenv("SX_CONFIG_DIR", readonlyDir)
+
+	prev := activeTokenStore
+	fake := newFakeKeyring()
+	fake.setErr = errors.New("no keyring")
+	counting := &countingKeyring{fakeKeyring: fake}
+	activeTokenStore = counting
+	t.Cleanup(func() { activeTokenStore = prev })
+
+	cred := &Credential{
+		RelayBaseURL: "https://app.skills.new/relay/SRabc/",
+		RelayGID:     "SRabc",
+		MachineToken: "fallback-token",
+	}
+	_ = Save(cred) // expected to fail; we care about the side effects
+	if counting.deleteCalls != 0 {
+		t.Errorf("unexpected keyring delete when set() had failed: %d", counting.deleteCalls)
+	}
+}
+
+func TestRevokeKeyringEntry(t *testing.T) {
+	withFakeKeyring(t)
+
+	if err := RevokeKeyringEntry(""); err == nil {
+		t.Error("expected error for empty GID")
+	}
+
+	// Set one up, then revoke — should succeed and clear the entry.
+	if err := activeTokenStore.Set("SRabc", "secret"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := RevokeKeyringEntry("SRabc"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := activeTokenStore.Get("SRabc"); !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("expected entry gone, got err=%v", err)
+	}
+
+	// Revoking a non-existent GID is a no-op; fake keyring returns nil.
+	if err := RevokeKeyringEntry("SRunknown"); err != nil {
+		t.Errorf("revoke-missing should be no-op: %v", err)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cred    Credential
+		wantErr bool
+	}{
+		{"all set", Credential{RelayBaseURL: "u", RelayGID: "g", MachineToken: "t"}, false},
+		{"missing url", Credential{RelayGID: "g", MachineToken: "t"}, true},
+		{"missing gid", Credential{RelayBaseURL: "u", MachineToken: "t"}, true},
+		{"missing token", Credential{RelayBaseURL: "u", RelayGID: "g"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cred.Validate()
+			if tc.wantErr && err == nil {
+				t.Error("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// contains is a tiny helper to avoid importing bytes in test-only code.
+// Using strings.Contains(string(b), ...) would do, but this keeps the
+// byte domain and plays nicely with future binary assertions.
+func contains(hay []byte, needle string) bool {
+	n := []byte(needle)
+	for i := 0; i+len(n) <= len(hay); i++ {
+		match := true
+		for j := range n {
+			if hay[i+j] != n[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// mustPath is used inside tests that need the Path helper and know
+// “SX_CONFIG_DIR“ is set. Not the usual "mustFoo" convenience — just
+// keeps the test bodies short.
+func mustPath(t *testing.T) string {
+	t.Helper()
+	path, err := Path()
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	if dir := filepath.Dir(path); dir == "" {
+		t.Fatalf("empty Path dir")
+	}
+	return path
+}
+
+// ensureTempConfig pre-flights the test-scoped config dir so higher-
+// level tests don't have to do it themselves. Currently unused by the
+// committed tests, but present so upstream refactors (adding a helper
+// for new test cases) don't have to reinvent the bootstrap.
+func ensureTempConfig(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", tmp)
+	return tmp
+}
+
+var (
+	_ = mustPath
+	_ = ensureTempConfig
+)

--- a/internal/cloud/credential_test.go
+++ b/internal/cloud/credential_test.go
@@ -517,3 +517,47 @@ var (
 	_ = mustPath
 	_ = ensureTempConfig
 )
+
+func TestIsKeyringUnavailable(t *testing.T) {
+	// Lock in every error-message marker the function recognizes. The
+	// upstream library (``zalando/go-keyring``) doesn't expose typed
+	// sentinels for "no backend available", so this matcher is the only
+	// thing keeping the on-disk fallback path alive on headless Linux.
+	// A library upgrade that reworded any of these would silently break
+	// containerized cloud serve — these test cases turn that into a
+	// loud regression instead.
+	cases := []struct {
+		name  string
+		err   error
+		match bool
+	}{
+		{name: "nil_error", err: nil, match: false},
+		{
+			name:  "secret_service_dbus_name_missing",
+			err:   errors.New("The name org.freedesktop.secrets was not provided by any .service files"),
+			match: true,
+		},
+		{
+			name:  "dbus_launch_binary_missing",
+			err:   errors.New("exec: \"dbus-launch\": executable file not found in $PATH"),
+			match: true,
+		},
+		{
+			name:  "no_session_bus",
+			err:   errors.New("DBUS_SESSION_BUS_ADDRESS is not set"),
+			match: true,
+		},
+		{
+			name:  "real_failure_passes_through",
+			err:   errors.New("permission denied"),
+			match: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isKeyringUnavailable(tc.err); got != tc.match {
+				t.Fatalf("isKeyringUnavailable(%v) = %v, want %v", tc.err, got, tc.match)
+			}
+		})
+	}
+}

--- a/internal/cloud/probe.go
+++ b/internal/cloud/probe.go
@@ -1,0 +1,71 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/coder/websocket"
+)
+
+// ErrProbeUnauthorized is returned by Probe when the relay's auth
+// handshake rejected our bearer token. Callers surface this as "token
+// rejected; re-run `sx cloud connect`" to the user without needing to
+// inspect the wrapped error.
+var ErrProbeUnauthorized = errors.New("relay rejected the machine token")
+
+// Probe performs a single-handshake verification of a credential
+// against its relay. Used by “sx cloud connect“ / “sx cloud attach“
+// to fail fast with a readable error when the pasted token is wrong,
+// rather than letting the failure surface only inside the long-running
+// “sx cloud serve“ loop.
+//
+// The probe dials the WebSocket endpoint with the stored Bearer token
+// and closes cleanly. A successful handshake means the relay accepted
+// the token and subscribed us — we don't need to stay connected. A
+// 401/403 on handshake maps to “ErrProbeUnauthorized“.
+//
+// “httpClient“ is optional; tests pass a stub, production leaves it
+// nil. “ctx“ bounds the whole dance — a reasonable default is 5s.
+func Probe(ctx context.Context, cred *Credential, httpClient *http.Client) error {
+	if cred == nil {
+		return errors.New("probe: credential is nil")
+	}
+	if err := cred.Validate(); err != nil {
+		return fmt.Errorf("probe: invalid credential: %w", err)
+	}
+	wsURL, err := cred.WebSocketURL()
+	if err != nil {
+		return fmt.Errorf("probe: bad WebSocket URL: %w", err)
+	}
+	dialOpts := &websocket.DialOptions{
+		HTTPClient: httpClient,
+		HTTPHeader: http.Header{
+			"Authorization": []string{"Bearer " + cred.MachineToken},
+		},
+	}
+	conn, resp, err := websocket.Dial(ctx, wsURL, dialOpts)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		// go-coder/websocket exposes the HTTP status code via its
+		// ``CloseStatus`` for close frames, but handshake failures
+		// come back as a wrapped error with the status in the text.
+		// Check the response first (more reliable) then fall back to
+		// string matching.
+		if resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+			return fmt.Errorf("%w (HTTP %d)", ErrProbeUnauthorized, resp.StatusCode)
+		}
+		return fmt.Errorf("probe handshake: %w", err)
+	}
+	// Hand-off: close cleanly. We only cared about the handshake — a
+	// successful ``Dial`` means the relay accepted our bearer, which
+	// is the only thing we can learn without round-tripping an MCP
+	// message. Close-time errors (peer closed first, TCP teardown
+	// race, ctx near deadline) are uninteresting here; returning them
+	// would cause spurious "probe failed" reports to the user.
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+	return nil
+}

--- a/internal/cloud/probe_test.go
+++ b/internal/cloud/probe_test.go
@@ -1,0 +1,72 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func TestProbe_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer good-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		// Peer should close immediately; we don't need to do anything.
+		_ = ws.Close(websocket.StatusNormalClosure, "")
+	}))
+	defer srv.Close()
+
+	cred := &Credential{
+		RelayBaseURL: strings.TrimSuffix(srv.URL, "/") + "/relay/SRtest/",
+		RelayGID:     "SRtest",
+		MachineToken: "good-token",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := Probe(ctx, cred, nil); err != nil {
+		t.Fatalf("Probe should succeed: %v", err)
+	}
+}
+
+func TestProbe_UnauthorizedMapsToSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Refuse the upgrade — handshake fails with HTTP 401.
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cred := &Credential{
+		RelayBaseURL: strings.TrimSuffix(srv.URL, "/") + "/relay/SRtest/",
+		RelayGID:     "SRtest",
+		MachineToken: "wrong-token",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := Probe(ctx, cred, nil)
+	if !errors.Is(err, ErrProbeUnauthorized) {
+		t.Fatalf("expected ErrProbeUnauthorized, got %v", err)
+	}
+}
+
+func TestProbe_InvalidCredential(t *testing.T) {
+	if err := Probe(context.Background(), nil, nil); err == nil {
+		t.Error("expected error for nil credential")
+	}
+	if err := Probe(context.Background(), &Credential{}, nil); err == nil {
+		t.Error("expected error for empty credential")
+	}
+}

--- a/internal/commands/cloud.go
+++ b/internal/commands/cloud.go
@@ -1,0 +1,433 @@
+package commands
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/internal/cloud"
+	"github.com/sleuth-io/sx/internal/config"
+	"github.com/sleuth-io/sx/internal/logger"
+	"github.com/sleuth-io/sx/internal/ui"
+)
+
+// DefaultCloudSignupURL is the skills.new page that walks a user
+// through “sx cloud connect“ in a browser. Environment override:
+// “SX_CLOUD_URL“.
+const DefaultCloudSignupURL = "https://app.skills.new/relay/connect"
+
+// NewCloudCommand creates the “sx cloud“ parent command. Subcommands
+// are “connect“, “attach“, “serve“, “status“, and “revoke“.
+func NewCloudCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Manage the skills.new relay that exposes this vault to chat clients",
+		Long: `Manage the skills.new cloud relay.
+
+A "relay" is a public MCP endpoint hosted on skills.new that forwards
+requests from claude.ai or chatgpt.com to the sx process running on
+your machine. The chat client reaches sx over a persistent WebSocket
+anchored to skills.new; the vault content itself never leaves this
+machine.
+
+Typical flow:
+
+  sx cloud connect       # open browser, confirm email, paste back the attach line
+  sx cloud attach ...    # persist the machine token on disk
+  sx cloud serve         # run the dispatcher loop (keep this running)
+  sx cloud status        # inspect the currently-attached relay
+  sx cloud revoke        # remove the local credential`,
+	}
+	cmd.AddCommand(newCloudConnectCommand())
+	cmd.AddCommand(newCloudAttachCommand())
+	cmd.AddCommand(newCloudServeCommand())
+	cmd.AddCommand(newCloudStatusCommand())
+	cmd.AddCommand(newCloudRevokeCommand())
+	return cmd
+}
+
+// ---------------------------------------------------------------------------
+// connect
+// ---------------------------------------------------------------------------
+
+func newCloudConnectCommand() *cobra.Command {
+	var noBrowser bool
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "connect",
+		Short: "Open the skills.new signup page and attach the returned credential",
+		Long: "Open the skills.new magic-link signup page in your default browser,\n" +
+			"wait for you to complete the flow, then paste the `sx cloud attach`\n" +
+			"command shown on the success page back into this terminal.\n\n" +
+			"The signup page mints a single machine token. Running `connect` again\n" +
+			"(or clicking a new magic link) from a different machine rotates that\n" +
+			"token — the previous sx instance stops serving on its next frame.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCloudConnect(cmd, noBrowser, force)
+		},
+	}
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false,
+		"Print the signup URL instead of launching a browser")
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Replace an existing credential even if it points at a different relay")
+	return cmd
+}
+
+func runCloudConnect(cmd *cobra.Command, noBrowser, force bool) error {
+	out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+
+	signupURL := DefaultCloudSignupURL
+	if env := os.Getenv("SX_CLOUD_URL"); env != "" {
+		signupURL = env
+	}
+
+	out.Info("Opening skills.new signup page...")
+	out.Printf("%s", signupURL+"\n\n")
+	if noBrowser {
+		out.Printf("%s", "Open the link above in your browser, then paste the `sx cloud attach` command shown there:\n")
+	} else {
+		// Best effort — headless environments can use --no-browser.
+		if err := browser.OpenURL(signupURL); err != nil {
+			out.Warning(fmt.Sprintf("Failed to open browser automatically: %v", err))
+			out.Printf("%s", "Open the link above in your browser, then paste the `sx cloud attach` command shown there:\n")
+		} else {
+			out.Printf("%s", "After confirming your email in the browser, paste the `sx cloud attach` command here:\n")
+		}
+	}
+
+	line, err := readAttachCommand(cmd.InOrStdin())
+	if err != nil {
+		return err
+	}
+	relayURL, token, err := parseAttachCommandLine(line)
+	if err != nil {
+		return fmt.Errorf("could not parse pasted command: %w", err)
+	}
+	return persistCredential(cmd, relayURL, token, force)
+}
+
+// readAttachCommand pulls a single line from stdin, skipping blank
+// lines so the user can paste at will.
+func readAttachCommand(r interface{ Read(p []byte) (int, error) }) (string, error) {
+	scanner := bufio.NewScanner(r)
+	// sx cloud attach lines are short; give ourselves headroom anyway
+	// so an unusually long URL doesn't silently truncate.
+	scanner.Buffer(make([]byte, 0, 4096), 1<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		return line, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading input: %w", err)
+	}
+	return "", errors.New("no input received")
+}
+
+// parseAttachCommandLine accepts either
+//   - a full "sx cloud attach --url=... --token=..." line (as printed on
+//     the success page), OR
+//   - a bare "--url=... --token=..." string.
+//
+// We deliberately don't re-execute the cobra command; we just extract
+// the two values.
+func parseAttachCommandLine(line string) (relayURL, token string, err error) {
+	line = strings.TrimSpace(line)
+	// Trim a leading ``sx cloud attach`` / ``./sx cloud attach`` /
+	// ``bin/sx cloud attach`` etc. — anything before the first ``--``.
+	if idx := strings.Index(line, "--"); idx > 0 {
+		line = line[idx:]
+	}
+	// Tokenize on whitespace; each token is either ``--url=...``,
+	// ``--token=...``, or (with a space separator) ``--url`` followed
+	// by the value as the next token. Handle both shapes.
+	fields := strings.Fields(line)
+	for i := 0; i < len(fields); i++ {
+		f := fields[i]
+		switch {
+		case strings.HasPrefix(f, "--url="):
+			relayURL = strings.TrimPrefix(f, "--url=")
+		case f == "--url" && i+1 < len(fields):
+			relayURL = fields[i+1]
+			i++
+		case strings.HasPrefix(f, "--token="):
+			token = strings.TrimPrefix(f, "--token=")
+		case f == "--token" && i+1 < len(fields):
+			token = fields[i+1]
+			i++
+		}
+	}
+	if relayURL == "" || token == "" {
+		return "", "", errors.New("missing --url or --token")
+	}
+	return relayURL, token, nil
+}
+
+// ---------------------------------------------------------------------------
+// attach
+// ---------------------------------------------------------------------------
+
+func newCloudAttachCommand() *cobra.Command {
+	var relayURL, token string
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "attach",
+		Short: "Persist a machine token for a skills.new relay",
+		Long: "Persist the machine token + relay URL produced by `sx cloud connect`.\n\n" +
+			"The machine token is written to the OS keyring (macOS Keychain,\n" +
+			"Windows Credential Manager, freedesktop Secret Service on Linux).\n" +
+			"If the keyring is unavailable, sx falls back to an on-disk TOML\n" +
+			"file with 0600 permissions and prints a warning.\n\n" +
+			"Attaching when a credential already exists for a different relay\n" +
+			"fails unless --force is set. Re-attaching the same relay (to rotate\n" +
+			"its token) is always allowed.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if relayURL == "" || token == "" {
+				return errors.New("--url and --token are required")
+			}
+			return persistCredential(cmd, relayURL, token, force)
+		},
+	}
+	cmd.Flags().StringVar(&relayURL, "url", "",
+		"Relay base URL, e.g. https://app.skills.new/relay/SR.../")
+	cmd.Flags().StringVar(&token, "token", "",
+		"Machine token shown once on the skills.new success page")
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Replace an existing credential even if it points at a different relay")
+	return cmd
+}
+
+func persistCredential(cmd *cobra.Command, relayURL, token string, force bool) error {
+	out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+
+	cleanURL, relayGID, err := cloud.ParseRelayURL(relayURL)
+	if err != nil {
+		return fmt.Errorf("invalid --url: %w", err)
+	}
+	cred := &cloud.Credential{
+		RelayBaseURL: cleanURL,
+		RelayGID:     relayGID,
+		MachineToken: token,
+	}
+
+	// Guard against a user pointing sx at a different relay than the
+	// one currently attached. Same-GID re-attach (token rotation) is
+	// common and proceeds; cross-relay swap requires --force.
+	var supersededGID string
+	if existing, loadErr := cloud.Load(); loadErr == nil && existing != nil && existing.RelayGID != relayGID {
+		if !force {
+			return fmt.Errorf(
+				"refusing to overwrite existing credential for relay %s with a credential for relay %s; "+
+					"re-run with --force to proceed",
+				existing.RelayGID, relayGID,
+			)
+		}
+		// Defer the actual keyring eviction until AFTER Probe + Save
+		// succeed — if the probe rejects the new token or Save fails,
+		// we want the old credential intact and usable.
+		supersededGID = existing.RelayGID
+	}
+
+	// Verify the token actually authenticates before we write it to
+	// disk / the keyring. A typo or wrong-relay paste otherwise
+	// surfaces only when ``sx cloud serve`` fails to connect.
+	probeCtx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	defer cancel()
+	if probeErr := cloud.Probe(probeCtx, cred, nil); probeErr != nil {
+		if errors.Is(probeErr, cloud.ErrProbeUnauthorized) {
+			return errors.New("relay rejected the machine token; re-run `sx cloud connect` to mint a fresh one")
+		}
+		return fmt.Errorf("could not reach relay to verify credential: %w", probeErr)
+	}
+
+	if err := cloud.Save(cred); err != nil {
+		return err
+	}
+
+	// Save succeeded — now it's safe to evict the old keyring entry.
+	// A failure here is non-fatal: the new credential is already
+	// authoritative (TOML + keyring both reference the new GID);
+	// a leaked old keyring entry is a secret-hygiene regression,
+	// not a correctness one, and we surface it to the operator so
+	// they can remove it manually if they care.
+	if supersededGID != "" {
+		out.Warning("Overwriting existing credential for relay " + supersededGID)
+		if revErr := cloud.RevokeKeyringEntry(supersededGID); revErr != nil {
+			out.Warning(fmt.Sprintf(
+				"failed to remove keyring entry for old relay %s: %v (proceeding)",
+				supersededGID, revErr,
+			))
+		}
+	}
+	path, _ := cloud.Path()
+	out.Success("Saved machine token for relay " + relayGID)
+	out.Printf("%s", fmt.Sprintf("  credential file: %s\n", path))
+	out.Printf("%s", "  run `sx cloud serve` to start forwarding MCP requests from chat clients.\n")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// serve
+// ---------------------------------------------------------------------------
+
+func newCloudServeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Dispatch MCP requests from the skills.new relay against the local vault",
+		Long: "Keep a WebSocket open to the skills.new relay and run each inbound\n" +
+			"MCP JSON-RPC request against the vault configured for this sx install.\n" +
+			"The process runs in the foreground; Ctrl+C exits cleanly.\n\n" +
+			"Reconnects automatically on transient network errors with exponential\n" +
+			"backoff. Requires `sx cloud attach` (or `sx cloud connect`) to have\n" +
+			"stored a machine token first.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCloudServe(cmd)
+		},
+	}
+	return cmd
+}
+
+func runCloudServe(cmd *cobra.Command) error {
+	out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	log := logger.Get()
+
+	cred, err := cloud.Load()
+	if err != nil {
+		if errors.Is(err, cloud.ErrNoCredential) {
+			return errors.New("no relay credential found; run `sx cloud connect` first")
+		}
+		return err
+	}
+
+	// Load the local vault config so we can build the same MCP server
+	// that ``sx serve`` (stdio) uses. The server factory runs per
+	// reconnect to keep state fresh.
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load sx config (is this directory initialized?): %w", err)
+	}
+	log.Info("loaded sx config for cloud serve", "vault_type", cfg.Type)
+
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+	go func() {
+		select {
+		case <-sigChan:
+			out.Info("\nShutting down sx cloud serve...")
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	out.Info(fmt.Sprintf("Serving relay %s via %s", cred.RelayGID, cred.RelayBaseURL))
+	out.Printf("%s", "Press Ctrl+C to stop.\n")
+
+	err = cloud.Serve(ctx, cloud.ServeOptions{
+		Credential:       cred,
+		MCPServerFactory: buildCloudServeMCPServer,
+	})
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+func newCloudStatusCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show the currently-attached skills.new relay",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCloudStatus(cmd)
+		},
+	}
+	return cmd
+}
+
+func runCloudStatus(cmd *cobra.Command) error {
+	out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	cred, err := cloud.Load()
+	if err != nil {
+		if errors.Is(err, cloud.ErrNoCredential) {
+			out.Printf("%s", "No relay attached. Run `sx cloud connect` to create one.\n")
+			return nil
+		}
+		return err
+	}
+	path, _ := cloud.Path()
+	wsURL, _ := cred.WebSocketURL()
+	masked := maskToken(cred.MachineToken)
+	out.Printf("%s", fmt.Sprintf("Relay GID:        %s\n", cred.RelayGID))
+	out.Printf("%s", fmt.Sprintf("Relay base URL:   %s\n", cred.RelayBaseURL))
+	out.Printf("%s", fmt.Sprintf("WebSocket URL:    %s\n", wsURL))
+	out.Printf("%s", fmt.Sprintf("Machine token:    %s\n", masked))
+	out.Printf("%s", fmt.Sprintf("Credential file:  %s\n", path))
+	if mcpURL := mcpEndpointURL(cred.RelayBaseURL); mcpURL != "" {
+		out.Printf("%s", fmt.Sprintf("MCP endpoint:     %s  (paste into claude.ai/chatgpt.com)\n", mcpURL))
+	}
+	return nil
+}
+
+// maskToken shows only the first 4 characters so “sx cloud status“ is
+// copy-pasteable into support tickets without leaking the secret.
+func maskToken(token string) string {
+	if len(token) <= 4 {
+		return "****"
+	}
+	return token[:4] + "..." + strings.Repeat("*", 8)
+}
+
+// mcpEndpointURL derives the /mcp/assets/ URL that the user pastes into
+// claude.ai or chatgpt.com. Returns "" if the base URL doesn't parse.
+func mcpEndpointURL(base string) string {
+	u, err := url.Parse(base)
+	if err != nil {
+		return ""
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/mcp/assets/"
+	return u.String()
+}
+
+// ---------------------------------------------------------------------------
+// revoke
+// ---------------------------------------------------------------------------
+
+func newCloudRevokeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Delete the local skills.new relay credential",
+		Long: "Remove the locally-stored machine token. The relay itself is NOT\n" +
+			"revoked on the server side — skills.new still considers it active\n" +
+			"until someone re-runs `sx cloud connect` (which rotates the token)\n" +
+			"or an admin explicitly revokes it. To regain access from this machine,\n" +
+			"run `sx cloud connect` again.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			if err := cloud.Delete(); err != nil {
+				return err
+			}
+			out.Success("Removed local relay credential")
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/commands/cloud.go
+++ b/internal/commands/cloud.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
@@ -338,9 +339,16 @@ func runCloudServe(cmd *cobra.Command) error {
 	out.Info(fmt.Sprintf("Serving relay %s via %s", cred.RelayGID, cred.RelayBaseURL))
 	out.Printf("%s", "Press Ctrl+C to stop.\n")
 
+	// Capture cfg in the factory closure rather than reloading from disk on
+	// every reconnect. The original wiring did two things wrong: it read the
+	// disk twice on startup (once here, once in the factory) and silently
+	// discarded the value of the first load — making the log line above
+	// drift from what the factory actually used.
 	err = cloud.Serve(ctx, cloud.ServeOptions{
-		Credential:       cred,
-		MCPServerFactory: buildCloudServeMCPServer,
+		Credential: cred,
+		MCPServerFactory: func() (*mcp.Server, error) {
+			return buildCloudServeMCPServerFromConfig(cfg)
+		},
 	})
 	if errors.Is(err, context.Canceled) {
 		return nil
@@ -419,7 +427,10 @@ func newCloudRevokeCommand() *cobra.Command {
 			"revoked on the server side — skills.new still considers it active\n" +
 			"until someone re-runs `sx cloud connect` (which rotates the token)\n" +
 			"or an admin explicitly revokes it. To regain access from this machine,\n" +
-			"run `sx cloud connect` again.",
+			"run `sx cloud connect` again.\n\n" +
+			"To fully revoke access server-side (e.g. before sharing this machine\n" +
+			"or rotating secrets), visit https://app.skills.new/relay to invalidate\n" +
+			"the token immediately.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
 			if err := cloud.Delete(); err != nil {

--- a/internal/commands/cloud_mcp.go
+++ b/internal/commands/cloud_mcp.go
@@ -11,9 +11,12 @@ import (
 	vaultpkg "github.com/sleuth-io/sx/internal/vault"
 )
 
-// buildCloudServeMCPServer constructs a fresh MCP server with the
-// vault's tools registered. Invoked once per cloud serve reconnect to
-// avoid leaking session state across connections.
+// buildCloudServeMCPServerFromConfig constructs a fresh MCP server with the
+// vault's tools registered, using a pre-loaded config snapshot. Invoked once
+// per cloud serve reconnect to avoid leaking session state across
+// connections; the caller passes the same ``cfg`` it loaded once at startup
+// so the disk isn't re-read on every reconnect (and the startup log line
+// describes the same vault the factory will instantiate).
 //
 // Parallel to “mcpserver.Server.registerVaultTools“ but returns a
 // standalone “*mcp.Server“ that can be driven by an in-memory
@@ -28,7 +31,7 @@ import (
 //     asset listing/loading toolset onto a server (used by PathVault and
 //     GitVault, which have no bespoke per-vault tools but want claude.ai /
 //     chatgpt.com to see real list_my_assets / load_my_asset surfaces).
-func buildCloudServeMCPServer() (*mcp.Server, error) {
+func buildCloudServeMCPServerFromConfig(cfg *config.Config) (*mcp.Server, error) {
 	log := logger.Get()
 
 	impl := &mcp.Implementation{
@@ -36,11 +39,6 @@ func buildCloudServeMCPServer() (*mcp.Server, error) {
 		Version: "1.0.0",
 	}
 	server := mcp.NewServer(impl, nil)
-
-	cfg, err := config.Load()
-	if err != nil {
-		return nil, fmt.Errorf("cloud serve: load sx config: %w", err)
-	}
 
 	vault, err := vaultpkg.NewFromConfig(cfg)
 	if err != nil {

--- a/internal/commands/cloud_mcp.go
+++ b/internal/commands/cloud_mcp.go
@@ -21,6 +21,13 @@ import (
 // tool-less server — a relay that connects but serves nothing is
 // indistinguishable from a healthy empty vault and leaves the operator
 // without a signal that something is wrong.
+//
+// Vaults can supply tools in two shapes:
+//   - “[]vaultpkg.ToolDef“ — explicit tool list (used by SleuthVault).
+//   - “*vaultpkg.AssetShimRegistrar“ — a registrar that wires the standard
+//     asset listing/loading toolset onto a server (used by PathVault and
+//     GitVault, which have no bespoke per-vault tools but want claude.ai /
+//     chatgpt.com to see real list_my_assets / load_my_asset surfaces).
 func buildCloudServeMCPServer() (*mcp.Server, error) {
 	log := logger.Get()
 
@@ -42,23 +49,24 @@ func buildCloudServeMCPServer() (*mcp.Server, error) {
 
 	tools := vault.GetMCPTools()
 	if tools == nil {
-		// A vault with no MCP tools is legitimate (e.g. PathVault) —
-		// we return the empty server without error. The operator sees
-		// "connected, no tools" and knows that's expected for this
-		// vault type.
 		log.Debug("cloud serve: vault provides no MCP tools")
 		return server, nil
 	}
-	defs, ok := tools.([]vaultpkg.ToolDef)
-	if !ok {
+
+	switch t := tools.(type) {
+	case *vaultpkg.AssetShimRegistrar:
+		t.Register(server)
+		return server, nil
+	case []vaultpkg.ToolDef:
+		if len(t) == 0 {
+			return nil, errors.New("cloud serve: vault returned empty tool list")
+		}
+		for _, def := range t {
+			mcp.AddTool(server, def.Tool, def.Handler)
+			log.Debug("cloud serve: registered MCP tool", "name", def.Tool.Name)
+		}
+		return server, nil
+	default:
 		return nil, fmt.Errorf("cloud serve: vault returned unexpected MCP tools type %T", tools)
 	}
-	if len(defs) == 0 {
-		return nil, errors.New("cloud serve: vault returned empty tool list")
-	}
-	for _, def := range defs {
-		mcp.AddTool(server, def.Tool, def.Handler)
-		log.Debug("cloud serve: registered MCP tool", "name", def.Tool.Name)
-	}
-	return server, nil
 }

--- a/internal/commands/cloud_mcp.go
+++ b/internal/commands/cloud_mcp.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/sleuth-io/sx/internal/config"
+	"github.com/sleuth-io/sx/internal/logger"
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+// buildCloudServeMCPServer constructs a fresh MCP server with the
+// vault's tools registered. Invoked once per cloud serve reconnect to
+// avoid leaking session state across connections.
+//
+// Parallel to “mcpserver.Server.registerVaultTools“ but returns a
+// standalone “*mcp.Server“ that can be driven by an in-memory
+// transport. Returns an error rather than silently producing a
+// tool-less server — a relay that connects but serves nothing is
+// indistinguishable from a healthy empty vault and leaves the operator
+// without a signal that something is wrong.
+func buildCloudServeMCPServer() (*mcp.Server, error) {
+	log := logger.Get()
+
+	impl := &mcp.Implementation{
+		Name:    "skills",
+		Version: "1.0.0",
+	}
+	server := mcp.NewServer(impl, nil)
+
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("cloud serve: load sx config: %w", err)
+	}
+
+	vault, err := vaultpkg.NewFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("cloud serve: create vault from config: %w", err)
+	}
+
+	tools := vault.GetMCPTools()
+	if tools == nil {
+		// A vault with no MCP tools is legitimate (e.g. PathVault) —
+		// we return the empty server without error. The operator sees
+		// "connected, no tools" and knows that's expected for this
+		// vault type.
+		log.Debug("cloud serve: vault provides no MCP tools")
+		return server, nil
+	}
+	defs, ok := tools.([]vaultpkg.ToolDef)
+	if !ok {
+		return nil, fmt.Errorf("cloud serve: vault returned unexpected MCP tools type %T", tools)
+	}
+	if len(defs) == 0 {
+		return nil, errors.New("cloud serve: vault returned empty tool list")
+	}
+	for _, def := range defs {
+		mcp.AddTool(server, def.Tool, def.Handler)
+		log.Debug("cloud serve: registered MCP tool", "name", def.Tool.Name)
+	}
+	return server, nil
+}

--- a/internal/commands/cloud_mcp.go
+++ b/internal/commands/cloud_mcp.go
@@ -14,7 +14,7 @@ import (
 // buildCloudServeMCPServerFromConfig constructs a fresh MCP server with the
 // vault's tools registered, using a pre-loaded config snapshot. Invoked once
 // per cloud serve reconnect to avoid leaking session state across
-// connections; the caller passes the same ``cfg`` it loaded once at startup
+// connections; the caller passes the same “cfg“ it loaded once at startup
 // so the disk isn't re-read on every reconnect (and the startup log line
 // describes the same vault the factory will instantiate).
 //

--- a/internal/commands/cloud_test.go
+++ b/internal/commands/cloud_test.go
@@ -1,0 +1,203 @@
+package commands
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/internal/cloud"
+	"github.com/sleuth-io/sx/internal/cloud/cloudtest"
+)
+
+func TestParseAttachCommandLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantURL string
+		wantTok string
+		wantErr bool
+	}{
+		{
+			name:    "canonical paste from success page",
+			input:   "sx cloud attach --url=https://app.skills.new/relay/SRabc/ --token=tok-xyz",
+			wantURL: "https://app.skills.new/relay/SRabc/",
+			wantTok: "tok-xyz",
+		},
+		{
+			name:    "space-separated flags",
+			input:   "sx cloud attach --url https://app.skills.new/relay/SRabc/ --token tok-xyz",
+			wantURL: "https://app.skills.new/relay/SRabc/",
+			wantTok: "tok-xyz",
+		},
+		{
+			name:    "bare flags without sx cloud attach prefix",
+			input:   "--url=https://app.skills.new/relay/SRabc/ --token=tok-xyz",
+			wantURL: "https://app.skills.new/relay/SRabc/",
+			wantTok: "tok-xyz",
+		},
+		{
+			name:    "swapped order",
+			input:   "sx cloud attach --token=tok-xyz --url=https://app.skills.new/relay/SRabc/",
+			wantURL: "https://app.skills.new/relay/SRabc/",
+			wantTok: "tok-xyz",
+		},
+		{
+			name:    "leading binary path",
+			input:   "/usr/local/bin/sx cloud attach --url=https://app.skills.new/relay/SRabc/ --token=tok-xyz",
+			wantURL: "https://app.skills.new/relay/SRabc/",
+			wantTok: "tok-xyz",
+		},
+		{
+			name:    "whitespace variations",
+			input:   "  sx cloud attach --url=https://app.skills.new/relay/SRabc/   --token=tok-xyz  ",
+			wantURL: "https://app.skills.new/relay/SRabc/",
+			wantTok: "tok-xyz",
+		},
+		{
+			name:    "missing token",
+			input:   "sx cloud attach --url=https://app.skills.new/relay/SRabc/",
+			wantErr: true,
+		},
+		{
+			name:    "missing url",
+			input:   "sx cloud attach --token=tok-xyz",
+			wantErr: true,
+		},
+		{
+			name:    "unrelated text",
+			input:   "hello world",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, gotTok, err := parseAttachCommandLine(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got URL=%q token=%q", gotURL, gotTok)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotURL != tc.wantURL {
+				t.Errorf("URL: got %q want %q", gotURL, tc.wantURL)
+			}
+			if gotTok != tc.wantTok {
+				t.Errorf("token: got %q want %q", gotTok, tc.wantTok)
+			}
+		})
+	}
+}
+
+func TestReadAttachCommandSkipsBlankLines(t *testing.T) {
+	input := "\n\n   \nsx cloud attach --url=https://x/relay/SR/ --token=t\n"
+	got, err := readAttachCommand(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "sx cloud attach --url=https://x/relay/SR/ --token=t"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestReadAttachCommandEmptyInputErrors(t *testing.T) {
+	if _, err := readAttachCommand(strings.NewReader("")); err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestMaskToken(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "****"},
+		{"ab", "****"},
+		{"abcd", "****"},
+		{"abcdefghij", "abcd...********"},
+	}
+	for _, tc := range cases {
+		got := maskToken(tc.in)
+		if got != tc.want {
+			t.Errorf("maskToken(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMCPEndpointURL(t *testing.T) {
+	got := mcpEndpointURL("https://app.skills.new/relay/SRabc/")
+	want := "https://app.skills.new/relay/SRabc/mcp/assets/"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// TestPersistCredential_FailedProbeKeepsOldCredentialIntact guards
+// against a subtle order-of-operations regression: when a user runs
+// “sx cloud attach --force“ for a different relay and the probe
+// rejects the new token, the OLD credential must still be loadable.
+// The fix is to defer the old-keyring eviction until after probe + save
+// succeed.
+func TestPersistCredential_FailedProbeKeepsOldCredentialIntact(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", tmp)
+	fake := cloudtest.InstallKeyring(t)
+
+	// Seed a working credential for the OLD relay.
+	old := &cloud.Credential{
+		RelayBaseURL: "https://app.skills.new/relay/SRold/",
+		RelayGID:     "SRold",
+		MachineToken: "old-token",
+	}
+	if err := cloud.Save(old); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	// Stand up a relay server that rejects the NEW token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	newURL := strings.TrimSuffix(srv.URL, "/") + "/relay/SRnew/"
+
+	// Fire persistCredential with --force + a bad token. Should fail.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	cmd.SetOut(os.Stderr)
+	cmd.SetErr(os.Stderr)
+
+	err := persistCredential(cmd, newURL, "bad-new-token", true)
+	if err == nil {
+		t.Fatal("expected persistCredential to fail when probe rejects the token")
+	}
+
+	// OLD credential must still be loadable — that's the core of this
+	// test. If the eviction fired too early, Load() now trips the
+	// "metadata present but token missing" branch in credential.go.
+	got, loadErr := cloud.Load()
+	if loadErr != nil {
+		t.Fatalf("old credential should still load after failed swap: %v", loadErr)
+	}
+	if got.RelayGID != "SRold" || got.MachineToken != "old-token" {
+		t.Errorf("old credential altered: got %+v", got)
+	}
+	// Keyring should still hold the old token, NOT the new one.
+	if _, has := fake.Entries()["SRnew"]; has {
+		t.Errorf("keyring should not contain the failed new token")
+	}
+	if v := fake.Entries()["SRold"]; v != "old-token" {
+		t.Errorf("keyring lost old token: got %q", v)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -105,14 +105,19 @@ func (s *Server) registerVaultTools(ctx context.Context, mcpServer *mcp.Server) 
 		return // No tools provided by this vault
 	}
 
-	// Register tools with the MCP server
-	// The tools are expected to be []vaultpkg.ToolDef from Sleuth vault
-	if toolDefs, ok := tools.([]vaultpkg.ToolDef); ok {
-		log.Debug("registering MCP tools from vault", "count", len(toolDefs))
-		for _, def := range toolDefs {
+	// Vaults expose tools in one of two shapes — see buildCloudServeMCPServer
+	// for the cloud parallel.
+	switch t := tools.(type) {
+	case *vaultpkg.AssetShimRegistrar:
+		t.Register(mcpServer)
+	case []vaultpkg.ToolDef:
+		log.Debug("registering MCP tools from vault", "count", len(t))
+		for _, def := range t {
 			mcp.AddTool(mcpServer, def.Tool, def.Handler)
 			log.Debug("registered MCP tool", "name", def.Tool.Name)
 		}
+	default:
+		log.Debug("vault returned unexpected MCP tools type", "type", fmt.Sprintf("%T", tools))
 	}
 }
 

--- a/internal/utils/zip.go
+++ b/internal/utils/zip.go
@@ -139,7 +139,7 @@ func ListZipFiles(zipData []byte) ([]string, error) {
 }
 
 // ZipEntry summarizes one file in a zip archive without decompressing it.
-// ``Size`` is the uncompressed size as recorded in the local file header,
+// “Size“ is the uncompressed size as recorded in the local file header,
 // suitable for inventory listings that don't need to read the body.
 type ZipEntry struct {
 	Name string
@@ -148,7 +148,7 @@ type ZipEntry struct {
 
 // ListZipEntries returns name + uncompressed size for every file in the
 // archive, reading only the central directory. Lets callers build an
-// inventory (e.g. an MCP ``bundled_files`` payload) without paying the cost
+// inventory (e.g. an MCP “bundled_files“ payload) without paying the cost
 // of decompressing every entry.
 func ListZipEntries(zipData []byte) ([]ZipEntry, error) {
 	if !IsZipFile(zipData) {

--- a/internal/utils/zip.go
+++ b/internal/utils/zip.go
@@ -125,23 +125,48 @@ func ReadZipFile(zipData []byte, filename string) ([]byte, error) {
 	return nil, fmt.Errorf("file not found in zip: %s", filename)
 }
 
-// ListZipFiles returns a list of all files in a zip archive
+// ListZipFiles returns a list of all file names in a zip archive.
 func ListZipFiles(zipData []byte) ([]string, error) {
+	entries, err := ListZipEntries(zipData)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]string, 0, len(entries))
+	for _, e := range entries {
+		files = append(files, e.Name)
+	}
+	return files, nil
+}
+
+// ZipEntry summarizes one file in a zip archive without decompressing it.
+// ``Size`` is the uncompressed size as recorded in the local file header,
+// suitable for inventory listings that don't need to read the body.
+type ZipEntry struct {
+	Name string
+	Size int64
+}
+
+// ListZipEntries returns name + uncompressed size for every file in the
+// archive, reading only the central directory. Lets callers build an
+// inventory (e.g. an MCP ``bundled_files`` payload) without paying the cost
+// of decompressing every entry.
+func ListZipEntries(zipData []byte) ([]ZipEntry, error) {
 	if !IsZipFile(zipData) {
 		return nil, errors.New("invalid zip file: missing magic bytes")
 	}
-
 	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read zip: %w", err)
 	}
-
-	var files []string
+	entries := make([]ZipEntry, 0, len(reader.File))
 	for _, file := range reader.File {
-		files = append(files, file.Name)
+		entries = append(entries, ZipEntry{
+			Name: file.Name,
+			//nolint:gosec // Uncompressed size from a trusted local archive
+			Size: int64(file.UncompressedSize64),
+		})
 	}
-
-	return files, nil
+	return entries, nil
 }
 
 // CreateZip creates a zip archive from a directory

--- a/internal/vault/asset_shim.go
+++ b/internal/vault/asset_shim.go
@@ -42,7 +42,7 @@ const shimMaxListAssets = 100
 const shimMaxListDescriptionLen = 200
 
 // chatDefaultTypeKeys is the chat-usable subset returned when no explicit
-// ``type`` filter is provided. Hooks, MCP configs, and Claude Code plugins
+// “type“ filter is provided. Hooks, MCP configs, and Claude Code plugins
 // are CLI-only lifecycle primitives and confuse a web-chat client, so the
 // caller has to opt in by name.
 var chatDefaultTypeKeys = []string{
@@ -133,8 +133,8 @@ func (r *AssetShimRegistrar) handleListAssets(
 // single asset type. Used by list_my_skills / list_my_rules / etc. — those
 // aliases exist because chatgpt.com / claude.ai dispatchers match heavily on
 // tool *name*, and a user asking "what skills do I have" lands more reliably
-// on a tool literally named ``list_my_skills`` than on a generic
-// ``list_my_assets`` call with an inferred filter.
+// on a tool literally named “list_my_skills“ than on a generic
+// “list_my_assets“ call with an inferred filter.
 func (r *AssetShimRegistrar) handleListByType(
 	typeKey string,
 ) func(context.Context, *mcp.CallToolRequest, ListByTypeArgs) (*mcp.CallToolResult, any, error) {
@@ -188,7 +188,7 @@ func (r *AssetShimRegistrar) listAssets(
 
 // handleLoadAsset implements load_my_asset. It downloads the latest version
 // zip, splits primary prompt content from bundled files, and returns both —
-// matching the Pulse shim's ``AssetDetails`` shape so cloud clients can rely
+// matching the Pulse shim's “AssetDetails“ shape so cloud clients can rely
 // on a single payload schema regardless of vault type.
 func (r *AssetShimRegistrar) handleLoadAsset(
 	ctx context.Context, _ *mcp.CallToolRequest, args LoadAssetArgs,

--- a/internal/vault/asset_shim.go
+++ b/internal/vault/asset_shim.go
@@ -200,10 +200,10 @@ func (r *AssetShimRegistrar) handleLoadAsset(
 
 	details, err := r.Repo.GetAssetDetails(ctx, slug)
 	if err != nil {
-		return errorContent(fmt.Sprintf("Asset not found: %s", slug))
+		return errorContent("Asset not found: " + slug)
 	}
 	if len(details.Versions) == 0 {
-		return errorContent(fmt.Sprintf("Asset has no versions: %s", slug))
+		return errorContent("Asset has no versions: " + slug)
 	}
 
 	latest := details.Versions[len(details.Versions)-1].Version
@@ -223,7 +223,7 @@ func (r *AssetShimRegistrar) handleLoadAsset(
 		// can decide whether to ``load_my_asset_file``, so we return the
 		// envelope with an empty primary_content rather than erroring.
 	} else if primaryContent == "" && len(bundled) == 0 {
-		return errorContent(fmt.Sprintf("Asset has no content: %s", slug))
+		return errorContent("Asset has no content: " + slug)
 	}
 
 	out := map[string]any{
@@ -257,10 +257,10 @@ func (r *AssetShimRegistrar) handleLoadAssetFile(
 
 	details, err := r.Repo.GetAssetDetails(ctx, slug)
 	if err != nil {
-		return errorContent(fmt.Sprintf("Asset not found: %s", slug))
+		return errorContent("Asset not found: " + slug)
 	}
 	if len(details.Versions) == 0 {
-		return errorContent(fmt.Sprintf("Asset has no versions: %s", slug))
+		return errorContent("Asset has no versions: " + slug)
 	}
 	latest := details.Versions[len(details.Versions)-1].Version
 

--- a/internal/vault/asset_shim.go
+++ b/internal/vault/asset_shim.go
@@ -296,10 +296,10 @@ func (r *AssetShimRegistrar) handleLoadAssetFile(
 }
 
 // fetchZip returns the asset's zip bytes, reusing the last fetch when the
-// caller asks for the same ``slug@version``. The cache holds at most one
+// caller asks for the same “slug@version“. The cache holds at most one
 // asset's zip at a time — different assets bust each other — so memory is
 // bounded by the largest asset accessed in a session, not by the catalog
-// size. The lock is held across the underlying ``GetAssetByVersion`` so a
+// size. The lock is held across the underlying “GetAssetByVersion“ so a
 // burst of concurrent requests for the same slug doesn't trigger a thundering
 // herd of git pulls / zip builds.
 func (r *AssetShimRegistrar) fetchZip(ctx context.Context, slug, version string) ([]byte, error) {

--- a/internal/vault/asset_shim.go
+++ b/internal/vault/asset_shim.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -27,6 +28,17 @@ import (
 // client's perspective. Diverging would mean prompt-tuning has to happen twice.
 type AssetShimRegistrar struct {
 	Repo assetReader
+
+	// zipCacheMu + zipCache memoize the latest zip bytes for a single
+	// ``slug@version``. The typical claude.ai workflow is
+	// ``load_my_asset`` followed by one or more ``load_my_asset_file``
+	// calls on the same asset; without a cache, GitVault re-walks the
+	// exploded repo and re-builds the zip from scratch on every call.
+	// One slot is enough — different assets bust each other, which keeps
+	// the bound on memory at the size of a single asset's zip.
+	zipCacheMu  sync.Mutex
+	zipCacheKey string
+	zipCache    []byte
 }
 
 // assetReader is the slice of the Vault interface needed to back the shim.
@@ -207,7 +219,7 @@ func (r *AssetShimRegistrar) handleLoadAsset(
 	}
 
 	latest := details.Versions[len(details.Versions)-1].Version
-	zipData, err := r.Repo.GetAssetByVersion(ctx, slug, latest)
+	zipData, err := r.fetchZip(ctx, slug, latest)
 	if err != nil {
 		return nil, nil, fmt.Errorf("download asset %s@%s: %w", slug, latest, err)
 	}
@@ -264,7 +276,7 @@ func (r *AssetShimRegistrar) handleLoadAssetFile(
 	}
 	latest := details.Versions[len(details.Versions)-1].Version
 
-	zipData, err := r.Repo.GetAssetByVersion(ctx, slug, latest)
+	zipData, err := r.fetchZip(ctx, slug, latest)
 	if err != nil {
 		return nil, nil, fmt.Errorf("download asset %s@%s: %w", slug, latest, err)
 	}
@@ -281,6 +293,29 @@ func (r *AssetShimRegistrar) handleLoadAssetFile(
 		return errorContent(fmt.Sprintf("File not found in asset %s: %s", slug, path))
 	}
 	return textContent(string(contentBytes))
+}
+
+// fetchZip returns the asset's zip bytes, reusing the last fetch when the
+// caller asks for the same ``slug@version``. The cache holds at most one
+// asset's zip at a time — different assets bust each other — so memory is
+// bounded by the largest asset accessed in a session, not by the catalog
+// size. The lock is held across the underlying ``GetAssetByVersion`` so a
+// burst of concurrent requests for the same slug doesn't trigger a thundering
+// herd of git pulls / zip builds.
+func (r *AssetShimRegistrar) fetchZip(ctx context.Context, slug, version string) ([]byte, error) {
+	key := slug + "@" + version
+	r.zipCacheMu.Lock()
+	defer r.zipCacheMu.Unlock()
+	if r.zipCacheKey == key && r.zipCache != nil {
+		return r.zipCache, nil
+	}
+	zipData, err := r.Repo.GetAssetByVersion(ctx, slug, version)
+	if err != nil {
+		return nil, err
+	}
+	r.zipCacheKey = key
+	r.zipCache = zipData
+	return zipData, nil
 }
 
 func filterByTypeKeys(in []AssetSummary, keys []string) []AssetSummary {
@@ -368,34 +403,33 @@ func splitZipContents(zipData []byte, primaryFile string) (string, []map[string]
 	if !utils.IsZipFile(zipData) {
 		return "", nil, errors.New("invalid zip data")
 	}
-	files, err := utils.ListZipFiles(zipData)
+	entries, err := utils.ListZipEntries(zipData)
 	if err != nil {
 		return "", nil, err
 	}
 	var primary string
-	bundled := make([]map[string]any, 0, len(files))
-	for _, name := range files {
-		if strings.HasSuffix(name, "/") {
+	bundled := make([]map[string]any, 0, len(entries))
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name, "/") {
 			continue
 		}
-		if name == "metadata.toml" {
+		if entry.Name == "metadata.toml" {
 			continue
 		}
-		if primaryFile != "" && name == primaryFile {
-			body, err := utils.ReadZipFile(zipData, name)
+		if primaryFile != "" && entry.Name == primaryFile {
+			body, err := utils.ReadZipFile(zipData, entry.Name)
 			if err != nil {
 				return "", nil, err
 			}
 			primary = string(body)
 			continue
 		}
-		body, err := utils.ReadZipFile(zipData, name)
-		if err != nil {
-			return "", nil, err
-		}
+		// Use the central-directory size rather than decompressing each
+		// bundled file. The MCP shim only needs ``size_bytes`` for the
+		// inventory; the body is fetched on demand via load_my_asset_file.
 		bundled = append(bundled, map[string]any{
-			"path":       name,
-			"size_bytes": len(body),
+			"path":       entry.Name,
+			"size_bytes": entry.Size,
 		})
 	}
 	return primary, bundled, nil

--- a/internal/vault/asset_shim.go
+++ b/internal/vault/asset_shim.go
@@ -1,0 +1,475 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/logger"
+	"github.com/sleuth-io/sx/internal/metadata"
+	"github.com/sleuth-io/sx/internal/utils"
+)
+
+// AssetShimRegistrar registers Pulse-style asset listing/loading MCP tools onto
+// an mcp.Server. PathVault and GitVault both opt in by returning a populated
+// registrar from GetMCPTools(); the cloud serve builder type-asserts on this
+// type and calls Register so claude.ai / chatgpt.com see real tools when they
+// connect via the relay.
+//
+// Tool descriptions and input schemas mirror sleuth/apps/mcp_gateway/asset_shim
+// so the local-vault MCP and the server-side shim behave identically from a
+// client's perspective. Diverging would mean prompt-tuning has to happen twice.
+type AssetShimRegistrar struct {
+	Repo assetReader
+}
+
+// assetReader is the slice of the Vault interface needed to back the shim.
+// Restricting to the methods we actually call keeps the registrar trivially
+// fakeable in tests and avoids dragging the full Vault contract into the shim.
+type assetReader interface {
+	ListAssets(ctx context.Context, opts ListAssetsOptions) (*ListAssetsResult, error)
+	GetAssetDetails(ctx context.Context, name string) (*AssetDetails, error)
+	GetAssetByVersion(ctx context.Context, name, version string) ([]byte, error)
+}
+
+const shimMaxListAssets = 100
+const shimMaxListDescriptionLen = 200
+
+// chatDefaultTypeKeys is the chat-usable subset returned when no explicit
+// ``type`` filter is provided. Hooks, MCP configs, and Claude Code plugins
+// are CLI-only lifecycle primitives and confuse a web-chat client, so the
+// caller has to opt in by name.
+var chatDefaultTypeKeys = []string{
+	asset.TypeSkill.Key,
+	asset.TypeRule.Key,
+	asset.TypeAgent.Key,
+	asset.TypeCommand.Key,
+}
+
+// ListAssetsArgs is the input for list_my_assets.
+type ListAssetsArgs struct {
+	Type   string `json:"type,omitempty" jsonschema:"Filter by asset type. Omit to list the chat-usable subset (skill, rule, agent, command). Pass 'hook' or 'mcp' only if the user specifically asks about those CLI-only types."`
+	Search string `json:"search,omitempty" jsonschema:"Case-insensitive substring filter over name + description."`
+}
+
+// ListByTypeArgs is the input for the per-type list aliases (list_my_skills, …).
+// They pin the type filter server-side so callers can omit it.
+type ListByTypeArgs struct {
+	Search string `json:"search,omitempty" jsonschema:"Case-insensitive substring filter over name + description."`
+}
+
+// LoadAssetArgs is the input for load_my_asset.
+type LoadAssetArgs struct {
+	Slug string `json:"slug" jsonschema:"Asset slug from list_my_assets."`
+}
+
+// LoadAssetFileArgs is the input for load_my_asset_file.
+type LoadAssetFileArgs struct {
+	Slug string `json:"slug" jsonschema:"Asset slug."`
+	Path string `json:"path" jsonschema:"File path as returned by load_my_asset's bundled_files."`
+}
+
+// Register wires the seven shim tools onto the supplied MCP server.
+func (r *AssetShimRegistrar) Register(server *mcp.Server) {
+	log := logger.Get()
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_my_assets",
+		Description: descListAssets,
+	}, r.handleListAssets)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_my_skills",
+		Description: perTypeDescription("skill", "skills"),
+	}, r.handleListByType(asset.TypeSkill.Key))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_my_rules",
+		Description: perTypeDescription("rule", "rules"),
+	}, r.handleListByType(asset.TypeRule.Key))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_my_agents",
+		Description: perTypeDescription("agent", "agents"),
+	}, r.handleListByType(asset.TypeAgent.Key))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_my_commands",
+		Description: perTypeDescription("command", "commands"),
+	}, r.handleListByType(asset.TypeCommand.Key))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "load_my_asset",
+		Description: descLoadAsset,
+	}, r.handleLoadAsset)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "load_my_asset_file",
+		Description: descLoadAssetFile,
+	}, r.handleLoadAssetFile)
+
+	log.Debug("cloud serve: registered asset shim MCP tools", "count", 7)
+}
+
+// handleListAssets implements the list_my_assets tool. The handler runs
+// the vault's ListAssets, applies the chat-default-type filter when no
+// explicit type was supplied, and trims long descriptions to keep the
+// response under client context caps.
+func (r *AssetShimRegistrar) handleListAssets(
+	ctx context.Context, _ *mcp.CallToolRequest, args ListAssetsArgs,
+) (*mcp.CallToolResult, any, error) {
+	typeFilter := strings.ToLower(strings.TrimSpace(args.Type))
+	search := strings.TrimSpace(args.Search)
+	return r.listAssets(ctx, typeFilter, search)
+}
+
+// handleListByType returns a tool handler that pins the type filter to a
+// single asset type. Used by list_my_skills / list_my_rules / etc. — those
+// aliases exist because chatgpt.com / claude.ai dispatchers match heavily on
+// tool *name*, and a user asking "what skills do I have" lands more reliably
+// on a tool literally named ``list_my_skills`` than on a generic
+// ``list_my_assets`` call with an inferred filter.
+func (r *AssetShimRegistrar) handleListByType(
+	typeKey string,
+) func(context.Context, *mcp.CallToolRequest, ListByTypeArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args ListByTypeArgs) (*mcp.CallToolResult, any, error) {
+		return r.listAssets(ctx, typeKey, strings.TrimSpace(args.Search))
+	}
+}
+
+func (r *AssetShimRegistrar) listAssets(
+	ctx context.Context, typeFilter, search string,
+) (*mcp.CallToolResult, any, error) {
+	opts := ListAssetsOptions{Type: typeFilter, Limit: shimMaxListAssets}
+	result, err := r.Repo.ListAssets(ctx, opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list assets: %w", err)
+	}
+
+	summaries := result.Assets
+	if typeFilter == "" {
+		// Vault's ListAssets only filters when a Type is supplied, so the
+		// chat-default subset narrowing has to happen here. Mirrors the
+		// shim's ``chat_default_types`` carve-out.
+		summaries = filterByTypeKeys(summaries, chatDefaultTypeKeys)
+	}
+	if search != "" {
+		summaries = filterBySearch(summaries, search)
+	}
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].Type.Key != summaries[j].Type.Key {
+			return summaries[i].Type.Key < summaries[j].Type.Key
+		}
+		return summaries[i].Name < summaries[j].Name
+	})
+
+	payload := make([]map[string]any, 0, len(summaries))
+	for _, s := range summaries {
+		entry := map[string]any{
+			"slug":        s.Name,
+			"name":        s.Name,
+			"type":        s.Type.Key,
+			"description": truncateDescription(s.Description, shimMaxListDescriptionLen),
+			"source":      "vault",
+		}
+		if s.LatestVersion != "" {
+			entry["version"] = s.LatestVersion
+		}
+		payload = append(payload, entry)
+	}
+	return jsonContent(map[string]any{"assets": payload})
+}
+
+// handleLoadAsset implements load_my_asset. It downloads the latest version
+// zip, splits primary prompt content from bundled files, and returns both —
+// matching the Pulse shim's ``AssetDetails`` shape so cloud clients can rely
+// on a single payload schema regardless of vault type.
+func (r *AssetShimRegistrar) handleLoadAsset(
+	ctx context.Context, _ *mcp.CallToolRequest, args LoadAssetArgs,
+) (*mcp.CallToolResult, any, error) {
+	slug := strings.TrimSpace(args.Slug)
+	if slug == "" {
+		return errorContent("Missing required argument: slug")
+	}
+
+	details, err := r.Repo.GetAssetDetails(ctx, slug)
+	if err != nil {
+		return errorContent(fmt.Sprintf("Asset not found: %s", slug))
+	}
+	if len(details.Versions) == 0 {
+		return errorContent(fmt.Sprintf("Asset has no versions: %s", slug))
+	}
+
+	latest := details.Versions[len(details.Versions)-1].Version
+	zipData, err := r.Repo.GetAssetByVersion(ctx, slug, latest)
+	if err != nil {
+		return nil, nil, fmt.Errorf("download asset %s@%s: %w", slug, latest, err)
+	}
+
+	primaryFile := primaryFileNameForType(details.Type, details.Metadata)
+	primaryContent, bundled, err := splitZipContents(zipData, primaryFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read asset zip %s@%s: %w", slug, latest, err)
+	}
+	if primaryContent == "" && primaryFile == "" {
+		// Config-only asset types (mcp, hook) deliberately have no prompt
+		// file. Clients still want the bundled inventory + metadata so they
+		// can decide whether to ``load_my_asset_file``, so we return the
+		// envelope with an empty primary_content rather than erroring.
+	} else if primaryContent == "" && len(bundled) == 0 {
+		return errorContent(fmt.Sprintf("Asset has no content: %s", slug))
+	}
+
+	out := map[string]any{
+		"slug":            slug,
+		"name":            details.Name,
+		"type":            details.Type.Key,
+		"description":     details.Description,
+		"primary_file":    primaryFile,
+		"primary_content": primaryContent,
+		"bundled_files":   bundled,
+		"version":         latest,
+	}
+	return jsonContent(out)
+}
+
+// handleLoadAssetFile implements load_my_asset_file. The handler downloads
+// the latest version's zip, finds the requested entry, and returns its
+// content. We refuse to serve the primary prompt file through this path so
+// there's a single canonical way to fetch it (load_my_asset).
+func (r *AssetShimRegistrar) handleLoadAssetFile(
+	ctx context.Context, _ *mcp.CallToolRequest, args LoadAssetFileArgs,
+) (*mcp.CallToolResult, any, error) {
+	slug := strings.TrimSpace(args.Slug)
+	path := strings.TrimSpace(args.Path)
+	if slug == "" {
+		return errorContent("Missing required argument: slug")
+	}
+	if path == "" {
+		return errorContent("Missing required argument: path")
+	}
+
+	details, err := r.Repo.GetAssetDetails(ctx, slug)
+	if err != nil {
+		return errorContent(fmt.Sprintf("Asset not found: %s", slug))
+	}
+	if len(details.Versions) == 0 {
+		return errorContent(fmt.Sprintf("Asset has no versions: %s", slug))
+	}
+	latest := details.Versions[len(details.Versions)-1].Version
+
+	zipData, err := r.Repo.GetAssetByVersion(ctx, slug, latest)
+	if err != nil {
+		return nil, nil, fmt.Errorf("download asset %s@%s: %w", slug, latest, err)
+	}
+
+	primaryFile := primaryFileNameForType(details.Type, details.Metadata)
+	if primaryFile != "" && path == primaryFile {
+		return errorContent(fmt.Sprintf(
+			"'%s' is the primary prompt file — use load_my_asset instead of load_my_asset_file", path,
+		))
+	}
+
+	contentBytes, err := utils.ReadZipFile(zipData, path)
+	if err != nil {
+		return errorContent(fmt.Sprintf("File not found in asset %s: %s", slug, path))
+	}
+	return textContent(string(contentBytes))
+}
+
+func filterByTypeKeys(in []AssetSummary, keys []string) []AssetSummary {
+	keep := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		keep[k] = struct{}{}
+	}
+	out := in[:0:0]
+	for _, s := range in {
+		if _, ok := keep[s.Type.Key]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func filterBySearch(in []AssetSummary, search string) []AssetSummary {
+	needle := strings.ToLower(search)
+	out := in[:0:0]
+	for _, s := range in {
+		if strings.Contains(strings.ToLower(s.Name), needle) ||
+			strings.Contains(strings.ToLower(s.Description), needle) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// truncateDescription mirrors the shim's tier-1 trim. Long descriptions
+// would otherwise blow up the catalog response on orgs with many assets.
+func truncateDescription(text string, limit int) string {
+	cleaned := strings.Join(strings.Fields(text), " ")
+	if len(cleaned) <= limit {
+		return cleaned
+	}
+	if limit < 1 {
+		return ""
+	}
+	trimmed := strings.TrimRight(cleaned[:limit-1], " ")
+	return trimmed + "…"
+}
+
+// primaryFileNameForType resolves the prompt-file name for an asset type.
+// Prefers the explicit metadata entry (Skill.PromptFile, Rule.PromptFile, …)
+// and falls back to the type's conventional default. Returns "" for asset
+// types that have no prompt file (mcp, hook, claude-code-plugin).
+func primaryFileNameForType(t asset.Type, meta *metadata.Metadata) string {
+	if meta != nil {
+		switch t.Key {
+		case asset.TypeSkill.Key:
+			if meta.Skill != nil && meta.Skill.PromptFile != "" {
+				return meta.Skill.PromptFile
+			}
+		case asset.TypeRule.Key:
+			if meta.Rule != nil && meta.Rule.PromptFile != "" {
+				return meta.Rule.PromptFile
+			}
+		case asset.TypeAgent.Key:
+			if meta.Agent != nil && meta.Agent.PromptFile != "" {
+				return meta.Agent.PromptFile
+			}
+		case asset.TypeCommand.Key:
+			if meta.Command != nil && meta.Command.PromptFile != "" {
+				return meta.Command.PromptFile
+			}
+		}
+	}
+	switch t.Key {
+	case asset.TypeSkill.Key:
+		return "SKILL.md"
+	case asset.TypeRule.Key:
+		return "RULE.md"
+	case asset.TypeAgent.Key:
+		return "AGENT.md"
+	case asset.TypeCommand.Key:
+		return "COMMAND.md"
+	}
+	return ""
+}
+
+// splitZipContents extracts the primary file's content and inventories the
+// rest. metadata.toml is kept out of the bundled-files list because it's an
+// implementation detail of the vault layout, not a user-facing resource.
+func splitZipContents(zipData []byte, primaryFile string) (string, []map[string]any, error) {
+	if !utils.IsZipFile(zipData) {
+		return "", nil, errors.New("invalid zip data")
+	}
+	files, err := utils.ListZipFiles(zipData)
+	if err != nil {
+		return "", nil, err
+	}
+	var primary string
+	bundled := make([]map[string]any, 0, len(files))
+	for _, name := range files {
+		if strings.HasSuffix(name, "/") {
+			continue
+		}
+		if name == "metadata.toml" {
+			continue
+		}
+		if primaryFile != "" && name == primaryFile {
+			body, err := utils.ReadZipFile(zipData, name)
+			if err != nil {
+				return "", nil, err
+			}
+			primary = string(body)
+			continue
+		}
+		body, err := utils.ReadZipFile(zipData, name)
+		if err != nil {
+			return "", nil, err
+		}
+		bundled = append(bundled, map[string]any{
+			"path":       name,
+			"size_bytes": len(body),
+		})
+	}
+	return primary, bundled, nil
+}
+
+func jsonContent(payload any) (*mcp.CallToolResult, any, error) {
+	body, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return nil, nil, err
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(body)}},
+	}, nil, nil
+}
+
+func textContent(text string) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: text}},
+	}, nil, nil
+}
+
+func errorContent(message string) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: message}},
+		IsError: true,
+	}, nil, nil
+}
+
+// perTypeDescription is the description text used by the per-type list aliases.
+// Kept in lockstep with sleuth/apps/mcp_gateway/asset_shim/tool_defs.py so the
+// model sees the same wording regardless of which side serves the request.
+func perTypeDescription(typeLabel, typePlural string) string {
+	return fmt.Sprintf(
+		"Lists the user's %s from their skills.new vault. Thin alias for "+
+			"list_my_assets with type=%q preset — use this when the user "+
+			"specifically asks about their %s.",
+		typePlural, typeLabel, typePlural,
+	)
+}
+
+const descListAssets = "Lists the user's own skills, rules, agents, and commands from their " +
+	"personal skills.new vault. This is a SEPARATE catalog from any skills you " +
+	"have loaded natively — the user has their own collection in skills.new " +
+	"that you don't see unless you call this tool. " +
+	"ALWAYS call this tool whenever the user: " +
+	"(a) asks 'what skills do I have', 'what skills are available', 'tell me my " +
+	"skills', 'list my skills', or any paraphrase; " +
+	"(b) asks what tools, agents, commands, rules, or capabilities they have or " +
+	"have access to; " +
+	"(c) asks 'what can you do for me' or 'what do I have'; " +
+	"(d) describes a task that might match a custom skill (domain-specific work, " +
+	"internal workflows, project conventions, unusual topics) — even if you think " +
+	"you can handle it without one; " +
+	"(e) starts a new conversation — call this once at session start so you know " +
+	"what's available before responding. " +
+	"When answering 'what skills do I have' questions, combine the results from " +
+	"this tool with any native skills and report the UNION of both sources. Never " +
+	"answer from your native skill list alone. " +
+	"By default the response omits hooks and MCP configs because those are CLI-" +
+	"only lifecycle primitives (Claude Code / sx) and pointers to OTHER MCP " +
+	"servers — neither is usable from this chat client. Pass type=hook or " +
+	"type=mcp to list those explicitly if the user asks about them. " +
+	"Returns slug, name, type, short description, source, and version per asset " +
+	"— not the body. Follow up with load_my_asset to fetch a specific asset's " +
+	"content once a topic matches."
+
+const descLoadAsset = "Fetches the full body of one of the user's skills.new assets — SKILL.md, " +
+	"RULE.md, AGENT.md, COMMAND.md, or the config payload for MCP/hook assets — " +
+	"plus an inventory of bundled files (paths + sizes only, no content). " +
+	"Call this whenever the user's task matches an entry returned by " +
+	"list_my_assets, OR when the user explicitly names a skill they have. Prefer " +
+	"the user's own skill content over your own knowledge when they overlap. " +
+	"Follow up with load_my_asset_file to pull any bundled resource on demand."
+
+const descLoadAssetFile = "Fetches the content of one bundled file for a user-authored asset. Call after " +
+	"load_my_asset has listed a bundled file in its bundled_files inventory " +
+	"and the task needs that file (reference doc, script, template, schema, etc.)."

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -52,7 +53,17 @@ type GitVault struct {
 	httpHandler *HTTPSourceHandler
 	pathHandler *PathSourceHandler
 	gitHandler  *GitSourceHandler
-	hasSynced   bool // Track if we've synced in this CLI execution
+
+	// hasSynced + syncMu guard cloneOrUpdate against concurrent MCP tool
+	// goroutines (one per inbound JSON-RPC frame in cloud serve). A plain
+	// bool was a data race that ``go test -race`` would catch and that
+	// could manifest as duplicate ``git pull`` invocations in production.
+	// Using a mutex + bool (instead of ``sync.Once``) preserves the
+	// original "retry on next call after a cancelled clone" semantics —
+	// ``sync.Once`` would permanently latch the cancellation error onto
+	// every subsequent caller.
+	syncMu    sync.Mutex
+	hasSynced bool
 }
 
 // NewGitVault creates a new Git repository
@@ -272,10 +283,14 @@ func (g *GitVault) VerifyIntegrity(data []byte, hashes map[string]string, size i
 	return nil
 }
 
-// cloneOrUpdate clones the repository if it doesn't exist, or pulls updates if it does
-// Only performs the operation once per CLI execution to avoid redundant network calls
+// cloneOrUpdate clones the repository if it doesn't exist, or pulls updates if it does.
+// Only performs the operation once per CLI execution to avoid redundant network calls.
+// The mutex is held for the duration of the clone/pull so concurrent MCP tool
+// goroutines wait for the first caller's network I/O instead of racing into a
+// duplicate clone.
 func (g *GitVault) cloneOrUpdate(ctx context.Context) error {
-	// Skip if we've already synced in this execution
+	g.syncMu.Lock()
+	defer g.syncMu.Unlock()
 	if g.hasSynced {
 		return nil
 	}
@@ -298,7 +313,6 @@ func (g *GitVault) cloneOrUpdate(ctx context.Context) error {
 		}
 	}
 
-	// Mark as synced for this execution
 	g.hasSynced = true
 	return nil
 }

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -1088,9 +1088,12 @@ func (g *GitVault) GetAssetDetails(ctx context.Context, name string) (*AssetDeta
 	return details, nil
 }
 
-// GetMCPTools returns no additional MCP tools for GitVault
+// GetMCPTools returns the asset-shim registrar so callers (notably the cloud
+// serve MCP builder) can publish list_my_assets / load_my_asset / … on top of
+// the git-backed vault. Without this, claude.ai connects to the relay and
+// reports "no tools available" because GitVault has no native MCP surface.
 func (g *GitVault) GetMCPTools() any {
-	return nil
+	return &AssetShimRegistrar{Repo: g}
 }
 
 // GetBootstrapOptions returns no bootstrap options for GitVault

--- a/internal/vault/pathrepo.go
+++ b/internal/vault/pathrepo.go
@@ -480,9 +480,12 @@ func (p *PathVault) GetAssetDetails(ctx context.Context, name string) (*AssetDet
 	return details, nil
 }
 
-// GetMCPTools returns no additional MCP tools for PathVault
+// GetMCPTools returns the asset-shim registrar so callers (notably the cloud
+// serve MCP builder) can publish list_my_assets / load_my_asset / … on top of
+// the path-backed vault. Without this, claude.ai connects to the relay and
+// reports "no tools available" because PathVault has no native MCP surface.
 func (p *PathVault) GetMCPTools() any {
-	return nil
+	return &AssetShimRegistrar{Repo: p}
 }
 
 // GetBootstrapOptions returns no bootstrap options for PathVault


### PR DESCRIPTION
This adds a cloud connect option that creates a light-weight relay in app.skills.new.

It also adds an `sx serve` command that will connect via websocket to the relay and allow the local process to serve the git and local vault assets to claude.ai and chatgpt.com.