### PR TITLE
SK-452: Honor scope flags with --no-install

### DIFF
--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -421,13 +421,10 @@ func handleIdenticalAsset(ctx context.Context, out *outputHelper, status *compon
 		},
 	}
 
-	// --no-install: still write lock file (global scope) but skip install prompt
+	// --no-install: write lock file but skip install prompt. Honors any
+	// scope flags so batch flows can pin assets to a target repo/path/scope.
 	if opts.NoInstall {
-		lockAsset.Scopes = []lockfile.Scope{}
-		if err := updateLockFile(ctx, out, vault, lockAsset, ""); err != nil {
-			return fmt.Errorf("failed to update lock file: %w", err)
-		}
-		return nil
+		return writeLockFileForNoInstall(ctx, out, vault, lockAsset, opts)
 	}
 
 	// Get scopes (from flags if --yes, otherwise prompt)
@@ -524,13 +521,10 @@ func addNewAsset(ctx context.Context, out *outputHelper, status *components.Stat
 
 	out.printf("✓ Successfully added %s@%s\n", meta.Asset.Name, meta.Asset.Version)
 
-	// --no-install: still write lock file (global scope) but skip install prompt
+	// --no-install: write lock file but skip install prompt. Honors any
+	// scope flags so batch flows can pin assets to a target repo/path/scope.
 	if opts.NoInstall {
-		lockAsset.Scopes = []lockfile.Scope{}
-		if err := updateLockFile(ctx, out, vault, lockAsset, ""); err != nil {
-			return fmt.Errorf("failed to update lock file: %w", err)
-		}
-		return nil
+		return writeLockFileForNoInstall(ctx, out, vault, lockAsset, opts)
 	}
 
 	// Get scopes (from flags if --yes, otherwise prompt)

--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -8,6 +8,30 @@ import (
 	"github.com/sleuth-io/sx/internal/vault"
 )
 
+// writeLockFileForNoInstall writes the lock entry for an asset added with
+// --no-install. Honors --scope-repo / --scope-global / --scope when set so
+// batch flows ("sx add ... --no-install --scope-repo X" in a loop, then a
+// single sx install at the end) get the scope they asked for rather than
+// silently global. Falls back to global when no scope flag is given,
+// preserving the long-standing default for plain --no-install.
+func writeLockFileForNoInstall(ctx context.Context, out *outputHelper, repo vault.Vault, asset *lockfile.Asset, opts addOptions) error {
+	result, err := opts.getScopes()
+	if err != nil {
+		return err
+	}
+	asset.Scopes = result.Scopes
+	if asset.Scopes == nil {
+		// Inherit / Remove from getScopes both end up here (no scope flag
+		// was set). Default to global to match pre-fix behavior — strict
+		// inherit semantics under --no-install would be a broader change.
+		asset.Scopes = []lockfile.Scope{}
+	}
+	if err := updateLockFile(ctx, out, repo, asset, result.ScopeEntity); err != nil {
+		return fmt.Errorf("failed to update lock file: %w", err)
+	}
+	return nil
+}
+
 // updateLockFile updates the repository's lock file with the asset using modern UI
 func updateLockFile(ctx context.Context, out *outputHelper, repo vault.Vault, asset *lockfile.Asset, scopeEntity string) error {
 	// SetInstallations updates the vault's lock file with the installation configuration

--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -21,9 +21,13 @@ func writeLockFileForNoInstall(ctx context.Context, out *outputHelper, repo vaul
 	}
 	asset.Scopes = result.Scopes
 	if asset.Scopes == nil {
-		// Inherit / Remove from getScopes both end up here (no scope flag
-		// was set). Default to global to match pre-fix behavior — strict
-		// inherit semantics under --no-install would be a broader change.
+		// Three getScopes branches produce nil Scopes:
+		//   - Inherit / Remove (no scope flag set) — fall back to global
+		//     to match pre-fix behavior; strict inherit semantics under
+		//     --no-install would be a broader change.
+		//   - --scope=<entity> — the entity is forwarded via
+		//     result.ScopeEntity to updateLockFile / SetInstallations;
+		//     an empty Scopes slice is the correct payload.
 		asset.Scopes = []lockfile.Scope{}
 	}
 	if err := updateLockFile(ctx, out, repo, asset, result.ScopeEntity); err != nil {

--- a/internal/commands/add_lockfile_test.go
+++ b/internal/commands/add_lockfile_test.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/vault"
+)
+
+// spyVault records SetInstallations / InheritInstallations calls so unit
+// tests can assert on the (asset, scopeEntity) pair that writeLockFileForNoInstall
+// threads through. All other Vault methods are unimplemented — the embedded
+// nil-interface deliberately panics if anything else is called.
+type spyVault struct {
+	vault.Vault
+	setCalls       []spySetCall
+	inheritCalls   []*lockfile.Asset
+	setShouldError error
+}
+
+type spySetCall struct {
+	asset       *lockfile.Asset
+	scopeEntity string
+}
+
+func (s *spyVault) SetInstallations(_ context.Context, asset *lockfile.Asset, scopeEntity string) error {
+	if s.setShouldError != nil {
+		return s.setShouldError
+	}
+	s.setCalls = append(s.setCalls, spySetCall{asset: asset, scopeEntity: scopeEntity})
+	return nil
+}
+
+func (s *spyVault) InheritInstallations(_ context.Context, asset *lockfile.Asset) error {
+	s.inheritCalls = append(s.inheritCalls, asset)
+	return nil
+}
+
+// TestWriteLockFileForNoInstall covers the regression-prone code paths in
+// writeLockFileForNoInstall that cannot be reached through the integration
+// test framework (the version prompt blocks plain --no-install on stdin),
+// and that the path vault flattens out (path vaults ignore scopeEntity, so
+// integration assertions can't distinguish "forwarded" from "silently
+// dropped").
+func TestWriteLockFileForNoInstall(t *testing.T) {
+	t.Run("forwards --scope=<entity> to SetInstallations", func(t *testing.T) {
+		// Pre-fix this branch was a hardcoded "" passed to updateLockFile;
+		// --no-install --scope=personal silently dropped the entity.
+		spy := &spyVault{}
+		out := &outputHelper{}
+		asset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0"}
+		opts := addOptions{NoInstall: true, Scope: "personal"}
+
+		if err := writeLockFileForNoInstall(context.Background(), out, spy, asset, opts); err != nil {
+			t.Fatalf("writeLockFileForNoInstall: %v", err)
+		}
+
+		if len(spy.setCalls) != 1 {
+			t.Fatalf("SetInstallations calls = %d, want 1", len(spy.setCalls))
+		}
+		if spy.setCalls[0].scopeEntity != "personal" {
+			t.Errorf("scopeEntity = %q, want %q (entity dropped)", spy.setCalls[0].scopeEntity, "personal")
+		}
+		// The empty Scopes payload is correct alongside ScopeEntity —
+		// vault entity routes the install, not the Scopes slice.
+		if len(spy.setCalls[0].asset.Scopes) != 0 {
+			t.Errorf("Scopes = %v, want empty slice (entity routes via scopeEntity)", spy.setCalls[0].asset.Scopes)
+		}
+	})
+
+	t.Run("plain --no-install (Remove branch) falls back to global", func(t *testing.T) {
+		// --no-install with no --yes and no scope flag puts getScopes()
+		// in the Remove branch, which the helper deliberately treats as
+		// global. Locks in the explicit fallback so a future change to
+		// Remove semantics doesn't silently regress this path.
+		spy := &spyVault{}
+		out := &outputHelper{}
+		asset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0"}
+		opts := addOptions{NoInstall: true}
+
+		if err := writeLockFileForNoInstall(context.Background(), out, spy, asset, opts); err != nil {
+			t.Fatalf("writeLockFileForNoInstall: %v", err)
+		}
+
+		if len(spy.setCalls) != 1 {
+			t.Fatalf("SetInstallations calls = %d, want 1", len(spy.setCalls))
+		}
+		if spy.setCalls[0].scopeEntity != "" {
+			t.Errorf("scopeEntity = %q, want \"\" (no entity flag)", spy.setCalls[0].scopeEntity)
+		}
+		// Global is represented by an empty (but non-nil) Scopes slice.
+		if spy.setCalls[0].asset.Scopes == nil {
+			t.Errorf("Scopes = nil, want empty slice (Remove fallback should produce global)")
+		}
+		if len(spy.setCalls[0].asset.Scopes) != 0 {
+			t.Errorf("Scopes = %v, want empty slice (global)", spy.setCalls[0].asset.Scopes)
+		}
+	})
+
+	t.Run("--yes --no-install (Inherit branch) falls back to global", func(t *testing.T) {
+		// Same fallback as Remove, different getScopes branch.
+		spy := &spyVault{}
+		out := &outputHelper{}
+		asset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0"}
+		opts := addOptions{NoInstall: true, Yes: true}
+
+		if err := writeLockFileForNoInstall(context.Background(), out, spy, asset, opts); err != nil {
+			t.Fatalf("writeLockFileForNoInstall: %v", err)
+		}
+
+		if len(spy.setCalls) != 1 {
+			t.Fatalf("SetInstallations calls = %d, want 1", len(spy.setCalls))
+		}
+		if spy.setCalls[0].asset.Scopes == nil || len(spy.setCalls[0].asset.Scopes) != 0 {
+			t.Errorf("Scopes = %v, want empty slice (global)", spy.setCalls[0].asset.Scopes)
+		}
+	})
+
+	t.Run("--no-install --scope-repo writes the repo scope", func(t *testing.T) {
+		spy := &spyVault{}
+		out := &outputHelper{}
+		asset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0"}
+		opts := addOptions{NoInstall: true, ScopeRepos: []string{"git@github.com:org/repo.git"}}
+
+		if err := writeLockFileForNoInstall(context.Background(), out, spy, asset, opts); err != nil {
+			t.Fatalf("writeLockFileForNoInstall: %v", err)
+		}
+
+		if len(spy.setCalls) != 1 {
+			t.Fatalf("SetInstallations calls = %d, want 1", len(spy.setCalls))
+		}
+		got := spy.setCalls[0].asset.Scopes
+		if len(got) != 1 {
+			t.Fatalf("Scopes = %v, want 1 scope", got)
+		}
+		if got[0].Repo != "git@github.com:org/repo.git" {
+			t.Errorf("Scopes[0].Repo = %q, want %q", got[0].Repo, "git@github.com:org/repo.git")
+		}
+	})
+}

--- a/internal/commands/integration_add_noninteractive_test.go
+++ b/internal/commands/integration_add_noninteractive_test.go
@@ -312,32 +312,6 @@ prompt-file = "SKILL.md"
 		}
 	})
 
