### PR TITLE
SK-471: Aggregate unsupported-event hook skips into per-client summary

### DIFF
--- a/internal/clients/claude_code/client.go
+++ b/internal/clients/claude_code/client.go
@@ -116,15 +116,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			err = fmt.Errorf("unsupported asset type: %s", bundle.Metadata.Asset.Type.Key)
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/claude_code/handlers/hook.go
+++ b/internal/clients/claude_code/handlers/hook.go
@@ -185,7 +185,7 @@ func (h *HookHandler) updateSettings(targetBase string) error {
 
 	hookEvent, supported := h.mapEventToClaudeCode()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Claude Code", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Claude Code", h.metadata.Hook.Event)
 	}
 
 	hookConfig := h.buildHookConfig(targetBase)

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -2,10 +2,13 @@ package clients
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/bootstrap"
+	"github.com/sleuth-io/sx/internal/handlers/hook"
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/metadata"
 )
@@ -212,6 +215,30 @@ const (
 	StatusFailed  ResultStatus = "failed"
 	StatusSkipped ResultStatus = "skipped"
 )
+
+// TranslateInstallError converts an error returned by a per-asset install
+// handler into the AssetResult fields a client should report.
+//
+// Errors that wrap hook.ErrUnsupportedEvent are translated to StatusSkipped:
+// the hook asset is well-formed but the target client has no lifecycle
+// event to fire it from (e.g. Gemini does not implement `pre-compact`).
+// This is not a user error and should not contribute to the install
+// command's exit status.
+//
+// All other non-nil errors are reported as StatusFailed and the error is
+// preserved on the AssetResult so callers can inspect or surface it.
+//
+// successMessage is used as result.Message when err is nil (for example,
+// the install path or "Installed to /home/...").
+func TranslateInstallError(err error, successMessage string) (ResultStatus, string, error) {
+	if err == nil {
+		return StatusSuccess, successMessage, nil
+	}
+	if errors.Is(err, hook.ErrUnsupportedEvent) {
+		return StatusSkipped, err.Error(), nil
+	}
+	return StatusFailed, fmt.Sprintf("Installation failed: %v", err), err
+}
 
 // VerifyResult represents the result of verifying a single asset's installation
 type VerifyResult struct {

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -223,10 +223,14 @@ const (
 // the hook asset is well-formed but the target client has no lifecycle
 // event to fire it from (e.g. Gemini does not implement `pre-compact`).
 // This is not a user error and should not contribute to the install
-// command's exit status.
+// command's exit status (HasAnyErrors only inspects Status, not Error).
 //
-// All other non-nil errors are reported as StatusFailed and the error is
-// preserved on the AssetResult so callers can inspect or surface it.
+// The original error is preserved on the AssetResult even when the status
+// is StatusSkipped so callers can introspect *why* the asset was skipped
+// (for example, to aggregate unsupported-event skips into a per-client
+// summary line, or to escalate them in a strict mode).
+//
+// All other non-nil errors are reported as StatusFailed.
 //
 // successMessage is used as result.Message when err is nil (for example,
 // the install path or "Installed to /home/...").
@@ -235,7 +239,7 @@ func TranslateInstallError(err error, successMessage string) (ResultStatus, stri
 		return StatusSuccess, successMessage, nil
 	}
 	if errors.Is(err, hook.ErrUnsupportedEvent) {
-		return StatusSkipped, err.Error(), nil
+		return StatusSkipped, err.Error(), err
 	}
 	return StatusFailed, fmt.Sprintf("Installation failed: %v", err), err
 }

--- a/internal/clients/cline/client.go
+++ b/internal/clients/cline/client.go
@@ -139,15 +139,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/cline/handlers/hook.go
+++ b/internal/clients/cline/handlers/hook.go
@@ -145,7 +145,7 @@ func (h *HookHandler) createHookScript(targetBase string) error {
 
 	clineEvent, supported := h.mapEventToCline()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Cline", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Cline", h.metadata.Hook.Event)
 	}
 
 	hookPath := filepath.Join(hooksDir, clineEvent)

--- a/internal/clients/cursor/client.go
+++ b/internal/clients/cursor/client.go
@@ -121,15 +121,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/cursor/handlers/hook.go
+++ b/internal/clients/cursor/handlers/hook.go
@@ -105,7 +105,7 @@ func (h *HookHandler) updateHooksJSON(targetBase string) error {
 
 	cursorEvent, supported := h.mapEventToCursor()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Cursor", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Cursor", h.metadata.Hook.Event)
 	}
 
 	entry := h.buildHookEntry(targetBase)

