### PR TITLE
SK-475: Stop overwriting README.md in Git vaults

### DIFF
--- a/internal/commands/update_templates.go
+++ b/internal/commands/update_templates.go
@@ -18,9 +18,10 @@ func NewUpdateTemplatesCommand() *cobra.Command {
 		Use:    "update-templates",
 		Hidden: true,
 		Short:  "Update templates in Git repository if needed",
-		Long: `Check and update templates (install.sh, README.md) in the Git repository
-if they are outdated or missing. Only updates files if their version is older
-than the current template version. This is a hidden maintenance command.`,
+		Long: `Check and update templates in the Git repository if they are outdated
+or missing. install.sh is regenerated when its version is older than the current
+template; README.md is only seeded when missing so user customizations are
+preserved. This is a hidden maintenance command.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdateTemplates(cmd, args)
 		},

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -39,10 +39,6 @@ const (
 	// installScriptTemplateVersion is the current version of the install.sh template
 	// Increment this when making changes to the template
 	installScriptTemplateVersion = "1"
-
-	// readmeTemplateVersion is the current version of the README.md template
-	// Increment this when making changes to the template
-	readmeTemplateVersion = "1"
 )
 
 // GitVault implements Vault for Git vaults
@@ -340,50 +336,43 @@ func (g *GitVault) ensureInstallScript(ctx context.Context) error {
 	return err
 }
 
-// updateTemplates is the internal implementation that returns which files were updated
+// updateTemplates is the internal implementation that returns which files were updated.
+//
+// install.sh is version-managed: missing or outdated copies are regenerated.
+// README.md is created on first init only — once it exists we leave it alone so
+// users can customize it (e.g. with a team quick-start guide) without sx
+// silently resetting it on the next commit.
 func (g *GitVault) updateTemplates(ctx context.Context, commit bool) ([]string, error) {
 	var updatedFiles []string
 	installScriptPath := filepath.Join(g.repoPath, "install.sh")
 	readmePath := filepath.Join(g.repoPath, "README.md")
 
-	// Use version constants directly (not from templates, which contain placeholders)
-	installScriptVersion := installScriptTemplateVersion
-	readmeVersion := readmeTemplateVersion
-
 	// Check if install.sh needs to be created or updated
 	needInstallScriptUpdate := false
 	if content, err := os.ReadFile(installScriptPath); err == nil {
-		// File exists, check if version needs update
 		fileVersion := extractTemplateVersion(string(content), "# Template version: ")
-		needInstallScriptUpdate = shouldUpdateTemplate(fileVersion, installScriptVersion)
+		needInstallScriptUpdate = shouldUpdateTemplate(fileVersion, installScriptTemplateVersion)
 	} else if os.IsNotExist(err) {
-		// File doesn't exist
 		needInstallScriptUpdate = true
 	} else {
 		return nil, fmt.Errorf("failed to check install.sh: %w", err)
 	}
 
-	// Check if README.md needs to be created or updated
-	needReadmeUpdate := false
-	if content, err := os.ReadFile(readmePath); err == nil {
-		// File exists, check if version needs update
-		fileVersion := extractTemplateVersion(string(content), "<!-- Template version: ")
-		needReadmeUpdate = shouldUpdateTemplate(fileVersion, readmeVersion)
-	} else if os.IsNotExist(err) {
-		// File doesn't exist
-		needReadmeUpdate = true
-	} else {
-		return nil, fmt.Errorf("failed to check README.md: %w", err)
+	// README is only seeded if missing — never overwritten
+	needReadmeCreate := false
+	if _, err := os.Stat(readmePath); err != nil {
+		if os.IsNotExist(err) {
+			needReadmeCreate = true
+		} else {
+			return nil, fmt.Errorf("failed to check README.md: %w", err)
+		}
 	}
 
-	// If both files are up to date, nothing to do
-	if !needInstallScriptUpdate && !needReadmeUpdate {
+	if !needInstallScriptUpdate && !needReadmeCreate {
 		return updatedFiles, nil
 	}
 
-	// Create or update install.sh if needed
 	if needInstallScriptUpdate {
-		// Generate install.sh with actual repository URL
 		installScript := generateInstallScript(g.repoURL)
 		if err := os.WriteFile(installScriptPath, []byte(installScript), 0755); err != nil {
 			return nil, fmt.Errorf("failed to create install.sh: %w", err)
@@ -391,9 +380,7 @@ func (g *GitVault) updateTemplates(ctx context.Context, commit bool) ([]string, 
 		updatedFiles = append(updatedFiles, "install.sh")
 	}
 
-	// Create or update README.md if needed
-	if needReadmeUpdate {
-		// Generate README with actual repository URL
+	if needReadmeCreate {
 		readme := generateReadme(g.repoURL)
 		if err := os.WriteFile(readmePath, []byte(readme), 0644); err != nil {
 			return nil, fmt.Errorf("failed to create README.md: %w", err)
@@ -403,18 +390,15 @@ func (g *GitVault) updateTemplates(ctx context.Context, commit bool) ([]string, 
 
 	// Commit and push the changes if requested and any files were updated
 	if commit && len(updatedFiles) > 0 {
-		// Stage the updated files
 		if err := g.gitClient.Add(ctx, g.repoPath, updatedFiles...); err != nil {
 			return nil, fmt.Errorf("failed to stage updated templates: %w", err)
 		}
 
-		// Commit with a descriptive message
-		commitMsg := fmt.Sprintf("Update templates to version %s/%s", installScriptTemplateVersion, readmeTemplateVersion)
+		commitMsg := "Update install.sh to version " + installScriptTemplateVersion
 		if err := g.gitClient.Commit(ctx, g.repoPath, commitMsg); err != nil {
 			return nil, fmt.Errorf("failed to commit updated templates: %w", err)
 		}
 
-		// Push to remote
 		if err := g.gitClient.Push(ctx, g.repoPath); err != nil {
 			return nil, fmt.Errorf("failed to push updated templates: %w", err)
 		}
@@ -505,8 +489,7 @@ func generateReadme(repoURL string) string {
 
 	var buf bytes.Buffer
 	data := map[string]string{
-		"INSTALL_URL":      rawURL,
-		"TEMPLATE_VERSION": readmeTemplateVersion,
+		"INSTALL_URL": rawURL,
 	}
 	if err := tmpl.Execute(&buf, data); err != nil {
 		panic(fmt.Sprintf("failed to execute README.md template: %v", err))

--- a/internal/vault/gitrepo_test.go
+++ b/internal/vault/gitrepo_test.go
@@ -173,28 +173,17 @@ func TestGenerateReadme(t *testing.T) {
 	repoURL := "https://github.com/test/repo.git"
 	result := generateReadme(repoURL)
 
-	// Check that the template was rendered
 	if result == "" {
 		t.Error("generateReadme() returned empty string")
 	}
 
-	// Check that template version was injected
-	if !strings.Contains(result, "<!-- Template version: "+readmeTemplateVersion+" -->") {
-		t.Errorf("generateReadme() should contain version %q", readmeTemplateVersion)
-	}
-
-	// Check that install URL was generated (should be raw GitHub URL)
 	expectedURL := "https://raw.githubusercontent.com/test/repo/main/install.sh"
 	if !strings.Contains(result, expectedURL) {
 		t.Errorf("generateReadme() should contain install URL %q, got:\n%s", expectedURL, result)
 	}
 
-	// Check that placeholders were replaced
 	if strings.Contains(result, "{{.INSTALL_URL}}") {
 		t.Error("generateReadme() still contains {{.INSTALL_URL}} placeholder")
-	}
-	if strings.Contains(result, "{{.TEMPLATE_VERSION}}") {
-		t.Error("generateReadme() still contains {{.TEMPLATE_VERSION}} placeholder")
 	}
 }
 

--- a/internal/vault/templates/README.md.tmpl
+++ b/internal/vault/templates/README.md.tmpl
@@ -1,5 +1,4 @@
 # Asset Vault
-<!-- Template version: {{.TEMPLATE_VERSION}} -->
 
 This vault contains assets (skills, agents, MCP servers, etc.) for use with sx.
 


### PR DESCRIPTION
## Summary
- Git vaults now only seed README.md when missing; user customizations are preserved across subsequent commits.
- Drops the README template version comment and the `readmeTemplateVersion` constant since the file is no longer auto-updated.
- install.sh continues to be version-managed (template fixes there are still meaningful).

Fixes #112
