### PR TITLE
SK-472: Add `--strict` flag to escalate soft skips into errors

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -223,10 +223,14 @@ const (
 // the hook asset is well-formed but the target client has no lifecycle
 // event to fire it from (e.g. Gemini does not implement `pre-compact`).
 // This is not a user error and should not contribute to the install
-// command's exit status.
+// command's exit status (HasAnyErrors only inspects Status, not Error).
 //
-// All other non-nil errors are reported as StatusFailed and the error is
-// preserved on the AssetResult so callers can inspect or surface it.
+// The original error is preserved on the AssetResult even when the status
+// is StatusSkipped so callers can introspect *why* the asset was skipped
+// (for example, a `--strict` mode that escalates unsupported-event skips
+// back into hard failures).
+//
+// All other non-nil errors are reported as StatusFailed.
 //
 // successMessage is used as result.Message when err is nil (for example,
 // the install path or "Installed to /home/...").
@@ -235,7 +239,7 @@ func TranslateInstallError(err error, successMessage string) (ResultStatus, stri
 		return StatusSuccess, successMessage, nil
 	}
 	if errors.Is(err, hook.ErrUnsupportedEvent) {
-		return StatusSkipped, err.Error(), nil
+		return StatusSkipped, err.Error(), err
 	}
 	return StatusFailed, fmt.Sprintf("Installation failed: %v", err), err
 }

--- a/internal/clients/install_error_test.go
+++ b/internal/clients/install_error_test.go
@@ -22,7 +22,7 @@ func TestTranslateInstallError(t *testing.T) {
 		}
 	})
 
