### PR TITLE
SK-469: Soft-skip hook installs when target client doesn't support the event

### DIFF
--- a/internal/clients/claude_code/client.go
+++ b/internal/clients/claude_code/client.go
@@ -116,15 +116,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			err = fmt.Errorf("unsupported asset type: %s", bundle.Metadata.Asset.Type.Key)
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/claude_code/handlers/hook.go
+++ b/internal/clients/claude_code/handlers/hook.go
@@ -185,7 +185,7 @@ func (h *HookHandler) updateSettings(targetBase string) error {
 
 	hookEvent, supported := h.mapEventToClaudeCode()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Claude Code", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Claude Code", h.metadata.Hook.Event)
 	}
 
 	hookConfig := h.buildHookConfig(targetBase)

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -2,10 +2,13 @@ package clients
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/bootstrap"
+	"github.com/sleuth-io/sx/internal/handlers/hook"
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/metadata"
 )
@@ -212,6 +215,30 @@ const (
 	StatusFailed  ResultStatus = "failed"
 	StatusSkipped ResultStatus = "skipped"
 )
+
+// TranslateInstallError converts an error returned by a per-asset install
+// handler into the AssetResult fields a client should report.
+//
+// Errors that wrap hook.ErrUnsupportedEvent are translated to StatusSkipped:
+// the hook asset is well-formed but the target client has no lifecycle
+// event to fire it from (e.g. Gemini does not implement `pre-compact`).
+// This is not a user error and should not contribute to the install
+// command's exit status.
+//
+// All other non-nil errors are reported as StatusFailed and the error is
+// preserved on the AssetResult so callers can inspect or surface it.
+//
+// successMessage is used as result.Message when err is nil (for example,
+// the install path or "Installed to /home/...").
+func TranslateInstallError(err error, successMessage string) (ResultStatus, string, error) {
+	if err == nil {
+		return StatusSuccess, successMessage, nil
+	}
+	if errors.Is(err, hook.ErrUnsupportedEvent) {
+		return StatusSkipped, err.Error(), nil
+	}
+	return StatusFailed, fmt.Sprintf("Installation failed: %v", err), err
+}
 
 // VerifyResult represents the result of verifying a single asset's installation
 type VerifyResult struct {

--- a/internal/clients/cline/client.go
+++ b/internal/clients/cline/client.go
@@ -139,15 +139,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/cline/handlers/hook.go
+++ b/internal/clients/cline/handlers/hook.go
@@ -145,7 +145,7 @@ func (h *HookHandler) createHookScript(targetBase string) error {
 
 	clineEvent, supported := h.mapEventToCline()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Cline", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Cline", h.metadata.Hook.Event)
 	}
 
 	hookPath := filepath.Join(hooksDir, clineEvent)

--- a/internal/clients/cursor/client.go
+++ b/internal/clients/cursor/client.go
@@ -121,15 +121,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/cursor/handlers/hook.go
+++ b/internal/clients/cursor/handlers/hook.go
@@ -105,7 +105,7 @@ func (h *HookHandler) updateHooksJSON(targetBase string) error {
 
 	cursorEvent, supported := h.mapEventToCursor()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Cursor", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Cursor", h.metadata.Hook.Event)
 	}
 
 	entry := h.buildHookEntry(targetBase)

--- a/internal/clients/gemini/client.go
+++ b/internal/clients/gemini/client.go
@@ -137,15 +137,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = installedPath
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, installedPath)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/gemini/handlers/hook.go
+++ b/internal/clients/gemini/handlers/hook.go
@@ -121,7 +121,7 @@ func (h *HookHandler) mapEventToGemini() (string, bool) {
 func (h *HookHandler) updateSettings(geminiDir string) error {
 	hookEvent, supported := h.mapEventToGemini()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Gemini", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Gemini", h.metadata.Hook.Event)
 	}
 
 	installDir := filepath.Join(geminiDir, "hooks", h.metadata.Asset.Name)