-	t.Run("add with --no-install --scope=<entity> forwards entity (SK-452)", func(t *testing.T) {
-		// Pre-fix, --no-install passed "" as scopeEntity, silently dropping
-		// --scope=personal alongside the repo-scope flags. The helper now
-		// forwards result.ScopeEntity. Path vaults ignore the entity and
-		// produce a global asset (mirroring the existing --yes --scope test
-		// at line ~212), which is what we assert here — the point is that
-		// the call succeeds and produces a valid lock entry rather than
-		// erroring or silently dropping the flag.
-		env.ResetVaultAssets(vaultDir)
-
-		addCmd := NewAddCommand()
-		addCmd.SetArgs([]string{sourceDir, "--yes", "--no-install", "--scope", "personal"})
-
-		if err := addCmd.Execute(); err != nil {
-			t.Fatalf("Failed to add skill: %v", err)
-		}
-
-		lf, _ := env.ReadVaultAssets(vaultDir)
-		if len(lf.Assets) == 0 {
-			t.Fatal("Expected at least one asset in lock file")
-		}
-		if !lf.Assets[0].IsGlobal() {
-			t.Errorf("path vault should ignore scope entity and produce global asset, got %d scopes", len(lf.Assets[0].Scopes))
-		}
-	})
-
 	t.Run("add with --no-install --scope-repo path fragment (SK-452)", func(t *testing.T) {
 		env.ResetVaultAssets(vaultDir)
 

--- a/internal/commands/integration_add_noninteractive_test.go
+++ b/internal/commands/integration_add_noninteractive_test.go
@@ -264,6 +264,81 @@ prompt-file = "SKILL.md"
 		}
 	})
 