-	t.Run("unsupported event becomes skipped", func(t *testing.T) {
+	t.Run("unsupported event becomes skipped with error preserved", func(t *testing.T) {
 		input := hook.UnsupportedEventError("Gemini", "pre-compact")
 		status, msg, err := TranslateInstallError(input, "ignored")
 		if status != StatusSkipped {
@@ -31,8 +31,11 @@ func TestTranslateInstallError(t *testing.T) {
 		if !strings.Contains(msg, "pre-compact") {
 			t.Errorf("msg = %q, want it to mention the event", msg)
 		}
-		if err != nil {
-			t.Errorf("err = %v, want nil (soft skip should not propagate)", err)
+		// Preserve the error so callers (e.g. --strict mode) can introspect
+		// *why* the asset was skipped, while leaving Status as Skipped so it
+		// doesn't count toward HasAnyErrors / installResult.Failed.
+		if !errors.Is(err, hook.ErrUnsupportedEvent) {
+			t.Errorf("err = %v, want sentinel preserved on result", err)
 		}
 	})
 
@@ -44,8 +47,8 @@ func TestTranslateInstallError(t *testing.T) {
 		if status != StatusSkipped {
 			t.Errorf("status = %q, want %q", status, StatusSkipped)
 		}
-		if err != nil {
-			t.Errorf("err = %v, want nil", err)
+		if !errors.Is(err, hook.ErrUnsupportedEvent) {
+			t.Errorf("err = %v, want sentinel preserved on result", err)
 		}
 	})
 

--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -244,7 +244,7 @@ func addFromZipSource(ctx context.Context, cmd *cobra.Command, out *outputHelper
 	// Handle install: auto-run if --yes, prompt if interactive, skip if --no-install
 	if opts.Yes && !opts.NoInstall {
 		out.println()
-		if err := runInstall(cmd, nil, false, "", false, "", "", false); err != nil {
+		if err := runInstall(cmd, nil, false, "", false, "", "", false, false); err != nil {
 			out.printfErr("Install failed: %v\n", err)
 		}
 	} else if !opts.NoInstall && !opts.isNonInteractive() {
@@ -372,7 +372,7 @@ func promptRunInstall(cmd *cobra.Command, ctx context.Context, out *outputHelper
 	}
 
 	out.println()
-	if err := runInstall(cmd, nil, false, "", false, "", "", false); err != nil {
+	if err := runInstall(cmd, nil, false, "", false, "", "", false, false); err != nil {
 		out.printfErr("Install failed: %v\n", err)
 	}
 }

--- a/internal/commands/add_config.go
+++ b/internal/commands/add_config.go
@@ -178,7 +178,7 @@ func handleAssetRemoval(ctx context.Context, cmd *cobra.Command, out *outputHelp
 
 		if confirmed {
 			out.println()
-			if err := runInstall(cmd, nil, false, "", false, "", "", false); err != nil {
+			if err := runInstall(cmd, nil, false, "", false, "", "", false, false); err != nil {
 				out.printfErr("Install failed: %v\n", err)
 			}
 		} else {

--- a/internal/commands/add_remote_mcp.go
+++ b/internal/commands/add_remote_mcp.go
@@ -110,7 +110,7 @@ func addRemoteMCP(ctx context.Context, cmd *cobra.Command, out *outputHelper, st
 	// Handle install: auto-run if --yes, prompt if interactive, skip if --no-install
 	if opts.Yes && !opts.NoInstall {
 		out.println()
-		if err := runInstall(cmd, nil, false, "", false, "", "", false); err != nil {
+		if err := runInstall(cmd, nil, false, "", false, "", "", false, false); err != nil {
 			out.printfErr("Install failed: %v\n", err)
 		}
 	} else if !opts.NoInstall && !opts.isNonInteractive() {

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -13,7 +13,7 @@ import (
 // lives in the cache directory, not the project.
 func RunDefaultCommand(cmd *cobra.Command, args []string) error {
 	if _, err := config.Load(); err == nil {
-		return runInstall(cmd, args, false, "", false, "", "", false)
+		return runInstall(cmd, args, false, "", false, "", "", false, false)
 	}
 	return cmd.Help()
 }

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/sleuth-io/sx/internal/clients"
 	"github.com/sleuth-io/sx/internal/config"
 	"github.com/sleuth-io/sx/internal/gitutil"
+	"github.com/sleuth-io/sx/internal/handlers/hook"
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/metadata"
@@ -33,6 +35,7 @@ func NewInstallCommand() *cobra.Command {
 	var targetDir string
 	var clientsFlag string
 	var dryRun bool
+	var strict bool
 
 	// Installation targeting flags — when any of these is set together
 	// with a positional asset name, sx install enters "set installation
@@ -89,7 +92,7 @@ equivalent of 'pip freeze' against the vault's manifest.`,
 				}
 				return runInstallSetTarget(cmd, args[0], targetFlags)
 			}
-			return runInstall(cmd, args, hookMode, clientID, fixMode, targetDir, clientsFlag, dryRun)
+			return runInstall(cmd, args, hookMode, clientID, fixMode, targetDir, clientsFlag, dryRun, strict)
 		},
 	}
 
@@ -99,6 +102,7 @@ equivalent of 'pip freeze' against the vault's manifest.`,
 	cmd.Flags().StringVar(&targetDir, "target", "", "Install as if running from this directory")
 	cmd.Flags().StringVar(&clientsFlag, "clients", "", "Install to multiple clients (e.g., 'claude-code,cursor')")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show the resolved asset list for the current context and exit without downloading or installing")
+	cmd.Flags().BoolVar(&strict, "strict", false, "Treat hook installs that soft-skip (event not supported by client) as failures (also via SX_STRICT=1)")
 
 	cmd.Flags().BoolVar(&orgFlag, "org", false, "Set this asset to install org-wide")
 	cmd.Flags().StringVar(&repoFlag, "repo", "", "Install this asset for a specific repository URL")
@@ -280,9 +284,14 @@ func describeAssetScopeForDryRun(a *lockfile.Asset) string {
 }
 
 // runInstall executes the install command
-func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID string, repairMode bool, targetDir string, clientsFlag string, dryRun bool) error {
+func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID string, repairMode bool, targetDir string, clientsFlag string, dryRun bool, strict bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
+
+	// SX_STRICT=1 is equivalent to --strict; --strict wins if both are set.
+	if !strict && os.Getenv("SX_STRICT") == "1" {
+		strict = true
+	}
 
 	log := logger.Get()
 	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
@@ -400,7 +409,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 	}
 
 	// Install assets to their appropriate locations
-	installResult := installAssets(ctx, downloadResult.Downloads, env.GitContext, env.CurrentScope, env.Clients, styledOut)
+	installResult := installAssets(ctx, downloadResult.Downloads, env.GitContext, env.CurrentScope, env.Clients, styledOut, strict)
 
 	// Save new installation state (only for successfully installed assets)
 	saveInstallationState(tracker, sortedAssets, assetsToInstall, downloadResult.Downloads, installResult, env.CurrentScope, targetClientIDs, out)
@@ -600,8 +609,10 @@ func repairTracker(ctx context.Context, tracker *assets.Tracker, sortedAssets []
 	styledOut.Newline()
 }
 
-// installAssets installs assets to all detected clients using the orchestrator
-func installAssets(ctx context.Context, successfulDownloads []*assets.AssetWithMetadata, gitContext *gitutil.GitContext, currentScope *scope.Scope, targetClients []clients.Client, styledOut *ui.Output) *assets.InstallResult {
+// installAssets installs assets to all detected clients using the orchestrator.
+// When strict is true, hook installs that soft-skip due to unsupported events
+// are escalated to hard failures (used by --strict / SX_STRICT=1).
+func installAssets(ctx context.Context, successfulDownloads []*assets.AssetWithMetadata, gitContext *gitutil.GitContext, currentScope *scope.Scope, targetClients []clients.Client, styledOut *ui.Output, strict bool) *assets.InstallResult {
 	styledOut.Header("Installing assets...")
 
 	// Install each asset to its proper scope
@@ -636,7 +647,7 @@ func installAssets(ctx context.Context, successfulDownloads []*assets.AssetWithM
 	}
 
 	// Process and report results
-	return processInstallationResults(allResults, styledOut)
+	return processInstallationResults(allResults, styledOut, strict)
 }
 
 // buildInstallScope creates the installation scope from current context
@@ -706,8 +717,10 @@ func runMultiClientInstallation(ctx context.Context, bundles []*clients.AssetBun
 	return orchestrator.InstallToClients(ctx, bundles, installScope, clients.InstallOptions{}, targetClients)
 }
 
-// processInstallationResults processes results from all clients and builds the final result
-func processInstallationResults(allResults map[string]clients.InstallResponse, styledOut *ui.Output) *assets.InstallResult {
+// processInstallationResults processes results from all clients and builds the final result.
+// When strict is true, StatusSkipped results that wrap hook.ErrUnsupportedEvent are
+// rendered and counted as failures rather than as informational soft skips.
+func processInstallationResults(allResults map[string]clients.InstallResponse, styledOut *ui.Output, strict bool) *assets.InstallResult {
 	installResult := &assets.InstallResult{
 		Installed: []string{},
 		Failed:    []string{},
@@ -715,12 +728,25 @@ func processInstallationResults(allResults map[string]clients.InstallResponse, s
 	}
 
 	successfullyInstalled := make(map[string]bool)
+	strictSawUnsupported := false
 
 	for clientID, resp := range allResults {
 		client, _ := clients.Global().Get(clientID)
 
 		for _, result := range resp.Results {
-			switch result.Status {
+			status := result.Status
+			// In strict mode, escalate unsupported-event soft skips to failures
+			// so CI / audit consumers see the same exit code they had before
+			// soft skip was introduced. Other StatusSkipped paths (no
+			// compatible assets, unsupported asset type) are unaffected —
+			// only hook events that *some* client supports but this one
+			// doesn't carry the sentinel.
+			if strict && status == clients.StatusSkipped && errors.Is(result.Error, hook.ErrUnsupportedEvent) {
+				status = clients.StatusFailed
+				strictSawUnsupported = true
+			}
+
+			switch status {
 			case clients.StatusSuccess:
 				msg := result.AssetName + " → " + client.DisplayName()
 				if result.Message != "" {
@@ -729,9 +755,15 @@ func processInstallationResults(allResults map[string]clients.InstallResponse, s
 				styledOut.SuccessItem(msg)
 				successfullyInstalled[result.AssetName] = true
 			case clients.StatusFailed:
-				styledOut.ErrorItem(result.AssetName + " → " + client.DisplayName() + ": " + result.Error.Error())
+				detail := result.Message
+				if result.Error != nil {
+					detail = result.Error.Error()
+				}
+				styledOut.ErrorItem(result.AssetName + " → " + client.DisplayName() + ": " + detail)
 				installResult.Failed = append(installResult.Failed, result.AssetName)
-				installResult.Errors = append(installResult.Errors, result.Error)
+				if result.Error != nil {
+					installResult.Errors = append(installResult.Errors, result.Error)
+				}
 			case clients.StatusSkipped:
 				if result.AssetName != "" && result.Message != "" {
 					styledOut.ListItem("⊘", result.AssetName+" → "+client.DisplayName()+": "+result.Message)
@@ -746,7 +778,7 @@ func processInstallationResults(allResults map[string]clients.InstallResponse, s
 	}
 
 	// Add error if ANY client failed
-	if clients.HasAnyErrors(allResults) {
+	if clients.HasAnyErrors(allResults) || strictSawUnsupported {
 		installResult.Errors = append(installResult.Errors, errors.New("installation failed for one or more clients"))
 	}
 

--- a/internal/commands/install_strict_test.go
+++ b/internal/commands/install_strict_test.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/internal/clients"
+	"github.com/sleuth-io/sx/internal/handlers/hook"
+	"github.com/sleuth-io/sx/internal/ui"
+)
+
+// processInstallationResults is unexported; test it through the package.
+//
+// Each subtest constructs an allResults map shaped like what the orchestrator
+// returns, runs processInstallationResults with strict={false,true}, and
+// asserts on whether the result counts as a failure.
+
+func TestProcessInstallationResults_StrictMode(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	unsupported := hook.UnsupportedEventError("Gemini", "pre-compact")
+
+	t.Run("non-strict: unsupported-event skip is informational", func(t *testing.T) {
+		styledOut := ui.NewOutput(&bytes.Buffer{}, &bytes.Buffer{})
+		results := map[string]clients.InstallResponse{
+			"gemini": {Results: []clients.AssetResult{
+				{
+					AssetName: "log-pre-compact",
+					Status:    clients.StatusSkipped,
+					Message:   unsupported.Error(),
+					Error:     unsupported,
+				},
+			}},
+		}
+		out := processInstallationResults(results, styledOut, false)
+		if len(out.Failed) != 0 {
+			t.Errorf("non-strict mode counted %d failures, want 0: %v", len(out.Failed), out.Failed)
+		}
+		if len(out.Errors) != 0 {
+			t.Errorf("non-strict mode reported errors: %v", out.Errors)
+		}
+	})
+
+	t.Run("strict: unsupported-event skip becomes failure", func(t *testing.T) {
+		styledOut := ui.NewOutput(&bytes.Buffer{}, &bytes.Buffer{})
+		results := map[string]clients.InstallResponse{
+			"gemini": {Results: []clients.AssetResult{
+				{
+					AssetName: "log-pre-compact",
+					Status:    clients.StatusSkipped,
+					Message:   unsupported.Error(),
+					Error:     unsupported,
+				},
+			}},
+		}
+		out := processInstallationResults(results, styledOut, true)
+		if len(out.Failed) != 1 {
+			t.Errorf("strict mode counted %d failures, want 1", len(out.Failed))
+		}
+		if !strings.Contains(out.Failed[0], "log-pre-compact") {
+			t.Errorf("Failed[0] = %q, want it to mention the asset", out.Failed[0])
+		}
+		if len(out.Errors) == 0 {
+			t.Errorf("strict mode produced no errors")
+		}
+	})
+
+	t.Run("strict: unrelated skip stays informational", func(t *testing.T) {
+		// Skips that aren't from unsupported events (e.g. "no compatible
+		// assets", "unsupported asset type") should NOT be escalated by --strict.
+		styledOut := ui.NewOutput(&bytes.Buffer{}, &bytes.Buffer{})
+		results := map[string]clients.InstallResponse{
+			"gemini": {Results: []clients.AssetResult{
+				{
+					Status:  clients.StatusSkipped,
+					Message: "No compatible assets",
+				},
+			}},
+		}
+		out := processInstallationResults(results, styledOut, true)
+		if len(out.Failed) != 0 {
+			t.Errorf("strict mode escalated unrelated skip: %v", out.Failed)
+		}
+	})
+
+	t.Run("strict: real failure stays a failure", func(t *testing.T) {
+		styledOut := ui.NewOutput(&bytes.Buffer{}, &bytes.Buffer{})
+		realErr := errors.New("disk full")
+		results := map[string]clients.InstallResponse{
+			"claude-code": {Results: []clients.AssetResult{
+				{
+					AssetName: "some-asset",
+					Status:    clients.StatusFailed,
+					Message:   realErr.Error(),
+					Error:     realErr,
+				},
+			}},
+		}
+		out := processInstallationResults(results, styledOut, true)
+		if len(out.Failed) != 1 {
+			t.Errorf("strict mode lost a real failure: %v", out.Failed)
+		}
+	})
+
+	t.Run("non-strict: real failure stays a failure", func(t *testing.T) {
+		styledOut := ui.NewOutput(&bytes.Buffer{}, &bytes.Buffer{})
+		realErr := errors.New("disk full")
+		results := map[string]clients.InstallResponse{
+			"claude-code": {Results: []clients.AssetResult{
+				{
+					AssetName: "some-asset",
+					Status:    clients.StatusFailed,
+					Message:   realErr.Error(),
+					Error:     realErr,
+				},
+			}},
+		}
+		out := processInstallationResults(results, styledOut, false)
+		if len(out.Failed) != 1 {
+			t.Errorf("non-strict mode lost a real failure: %v", out.Failed)
+		}
+	})
+}

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -131,7 +131,7 @@ func runRemove(cmd *cobra.Command, assetName, versionFlag string, yes bool) erro
 
 	if shouldInstall {
 		out.println()
-		if err := runInstall(cmd, nil, false, "", false, "", "", false); err != nil {
+		if err := runInstall(cmd, nil, false, "", false, "", "", false, false); err != nil {
 			out.printfErr("Install failed: %v\n", err)
 		}
 	} else {

--- a/internal/commands/vault.go
+++ b/internal/commands/vault.go
@@ -754,7 +754,7 @@ func runVaultRemove(cmd *cobra.Command, assetName, versionFlag string, yes, dele
 
 	if shouldInstall {
 		out.println()
-		if err := runInstall(cmd, nil, false, "", false, "", "", false); err != nil {
+		if err := runInstall(cmd, nil, false, "", false, "", "", false, false); err != nil {
 			out.printfErr("Install failed: %v\n", err)
 		}
 	} else {
@@ -861,7 +861,7 @@ func runVaultRename(cmd *cobra.Command, oldName, newName string, yes bool) error
 
 	if shouldInstall {
 		out.println()
-		if err := runInstall(cmd, nil, false, "", false, "", "", false); err != nil {
+		if err := runInstall(cmd, nil, false, "", false, "", "", false, false); err != nil {
 			out.printfErr("Install failed: %v\n", err)
 		}
 	} else {


### PR DESCRIPTION
Closes #106.

## Problem

Issue #103 (PR #102, SK-469) makes `sx install` soft-skip hook registrations when the target client doesn't support the asset's canonical event. That is the right *default* — most users don't want ✗ on hooks the client physically can't fire.

But CI/audit consumers want the opposite: a job that asserts every expected asset installed, and flags any new client/event mismatch as a regression. For those, soft-skip is silent failure.

## Change

Add `--strict` to `sx install` (also via `SX_STRICT=1`). When set, soft skips that wrap `hook.ErrUnsupportedEvent` are escalated to hard failures — `✗` rendering, counted in `installResult.Failed`, non-zero exit code.

```
sx install                 # default: ⊘ + exit 0 for unsupported events
sx install --strict        # ✗ + non-zero exit
SX_STRICT=1 sx install     # equivalent to --strict
```

Soft skips that arose from *other* paths (e.g. `"No compatible assets"`, `"Unsupported asset type: ..."`) are **not** escalated. Those reflect long-standing client-capability boundaries and should stay informational. Only `StatusSkipped` results carrying `hook.ErrUnsupportedEvent` get reclassified.

## Implementation

- Adds a `strict bool` parameter through `runInstall` → `installAssets` → `processInstallationResults`. Default behavior unchanged.
- The summary loop checks `errors.Is(result.Error, hook.ErrUnsupportedEvent)` on each `StatusSkipped` and, in strict mode, treats it as failed.
- `--strict` and `SX_STRICT=1` are equivalent; flag wins if both set.
- All other callers of `runInstall` (in `add.go`, `remove.go`, `vault.go`, `add_config.go`, `add_remote_mcp.go`, `commands.go`) pass `false` to preserve existing behavior — strict is opt-in via the install command flag only.

### Companion change

`TranslateInstallError` now preserves the sentinel on `StatusSkipped` (it was returning `nil` for the error before). Without this, strict mode has nothing to introspect. The non-strict exit code is unaffected: `HasAnyErrors` and `installResult.Failed` inspect `Status` only, not `Error`.

## Tests

`install_strict_test.go::TestProcessInstallationResults_StrictMode` covers:

- non-strict + unsupported-event skip → 0 failures
- strict + unsupported-event skip → 1 failure
- strict + unrelated skip (e.g. asset type) → 0 failures (not escalated)
- strict + real failure → 1 failure (unchanged)
- non-strict + real failure → 1 failure (unchanged)

`go test ./...` and `go vet ./...` clean.

## Dependency

Depends on #102 / SK-469 (the soft-skip sentinel + helper). This branch is stacked on `ealt/soft-skip-unsupported-events`; rebasing onto main once #102 lands is straightforward.