### PR TITLE
SK-470: Reject invalid hook events at `sx add` time

### DIFF
--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sleuth-io/sx/internal/config"
 	"github.com/sleuth-io/sx/internal/github"
 	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/metadata"
 	"github.com/sleuth-io/sx/internal/ui"
 	"github.com/sleuth-io/sx/internal/ui/components"
 	vaultpkg "github.com/sleuth-io/sx/internal/vault"
@@ -484,6 +485,13 @@ func addNewAsset(ctx context.Context, out *outputHelper, status *components.Stat
 	zipData, err := updateMetadataInZip(meta, zipData, metadataExists)
 	if err != nil {
 		return err
+	}
+
+	// Validate the (possibly user-authored) metadata before it enters the
+	// vault. Catches problems like typo'd hook events (`event = "subagent-strat"`)
+	// that would otherwise pass `sx add` and only fail at install time.
+	if err := metadata.ValidateZip(zipData, &assetType); err != nil {
+		return fmt.Errorf("metadata validation failed: %w", err)
 	}
 
 	// Create asset entry (what it is)

--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -488,10 +488,11 @@ func addNewAsset(ctx context.Context, out *outputHelper, status *components.Stat
 	}
 
 	// Validate the (possibly user-authored) metadata before it enters the
-	// vault. Catches problems like typo'd hook events (`event = "subagent-strat"`)
-	// that would otherwise pass `sx add` and only fail at install time.
+	// vault. Catches problems like unknown hook events that would otherwise
+	// pass `sx add` and only fail at install time. ValidateZip already wraps
+	// its errors with a "metadata validation failed:" prefix.
 	if err := metadata.ValidateZip(zipData, &assetType); err != nil {
-		return fmt.Errorf("metadata validation failed: %w", err)
+		return err
 	}
 
 	// Create asset entry (what it is)

--- a/internal/commands/integration_add_noninteractive_test.go
+++ b/internal/commands/integration_add_noninteractive_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -268,8 +269,23 @@ prompt-file = "SKILL.md"
 		env.ResetVaultAssets(vaultDir)
 		os.RemoveAll(filepath.Join(vaultDir, "assets", "custom-name"))
 
+		// Type override changes the asset's schema requirements, so the
+		// source must satisfy the *target* type's contract — a rule
+		// requires RULE.md, not the skill source's SKILL.md. Use a
+		// rule-shaped source for this subtest.
+		ruleSourceDir := env.MkdirAll(filepath.Join(env.TempDir, "source-rule-override"))
+		env.WriteFile(filepath.Join(ruleSourceDir, "metadata.toml"), `[asset]
+name = "test-rule"
+type = "rule"
+description = "A test rule"
+
+[rule]
+prompt-file = "RULE.md"
+`)
+		env.WriteFile(filepath.Join(ruleSourceDir, "RULE.md"), "# Test Rule")
+
 		addCmd := NewAddCommand()
-		addCmd.SetArgs([]string{sourceDir, "--yes", "--name", "custom-name", "--type", "rule"})
+		addCmd.SetArgs([]string{ruleSourceDir, "--yes", "--name", "custom-name", "--type", "rule"})
 
 		if err := addCmd.Execute(); err != nil {
 			t.Fatalf("Failed to add skill: %v", err)
@@ -360,6 +376,35 @@ func TestAddNonInteractiveErrors(t *testing.T) {
 		err := addCmd.Execute()
 		if err == nil {
 			t.Error("Expected error when invalid --type is provided")
+		}
+	})
+
+	t.Run("error when hook event is unknown", func(t *testing.T) {
+		// A typo'd hook event must be rejected at sx add time, not silently
+		// accepted into the vault. The validation runs against
+		// metadata/validation.go's validHookEvents (the canonical event set).
+		sourceDir := env.MkdirAll(filepath.Join(env.TempDir, "source-bad-hook"))
+		env.WriteFile(filepath.Join(sourceDir, "metadata.toml"), `[asset]
+name = "bad-hook"
+type = "hook"
+description = "Hook with a typo'd event"
+
+[hook]
+event = "subagent-strat"
+script-file = "hook.sh"
+`)
+		env.WriteFile(filepath.Join(sourceDir, "hook.sh"), "#!/bin/sh\necho hi\n")
+
+		addCmd := NewAddCommand()
+		addCmd.SetArgs([]string{sourceDir, "--yes"})
+
+		err := addCmd.Execute()
+		if err == nil {
+			t.Fatal("Expected error when hook event is unknown")
+		}
+		if !strings.Contains(err.Error(), "invalid hook event") &&
+			!strings.Contains(err.Error(), "subagent-strat") {
+			t.Errorf("Expected error to mention invalid event or the typo: %v", err)
 		}
 	})
 }