+	t.Run("add with --no-install --scope-repo honors the scope (SK-452)", func(t *testing.T) {
+		// Regression: --no-install was hardcoding global scope and silently
+		// dropping --scope-repo. Batch flows ("sx add ... --no-install
+		// --scope-repo X" in a loop, then a single sx install) need the
+		// scope to land in the lock file so the install fan-out routes the
+		// asset correctly.
+		env.ResetVaultAssets(vaultDir)
+
+		addCmd := NewAddCommand()
+		addCmd.SetArgs([]string{sourceDir, "--yes", "--no-install",
+			"--scope-repo", "git@github.com:org/consumer-project.git"})
+
+		if err := addCmd.Execute(); err != nil {
+			t.Fatalf("Failed to add skill: %v", err)
+		}
+
+		lf, _ := env.ReadVaultAssets(vaultDir)
+		if len(lf.Assets) == 0 {
+			t.Fatal("Expected at least one asset in lock file")
+		}
+		asset := lf.Assets[0]
+		if len(asset.Scopes) != 1 {
+			t.Fatalf("Expected 1 scope, got %d (--scope-repo was dropped)", len(asset.Scopes))
+		}
+		if asset.Scopes[0].Repo != "git@github.com:org/consumer-project.git" {
+			t.Errorf("Expected repo 'git@github.com:org/consumer-project.git', got %q", asset.Scopes[0].Repo)
+		}
+	})
+
+	t.Run("add with --no-install --scope-global stays global (SK-452 baseline)", func(t *testing.T) {
+		env.ResetVaultAssets(vaultDir)
+
+		addCmd := NewAddCommand()
+		addCmd.SetArgs([]string{sourceDir, "--yes", "--no-install", "--scope-global"})
+
+		if err := addCmd.Execute(); err != nil {
+			t.Fatalf("Failed to add skill: %v", err)
+		}
+
+		lf, _ := env.ReadVaultAssets(vaultDir)
+		if len(lf.Assets) == 0 {
+			t.Fatal("Expected at least one asset in lock file")
+		}
+		if !lf.Assets[0].IsGlobal() {
+			t.Errorf("Expected global scope, got %d scopes", len(lf.Assets[0].Scopes))
+		}
+	})
+
+	t.Run("add with --no-install --scope-repo path fragment (SK-452)", func(t *testing.T) {
+		env.ResetVaultAssets(vaultDir)
+
+		addCmd := NewAddCommand()
+		addCmd.SetArgs([]string{sourceDir, "--yes", "--no-install",
+			"--scope-repo", "git@github.com:org/repo.git#services/api"})
+
+		if err := addCmd.Execute(); err != nil {
+			t.Fatalf("Failed to add skill: %v", err)
+		}
+
+		lf, _ := env.ReadVaultAssets(vaultDir)
+		if len(lf.Assets) == 0 {
+			t.Fatal("Expected at least one asset in lock file")
+		}
+		asset := lf.Assets[0]
+		if len(asset.Scopes) != 1 {
+			t.Fatalf("Expected 1 scope, got %d", len(asset.Scopes))
+		}
+		if asset.Scopes[0].Repo != "git@github.com:org/repo.git" {
+			t.Errorf("Expected repo URL, got %q", asset.Scopes[0].Repo)
+		}
+		if len(asset.Scopes[0].Paths) != 1 || asset.Scopes[0].Paths[0] != "services/api" {
+			t.Errorf("Expected paths [services/api], got %v", asset.Scopes[0].Paths)
+		}
+	})
+
 	t.Run("add with explicit --name and --type overrides", func(t *testing.T) {
 		// Clean up previous lock file and assets
 		env.ResetVaultAssets(vaultDir)

--- a/internal/commands/integration_add_noninteractive_test.go
+++ b/internal/commands/integration_add_noninteractive_test.go
@@ -312,6 +312,32 @@ prompt-file = "SKILL.md"
 		}
 	})
 