--- a/internal/clients/install_error_test.go
+++ b/internal/clients/install_error_test.go
@@ -1,0 +1,65 @@
+package clients
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/handlers/hook"
+)
+
+func TestTranslateInstallError(t *testing.T) {
+	t.Run("nil error becomes success", func(t *testing.T) {
+		status, msg, err := TranslateInstallError(nil, "/path/to/install")
+		if status != StatusSuccess {
+			t.Errorf("status = %q, want %q", status, StatusSuccess)
+		}
+		if msg != "/path/to/install" {
+			t.Errorf("msg = %q, want %q", msg, "/path/to/install")
+		}
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+	})
+
+	t.Run("unsupported event becomes skipped", func(t *testing.T) {
+		input := hook.UnsupportedEventError("Gemini", "pre-compact")
+		status, msg, err := TranslateInstallError(input, "ignored")
+		if status != StatusSkipped {
+			t.Errorf("status = %q, want %q", status, StatusSkipped)
+		}
+		if !strings.Contains(msg, "pre-compact") {
+			t.Errorf("msg = %q, want it to mention the event", msg)
+		}
+		if err != nil {
+			t.Errorf("err = %v, want nil (soft skip should not propagate)", err)
+		}
+	})
+
+	t.Run("wrapped unsupported event becomes skipped", func(t *testing.T) {
+		// Simulate a handler that wraps the sentinel with additional context.
+		wrapped := errors.Join(hook.UnsupportedEventError("Gemini", "pre-compact"),
+			errors.New("during settings.json update"))
+		status, _, err := TranslateInstallError(wrapped, "ignored")
+		if status != StatusSkipped {
+			t.Errorf("status = %q, want %q", status, StatusSkipped)
+		}
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+	})
+
+	t.Run("other errors become failure", func(t *testing.T) {
+		input := errors.New("disk full")
+		status, msg, err := TranslateInstallError(input, "ignored")
+		if status != StatusFailed {
+			t.Errorf("status = %q, want %q", status, StatusFailed)
+		}
+		if !strings.Contains(msg, "disk full") {
+			t.Errorf("msg = %q, want it to include the error detail", msg)
+		}
+		if err == nil {
+			t.Errorf("err = nil, want the original error preserved")
+		}
+	})
+}

--- a/internal/clients/kiro/client.go
+++ b/internal/clients/kiro/client.go
@@ -126,15 +126,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/kiro/handlers/hook.go
+++ b/internal/clients/kiro/handlers/hook.go
@@ -148,7 +148,7 @@ func (h *HookHandler) writeHookFile(targetBase string) error {
 
 	kiroEvent, supported := h.mapEventToKiro()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Kiro", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Kiro", h.metadata.Hook.Event)
 	}
 
 	// Resolve the command to execute

--- a/internal/handlers/hook/hook.go
+++ b/internal/handlers/hook/hook.go
@@ -58,6 +58,25 @@ func CacheZipFiles(zipData []byte) []string {
 	return files
 }
 
+// ErrUnsupportedEvent is returned when a hook asset's canonical event is not
+// supported by the target client. Callers (typically a client's InstallAssets
+// implementation) use errors.Is to distinguish this from real install
+// failures and surface the result as StatusSkipped rather than StatusFailed.
+//
+// This is not a user error: the asset is well-formed and the user's
+// configuration is correct; the target client simply has no lifecycle event
+// to fire it from. For example, Gemini Code Assist does not implement
+// `pre-compact` or `subagent-start`, so log hooks for those events are
+// soft-skipped on Gemini and installed as usual on Claude Code.
+var ErrUnsupportedEvent = errors.New("unsupported hook event")
+
+// UnsupportedEventError builds an error that wraps ErrUnsupportedEvent with
+// a human-readable message naming the client and event. Callers detect it
+// via errors.Is(err, ErrUnsupportedEvent).
+func UnsupportedEventError(clientName, event string) error {
+	return fmt.Errorf("%w %q on %s", ErrUnsupportedEvent, event, clientName)
+}
+
 // MapEvent maps a canonical hook event name to a client-native event name.
 // It first checks the client-specific override map, then falls back to the
 // standard eventMap. Returns the native event name and whether the event

--- a/internal/handlers/hook/hook_test.go
+++ b/internal/handlers/hook/hook_test.go
@@ -3,6 +3,8 @@ package hook
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/sleuth-io/sx/internal/asset"
@@ -154,6 +156,33 @@ func TestMapEvent(t *testing.T) {
 		native, ok := MapEvent("post-tool-use", eventMap, overrides)
 		if !ok || native != "PostToolUse" {
 			t.Errorf("got (%q, %v), want (PostToolUse, true)", native, ok)
+		}
+	})
+}
+
+func TestUnsupportedEventError(t *testing.T) {
+	t.Run("wraps sentinel", func(t *testing.T) {
+		err := UnsupportedEventError("Gemini", "pre-compact")
+		if !errors.Is(err, ErrUnsupportedEvent) {
+			t.Errorf("errors.Is(err, ErrUnsupportedEvent) = false, want true")
+		}
+	})
+
+	t.Run("message names client and event", func(t *testing.T) {
+		err := UnsupportedEventError("Gemini", "pre-compact")
+		msg := err.Error()
+		if !strings.Contains(msg, "Gemini") {
+			t.Errorf("error message %q does not contain client name 'Gemini'", msg)
+		}
+		if !strings.Contains(msg, "pre-compact") {
+			t.Errorf("error message %q does not contain event name 'pre-compact'", msg)
+		}
+	})
+
+	t.Run("distinct from unrelated error", func(t *testing.T) {
+		other := errors.New("some other error")
+		if errors.Is(other, ErrUnsupportedEvent) {
+			t.Errorf("unrelated error matched ErrUnsupportedEvent sentinel")
 		}
 	})
 }