--- a/internal/commands/integration_add_noninteractive_test.go
+++ b/internal/commands/integration_add_noninteractive_test.go
@@ -380,17 +380,17 @@ func TestAddNonInteractiveErrors(t *testing.T) {
 	})
 
 	t.Run("error when hook event is unknown", func(t *testing.T) {
-		// A typo'd hook event must be rejected at sx add time, not silently
+		// An unknown hook event must be rejected at sx add time, not silently
 		// accepted into the vault. The validation runs against
 		// metadata/validation.go's validHookEvents (the canonical event set).
 		sourceDir := env.MkdirAll(filepath.Join(env.TempDir, "source-bad-hook"))
 		env.WriteFile(filepath.Join(sourceDir, "metadata.toml"), `[asset]
 name = "bad-hook"
 type = "hook"
-description = "Hook with a typo'd event"
+description = "Hook with an unknown event"
 
 [hook]
-event = "subagent-strat"
+event = "subagent-launch"
 script-file = "hook.sh"
 `)
 		env.WriteFile(filepath.Join(sourceDir, "hook.sh"), "#!/bin/sh\necho hi\n")
@@ -403,8 +403,8 @@ script-file = "hook.sh"
 			t.Fatal("Expected error when hook event is unknown")
 		}
 		if !strings.Contains(err.Error(), "invalid hook event") &&
-			!strings.Contains(err.Error(), "subagent-strat") {
-			t.Errorf("Expected error to mention invalid event or the typo: %v", err)
+			!strings.Contains(err.Error(), "subagent-launch") {
+			t.Errorf("Expected error to mention invalid event or the bad value: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Closes #104.

## Problem

sx already maintains a canonical set of valid hook events (`validHookEvents` in `internal/metadata/validation.go`), and `HookConfig.Validate()` rejects unknown ones. That check runs at *install time* via `ValidateZipForHook`. But `sx add` parses metadata via `metadata.Parse(...)` and never calls `Validate()`, so a typo like:

```toml
[hook]
event = "subagent-strat"
script-file = "hook.sh"
```

passes `sx add` and lands in the vault. The mistake only surfaces when a downstream consumer tries to install the asset — by which point the asset is published and version-bumped.

This becomes worse once #103 / SK-469 lands: hook installs that don't match a client's event mapping become silent soft skips. A typo'd event would soft-skip on *every* client (since no client maps it) and the hook would appear "installed" everywhere while actually firing nowhere.

## Change

Call `metadata.ValidateZip(zipData, &assetType)` in `addNewAsset` (the path that uploads a new asset version into the vault), just before the upload. `ValidateZip` already calls `ValidateWithFiles` which calls `Validate()`, so this picks up:

- invalid hook events (the headline case)
- script-file/command mutual exclusion
- missing prompt-file / script-file referenced by metadata
- semver violations on the asset version
- empty asset names

…and any other check that lives in `metadata/validation.go`. Validation ran at install time before; running it at add time too just means problems surface where they can still be fixed in the source rather than after publication.

The check uses the canonical event set already maintained in `validHookEvents` — no new event registry needed.

## Tests

- `TestAddNonInteractiveErrors / "error when hook event is unknown"` — typo'd event hard-fails at `sx add`.
- `TestAddNonInteractiveIntegration / "add with explicit --name and --type overrides"` — updated to use a rule-shaped source. The previous version used a skill source with `--type rule`, a schema mismatch (rule requires `RULE.md`, not `SKILL.md`) that was only passing because validation was missing. Updated to give the test a source that actually satisfies the override.

`go test ./...` and `go vet ./...` clean.

## Independent of #102

This change has no overlap with the soft-skip work in #102 / SK-469 — it's a pure improvement to `sx add`. Mergeable in any order.