+	t.Run("add with --no-install --scope=<entity> forwards entity (SK-452)", func(t *testing.T) {
+		// Pre-fix, --no-install passed "" as scopeEntity, silently dropping
+		// --scope=personal alongside the repo-scope flags. The helper now
+		// forwards result.ScopeEntity. Path vaults ignore the entity and
+		// produce a global asset (mirroring the existing --yes --scope test
+		// at line ~212), which is what we assert here — the point is that
+		// the call succeeds and produces a valid lock entry rather than
+		// erroring or silently dropping the flag.
+		env.ResetVaultAssets(vaultDir)
+
+		addCmd := NewAddCommand()
+		addCmd.SetArgs([]string{sourceDir, "--yes", "--no-install", "--scope", "personal"})
+
+		if err := addCmd.Execute(); err != nil {
+			t.Fatalf("Failed to add skill: %v", err)
+		}
+
+		lf, _ := env.ReadVaultAssets(vaultDir)
+		if len(lf.Assets) == 0 {
+			t.Fatal("Expected at least one asset in lock file")
+		}
+		if !lf.Assets[0].IsGlobal() {
+			t.Errorf("path vault should ignore scope entity and produce global asset, got %d scopes", len(lf.Assets[0].Scopes))
+		}
+	})
+
 	t.Run("add with --no-install --scope-repo path fragment (SK-452)", func(t *testing.T) {
 		env.ResetVaultAssets(vaultDir)
 


### PR DESCRIPTION
## Summary
- `--no-install` was hardcoding global scope and silently dropping `--scope-repo`, `--scope-global`, and `--scope=<entity>`, breaking batch flows that pin assets to a target repo before a single `sx install --repair --target=...` at the end.
- Route `--no-install` through `getScopes()` so explicit scope flags land in the lock file; default to global when no scope flag is set, preserving prior behavior for plain `--no-install` and `--no-install --yes`.
- The previous code passed `""` as `scopeEntity` to `updateLockFile`, so `--no-install --scope=personal` was silently dropped just like `--scope-repo`. The helper now forwards `result.ScopeEntity`.
- Extract `writeLockFileForNoInstall` to remove the duplicated block from `addNewAsset` and `handleIdenticalAsset`.

Closes #96.

Manually verified the reporter's batch use case in a Docker+tmux container: two `sx add … --no-install --scope-repo X` commands followed by `sx install` correctly install only when run from a clone of the targeted repo. Plain `--no-install` and `--no-install --scope-global` still produce global-scoped entries.

**Security implications of changes have been considered**