--- a/internal/clients/gemini/client.go
+++ b/internal/clients/gemini/client.go
@@ -137,15 +137,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = installedPath
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, installedPath)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/gemini/handlers/hook.go
+++ b/internal/clients/gemini/handlers/hook.go
@@ -121,7 +121,7 @@ func (h *HookHandler) mapEventToGemini() (string, bool) {
 func (h *HookHandler) updateSettings(geminiDir string) error {
 	hookEvent, supported := h.mapEventToGemini()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Gemini", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Gemini", h.metadata.Hook.Event)
 	}
 
 	installDir := filepath.Join(geminiDir, "hooks", h.metadata.Asset.Name)

--- a/internal/clients/install_error_test.go
+++ b/internal/clients/install_error_test.go
@@ -1,0 +1,65 @@
+package clients
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/handlers/hook"
+)
+
+func TestTranslateInstallError(t *testing.T) {
+	t.Run("nil error becomes success", func(t *testing.T) {
+		status, msg, err := TranslateInstallError(nil, "/path/to/install")
+		if status != StatusSuccess {
+			t.Errorf("status = %q, want %q", status, StatusSuccess)
+		}
+		if msg != "/path/to/install" {
+			t.Errorf("msg = %q, want %q", msg, "/path/to/install")
+		}
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+	})
+
+	t.Run("unsupported event becomes skipped", func(t *testing.T) {
+		input := hook.UnsupportedEventError("Gemini", "pre-compact")
+		status, msg, err := TranslateInstallError(input, "ignored")
+		if status != StatusSkipped {
+			t.Errorf("status = %q, want %q", status, StatusSkipped)
+		}
+		if !strings.Contains(msg, "pre-compact") {
+			t.Errorf("msg = %q, want it to mention the event", msg)
+		}
+		if err != nil {
+			t.Errorf("err = %v, want nil (soft skip should not propagate)", err)
+		}
+	})
+
+	t.Run("wrapped unsupported event becomes skipped", func(t *testing.T) {
+		// Simulate a handler that wraps the sentinel with additional context.
+		wrapped := errors.Join(hook.UnsupportedEventError("Gemini", "pre-compact"),
+			errors.New("during settings.json update"))
+		status, _, err := TranslateInstallError(wrapped, "ignored")
+		if status != StatusSkipped {
+			t.Errorf("status = %q, want %q", status, StatusSkipped)
+		}
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+	})
+
+	t.Run("other errors become failure", func(t *testing.T) {
+		input := errors.New("disk full")
+		status, msg, err := TranslateInstallError(input, "ignored")
+		if status != StatusFailed {
+			t.Errorf("status = %q, want %q", status, StatusFailed)
+		}
+		if !strings.Contains(msg, "disk full") {
+			t.Errorf("msg = %q, want it to include the error detail", msg)
+		}
+		if err == nil {
+			t.Errorf("err = nil, want the original error preserved")
+		}
+	})
+}

--- a/internal/clients/install_error_test.go
+++ b/internal/clients/install_error_test.go
@@ -22,7 +22,7 @@ func TestTranslateInstallError(t *testing.T) {
 		}
 	})
 