### PR DESCRIPTION
Closes #103.

## Problem

When `sx install` fans an asset out to all enabled clients, hook assets whose canonical event isn't supported by a given client surface as hard install failures, even though there is nothing the user can do about it and the install on every other client succeeds.

Concrete example with `claude-code`, `cursor`, `gemini` all enabled and the `log-pre-compact` hook (canonical event `pre-compact`) installed:

```
✓ log-pre-compact → Claude Code (Installed to /Users/me/.claude)
✓ log-pre-compact → Cursor (Installed to /Users/me/.cursor)
✗ log-pre-compact → Gemini Code Assist: failed to update settings: hook event "pre-compact" not supported for Gemini
```

The hook is correct, the user's configuration is correct, and Gemini simply has no `pre-compact` lifecycle event to fire it from. The only "fix" today is `sx clients disable gemini`, which would lose Gemini for the 20+ other assets that *do* belong there.

This makes every multi-client `sx install` exit non-zero in any wrapper that treats sx's exit status as authoritative.

## Change

When a hook handler can't map the canonical event to a client-native event, return a sentinel error (`hook.ErrUnsupportedEvent`) instead of an ad-hoc `fmt.Errorf`. The install fan-out detects the sentinel via `errors.Is` and produces a `StatusSkipped` result instead of `StatusFailed`. Existing `StatusSkipped` rendering already prints a `⊘` line and excludes the entry from `installResult.Failed` and `HasAnyErrors`, so:

```
✓ log-pre-compact → Claude Code (Installed to /Users/me/.claude)
✓ log-pre-compact → Cursor (Installed to /Users/me/.cursor)
⊘ log-pre-compact → Gemini Code Assist: unsupported hook event "pre-compact" on Gemini
```

…and the overall command exits 0.

## Implementation

- `internal/handlers/hook/hook.go` — `ErrUnsupportedEvent` sentinel and `UnsupportedEventError(client, event)` helper.
- All five client hook handlers (`claude_code`, `cline`, `cursor`, `gemini`, `kiro`) return the wrapped sentinel instead of an ad-hoc error.
- `internal/clients/client.go` — `TranslateInstallError(err, msg)` reusable helper. Each client's `InstallAssets` collapses its inline result-building branch into one call.
- Tests cover the sentinel (`TestUnsupportedEventError`) and the translation helper (`TestTranslateInstallError`, four cases: nil / sentinel / wrapped sentinel / unrelated error).

`go test ./...` and `go vet ./...` clean.

## Follow-ups (out of scope, filed separately)

This change deliberately does **not** address several adjacent concerns. Each is independent and tracked under its own issue + PR:

- **Issue #104 / SK-470 — PR #110:** Reject hook events unknown to all clients at `sx add` / publish time. Once unsupported events soft-skip everywhere, a typo like `event = "subagent-strat"` matches no client and silently no-ops. PR #110 closes that gap by running `metadata.ValidateZip` (which checks `validHookEvents`) at `sx add` time.
- **Issue #105 / SK-471 — PR #109:** Aggregate unsupported-event hook skips into one summary line per client (`Gemini Code Assist: skipped 3 hooks (events not supported: pre-compact, subagent-start, subagent-stop)`) instead of one ⊘ line per (asset, client) pair.
- **Issue #106 / SK-472 — PR #108:** `--strict` flag (also `SX_STRICT=1`) on `sx install` that escalates unsupported-event soft skips back into hard failures, for CI / audit consumers that want today's behavior.
- **Issue #107 / SK-473 — PR #111:** Optional `[asset].clients = [...]` metadata field for authors who want to declare assets as explicitly client-specific. Independent of soft skip — handles the *"I don't belong here"* case (silent), where soft skip handles the *"I belong here but the client can't fire me"* case (visible).

PRs #110 and #111 are independent of this one. PRs #108 and #109 stack on this branch and rebase cleanly onto main once it lands; they each carry an identical small follow-up (preserve the sentinel on `StatusSkipped` so the strict and summary paths can introspect it).

## Why this is the right default

A canonical event a client cannot fire is an architectural mismatch, not a user error. The current behavior makes every multi-client user choose between "accept ✗ in every install" and "manually disable clients to suppress them." Soft skip aligns the exit code with what's actually broken.