-	t.Run("unsupported event becomes skipped", func(t *testing.T) {
+	t.Run("unsupported event becomes skipped with error preserved", func(t *testing.T) {
 		input := hook.UnsupportedEventError("Gemini", "pre-compact")
 		status, msg, err := TranslateInstallError(input, "ignored")
 		if status != StatusSkipped {
@@ -31,8 +31,11 @@ func TestTranslateInstallError(t *testing.T) {
 		if !strings.Contains(msg, "pre-compact") {
 			t.Errorf("msg = %q, want it to mention the event", msg)
 		}
-		if err != nil {
-			t.Errorf("err = %v, want nil (soft skip should not propagate)", err)
+		// Preserve the error so callers (e.g. per-client summary aggregation)
+		// can introspect *why* the asset was skipped, while leaving Status
+		// as Skipped so it doesn't count toward HasAnyErrors / Failed.
+		if !errors.Is(err, hook.ErrUnsupportedEvent) {
+			t.Errorf("err = %v, want sentinel preserved on result", err)
 		}
 	})
 
@@ -44,8 +47,8 @@ func TestTranslateInstallError(t *testing.T) {
 		if status != StatusSkipped {
 			t.Errorf("status = %q, want %q", status, StatusSkipped)
 		}
-		if err != nil {
-			t.Errorf("err = %v, want nil", err)
+		if !errors.Is(err, hook.ErrUnsupportedEvent) {
+			t.Errorf("err = %v, want sentinel preserved on result", err)
 		}
 	})
 

--- a/internal/clients/kiro/client.go
+++ b/internal/clients/kiro/client.go
@@ -126,15 +126,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			continue
 		}
 
-		if err != nil {
-			result.Status = clients.StatusFailed
-			result.Error = err
-			result.Message = fmt.Sprintf("Installation failed: %v", err)
-		} else {
-			result.Status = clients.StatusSuccess
-			result.Message = "Installed to " + targetBase
-		}
-
+		result.Status, result.Message, result.Error = clients.TranslateInstallError(err, "Installed to "+targetBase)
 		resp.Results = append(resp.Results, result)
 	}
 

--- a/internal/clients/kiro/handlers/hook.go
+++ b/internal/clients/kiro/handlers/hook.go
@@ -148,7 +148,7 @@ func (h *HookHandler) writeHookFile(targetBase string) error {
 
 	kiroEvent, supported := h.mapEventToKiro()
 	if !supported {
-		return fmt.Errorf("hook event %q not supported for Kiro", h.metadata.Hook.Event)
+		return hook.UnsupportedEventError("Kiro", h.metadata.Hook.Event)
 	}
 
 	// Resolve the command to execute

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/sleuth-io/sx/internal/clients"
 	"github.com/sleuth-io/sx/internal/config"
 	"github.com/sleuth-io/sx/internal/gitutil"
+	"github.com/sleuth-io/sx/internal/handlers/hook"
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/metadata"
@@ -715,6 +717,11 @@ func processInstallationResults(allResults map[string]clients.InstallResponse, s
 	}
 
 	successfullyInstalled := make(map[string]bool)
+	// Aggregate unsupported-event hook skips per client so we can emit one
+	// summary line ("Gemini: skipped 3 hooks (events not supported: ...)")
+	// instead of one ⊘ line per (asset, client) pair.
+	type unsupportedSkip struct{ asset, event string }
+	unsupportedByClient := make(map[string][]unsupportedSkip)
 
 	for clientID, resp := range allResults {
 		client, _ := clients.Global().Get(clientID)
@@ -733,11 +740,53 @@ func processInstallationResults(allResults map[string]clients.InstallResponse, s
 				installResult.Failed = append(installResult.Failed, result.AssetName)
 				installResult.Errors = append(installResult.Errors, result.Error)
 			case clients.StatusSkipped:
+				// Aggregate unsupported-event skips into a per-client summary
+				// (rendered after the loop). All other skip reasons keep
+				// their per-asset ⊘ line.
+				var details *hook.UnsupportedEventDetails
+				if errors.As(result.Error, &details) {
+					unsupportedByClient[clientID] = append(unsupportedByClient[clientID], unsupportedSkip{
+						asset: result.AssetName,
+						event: details.Event,
+					})
+					continue
+				}
 				if result.AssetName != "" && result.Message != "" {
 					styledOut.ListItem("⊘", result.AssetName+" → "+client.DisplayName()+": "+result.Message)
 				}
 			}
 		}
+	}
+
+	// Emit one aggregate summary per client that had unsupported-event skips.
+	// Sorted client IDs for deterministic output.
+	skippedClients := make([]string, 0, len(unsupportedByClient))
+	for id := range unsupportedByClient {
+		skippedClients = append(skippedClients, id)
+	}
+	sort.Strings(skippedClients)
+	for _, clientID := range skippedClients {
+		client, _ := clients.Global().Get(clientID)
+		skips := unsupportedByClient[clientID]
+		// De-dup events while preserving first-seen order.
+		seen := make(map[string]struct{}, len(skips))
+		uniqueEvents := make([]string, 0, len(skips))
+		for _, s := range skips {
+			if _, ok := seen[s.event]; ok {
+				continue
+			}
+			seen[s.event] = struct{}{}
+			uniqueEvents = append(uniqueEvents, s.event)
+		}
+		var label string
+		if len(skips) == 1 {
+			label = fmt.Sprintf("%s: skipped 1 hook (event not supported: %s)",
+				client.DisplayName(), uniqueEvents[0])
+		} else {
+			label = fmt.Sprintf("%s: skipped %d hooks (events not supported: %s)",
+				client.DisplayName(), len(skips), strings.Join(uniqueEvents, ", "))
+		}
+		styledOut.ListItem("⊘", label)
 	}
 
 	// Build list of successfully installed assets

--- a/internal/commands/install_skipped_summary_test.go
+++ b/internal/commands/install_skipped_summary_test.go
@@ -1,0 +1,125 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/clients"
+	"github.com/sleuth-io/sx/internal/handlers/hook"
+	"github.com/sleuth-io/sx/internal/ui"
+)
+
+// captureOutput renders processInstallationResults into a buffer so tests
+// can assert on the user-visible install summary.
+func captureOutput(t *testing.T, results map[string]clients.InstallResponse) string {
+	t.Helper()
+	var buf bytes.Buffer
+	styledOut := ui.NewOutput(&buf, &bytes.Buffer{})
+	processInstallationResults(results, styledOut)
+	return buf.String()
+}
+
+func TestProcessInstallationResults_UnsupportedEventSummary(t *testing.T) {
+	t.Run("aggregates multiple skips per client into one line", func(t *testing.T) {
+		results := map[string]clients.InstallResponse{
+			"gemini": {Results: []clients.AssetResult{
+				skippedHook("log-pre-compact", "Gemini", "pre-compact"),
+				skippedHook("log-subagent-start", "Gemini", "subagent-start"),
+				skippedHook("log-subagent-stop", "Gemini", "subagent-stop"),
+			}},
+		}
+		out := captureOutput(t, results)
+
+		// One summary line per affected client.
+		if !strings.Contains(out, "skipped 3 hooks") {
+			t.Errorf("output did not aggregate three skips:\n%s", out)
+		}
+		if !strings.Contains(out, "pre-compact") || !strings.Contains(out, "subagent-start") || !strings.Contains(out, "subagent-stop") {
+			t.Errorf("summary missing one of the events:\n%s", out)
+		}
+		// Per-asset ⊘ lines should be suppressed for unsupported-event skips.
+		if strings.Contains(out, "log-pre-compact → Gemini") {
+			t.Errorf("per-asset ⊘ line not suppressed:\n%s", out)
+		}
+	})
+
+	t.Run("singular phrasing for one skip", func(t *testing.T) {
+		results := map[string]clients.InstallResponse{
+			"gemini": {Results: []clients.AssetResult{
+				skippedHook("log-pre-compact", "Gemini", "pre-compact"),
+			}},
+		}
+		out := captureOutput(t, results)
+		if !strings.Contains(out, "skipped 1 hook (event not supported: pre-compact)") {
+			t.Errorf("singular phrasing not used:\n%s", out)
+		}
+	})
+
+	t.Run("non-unsupported skips keep per-asset ⊘ line", func(t *testing.T) {
+		// "No compatible assets" / "Unsupported asset type" skips are NOT
+		// rolled into the unsupported-event summary; they retain individual
+		// rendering because the user may want to see them per-asset.
+		results := map[string]clients.InstallResponse{
+			"cursor": {Results: []clients.AssetResult{
+				{
+					AssetName: "some-skill",
+					Status:    clients.StatusSkipped,
+					Message:   "Unsupported asset type: foo",
+					Error:     nil,
+				},
+			}},
+		}
+		out := captureOutput(t, results)
+		if !strings.Contains(out, "some-skill → Cursor") {
+			t.Errorf("non-unsupported skip should keep per-asset rendering:\n%s", out)
+		}
+	})
+
+	t.Run("multiple clients each get their own summary", func(t *testing.T) {
+		results := map[string]clients.InstallResponse{
+			"gemini": {Results: []clients.AssetResult{
+				skippedHook("log-pre-compact", "Gemini", "pre-compact"),
+			}},
+			"cline": {Results: []clients.AssetResult{
+				skippedHook("log-stop", "Cline", "stop"),
+			}},
+		}
+		out := captureOutput(t, results)
+		if !strings.Contains(out, "Gemini") || !strings.Contains(out, "pre-compact") {
+			t.Errorf("missing Gemini summary:\n%s", out)
+		}
+		if !strings.Contains(out, "Cline") || !strings.Contains(out, "stop") {
+			t.Errorf("missing Cline summary:\n%s", out)
+		}
+	})
+
+	t.Run("duplicate events deduplicated within a client", func(t *testing.T) {
+		// Two assets fan out to the same unsupported event — the summary
+		// should list the event once but count both skips.
+		results := map[string]clients.InstallResponse{
+			"gemini": {Results: []clients.AssetResult{
+				skippedHook("log-pre-compact-a", "Gemini", "pre-compact"),
+				skippedHook("log-pre-compact-b", "Gemini", "pre-compact"),
+			}},
+		}
+		out := captureOutput(t, results)
+		if !strings.Contains(out, "skipped 2 hooks") {
+			t.Errorf("count should reflect 2 skips:\n%s", out)
+		}
+		// "pre-compact" should appear exactly once in events list.
+		if strings.Count(out, "pre-compact") != 1 {
+			t.Errorf("event list not deduplicated:\n%s", out)
+		}
+	})
+}
+
+func skippedHook(asset, client, event string) clients.AssetResult {
+	err := hook.UnsupportedEventError(client, event)
+	return clients.AssetResult{
+		AssetName: asset,
+		Status:    clients.StatusSkipped,
+		Message:   err.Error(),
+		Error:     err,
+	}
+}

--- a/internal/handlers/hook/hook.go
+++ b/internal/handlers/hook/hook.go
@@ -70,12 +70,34 @@ func CacheZipFiles(zipData []byte) []string {
 // soft-skipped on Gemini and installed as usual on Claude Code.
 var ErrUnsupportedEvent = errors.New("unsupported hook event")
 
-// UnsupportedEventError builds an error that wraps ErrUnsupportedEvent with
-// a human-readable message naming the client and event. Callers detect it
-// via errors.Is(err, ErrUnsupportedEvent).
-func UnsupportedEventError(clientName, event string) error {
-	return fmt.Errorf("%w %q on %s", ErrUnsupportedEvent, event, clientName)
+// unsupportedEventErr is the concrete type returned by UnsupportedEventError.
+// It carries Client and Event as structured fields so callers can build
+// per-client summaries without parsing the message string. Callers should
+// match it via errors.As, or detect the wrapped sentinel via errors.Is.
+type unsupportedEventErr struct {
+	Client string
+	Event  string
 }
+
+func (e *unsupportedEventErr) Error() string {
+	return fmt.Sprintf("%s %q on %s", ErrUnsupportedEvent.Error(), e.Event, e.Client)
+}
+
+func (e *unsupportedEventErr) Unwrap() error { return ErrUnsupportedEvent }
+
+// UnsupportedEventError builds an error that wraps ErrUnsupportedEvent with
+// the client and event captured as structured fields. Callers detect it via
+// errors.Is(err, ErrUnsupportedEvent), and extract the fields via:
+//
+//	var ue *UnsupportedEventDetails
+//	if errors.As(err, &ue) { ... ue.Client, ue.Event ... }
+func UnsupportedEventError(clientName, event string) error {
+	return &unsupportedEventErr{Client: clientName, Event: event}
+}
+
+// UnsupportedEventDetails is the public alias for the concrete type used with
+// errors.As to recover the (Client, Event) pair from an UnsupportedEventError.
+type UnsupportedEventDetails = unsupportedEventErr
 
 // MapEvent maps a canonical hook event name to a client-native event name.
 // It first checks the client-specific override map, then falls back to the

--- a/internal/handlers/hook/hook.go
+++ b/internal/handlers/hook/hook.go
@@ -58,6 +58,25 @@ func CacheZipFiles(zipData []byte) []string {
 	return files
 }
 
+// ErrUnsupportedEvent is returned when a hook asset's canonical event is not
+// supported by the target client. Callers (typically a client's InstallAssets
+// implementation) use errors.Is to distinguish this from real install
+// failures and surface the result as StatusSkipped rather than StatusFailed.
+//
+// This is not a user error: the asset is well-formed and the user's
+// configuration is correct; the target client simply has no lifecycle event
+// to fire it from. For example, Gemini Code Assist does not implement
+// `pre-compact` or `subagent-start`, so log hooks for those events are
+// soft-skipped on Gemini and installed as usual on Claude Code.
+var ErrUnsupportedEvent = errors.New("unsupported hook event")
+
+// UnsupportedEventError builds an error that wraps ErrUnsupportedEvent with
+// a human-readable message naming the client and event. Callers detect it
+// via errors.Is(err, ErrUnsupportedEvent).
+func UnsupportedEventError(clientName, event string) error {
+	return fmt.Errorf("%w %q on %s", ErrUnsupportedEvent, event, clientName)
+}
+
 // MapEvent maps a canonical hook event name to a client-native event name.
 // It first checks the client-specific override map, then falls back to the
 // standard eventMap. Returns the native event name and whether the event

--- a/internal/handlers/hook/hook_test.go
+++ b/internal/handlers/hook/hook_test.go
@@ -3,6 +3,8 @@ package hook
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/sleuth-io/sx/internal/asset"
@@ -154,6 +156,33 @@ func TestMapEvent(t *testing.T) {
 		native, ok := MapEvent("post-tool-use", eventMap, overrides)
 		if !ok || native != "PostToolUse" {
 			t.Errorf("got (%q, %v), want (PostToolUse, true)", native, ok)
+		}
+	})
+}
+
+func TestUnsupportedEventError(t *testing.T) {
+	t.Run("wraps sentinel", func(t *testing.T) {
+		err := UnsupportedEventError("Gemini", "pre-compact")
+		if !errors.Is(err, ErrUnsupportedEvent) {
+			t.Errorf("errors.Is(err, ErrUnsupportedEvent) = false, want true")
+		}
+	})
+
+	t.Run("message names client and event", func(t *testing.T) {
+		err := UnsupportedEventError("Gemini", "pre-compact")
+		msg := err.Error()
+		if !strings.Contains(msg, "Gemini") {
+			t.Errorf("error message %q does not contain client name 'Gemini'", msg)
+		}
+		if !strings.Contains(msg, "pre-compact") {
+			t.Errorf("error message %q does not contain event name 'pre-compact'", msg)
+		}
+	})
+
+	t.Run("distinct from unrelated error", func(t *testing.T) {
+		other := errors.New("some other error")
+		if errors.Is(other, ErrUnsupportedEvent) {
+			t.Errorf("unrelated error matched ErrUnsupportedEvent sentinel")
 		}
 	})
 }


### PR DESCRIPTION
Closes #105.

## Problem

After PR #102 / SK-469, soft-skipped hook installs render one ⊘ line per (asset, client) pair:

```
⊘ log-pre-compact → Gemini Code Assist: unsupported hook event "pre-compact" on Gemini
⊘ log-subagent-start → Gemini Code Assist: unsupported hook event "subagent-start" on Gemini
⊘ log-subagent-stop → Gemini Code Assist: unsupported hook event "subagent-stop" on Gemini
```

That's faithful but noisy. For multi-client users who publish three or four log hooks fanning out to clients that don't support them, the install summary fills with redundant lines that only differ in event name.

## Change

Aggregate unsupported-event skips into one summary line per client:

```
⊘ Gemini Code Assist: skipped 3 hooks (events not supported: pre-compact, subagent-start, subagent-stop)
```

Singular phrasing for one skip:

```
⊘ Gemini Code Assist: skipped 1 hook (event not supported: pre-compact)
```

Skips that don't carry the unsupported-event sentinel (`"No compatible assets"`, `"Unsupported asset type: ..."`) keep their per-asset ⊘ rendering — those reflect the user's vault contents, not client-capability gaps.

## Implementation

- `hook.UnsupportedEventError` now returns a typed error with structured `Client` / `Event` fields, exported via `hook.UnsupportedEventDetails`. Existing detection (`errors.Is(err, hook.ErrUnsupportedEvent)`) keeps working unchanged.
- `processInstallationResults` collects unsupported-event skips into a per-client map during the main loop using `errors.As`, suppresses the per-asset ⊘ line for those, then emits one aggregate summary per affected client at the end.
- Output is sorted by client ID for deterministic rendering. Events are deduplicated per client (two assets fanning out to the same event count once in the events list but both contribute to the count).

### Companion change

`TranslateInstallError` preserves the sentinel on `StatusSkipped` (was returning `nil` previously). Without this the aggregator has nothing to introspect. Identical change as PR #108 / SK-472 — rebases cleanly with either.

## Tests

`install_skipped_summary_test.go` covers:

- Aggregation across multiple skips → one summary line, all events listed
- Singular phrasing for one skip
- Non-unsupported skips → per-asset ⊘ preserved
- Multiple clients → each gets its own summary
- Duplicate events (two assets, same event) → event listed once, count reflects both

`go test ./...` and `go vet ./...` clean.

## Dependency

Depends on #102 / SK-469 (the soft-skip sentinel + helper). Stacked on `ealt/soft-skip-unsupported-events`; rebases cleanly onto main once #102 lands.

This PR and #108 (SK-472, --strict) both make small, identical changes to `TranslateInstallError` to preserve the sentinel — they don't conflict and either order is fine.