### PR TITLE
SK-487: Push git-vault usage events on a throttle

### DIFF
--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -116,7 +116,12 @@ func (c *Client) Pull(ctx context.Context, repoPath string) error {
 	start := time.Now()
 	log.Debug("git pull starting", "repoPath", repoPath)
 
-	cmd := execGitCommand(ctx, c.sshKeyPath, "pull", "--quiet")
+	// --no-rebase pins the reconciliation strategy to merge so newer
+	// git (≥2.27) doesn't refuse to pull divergent branches without an
+	// explicit pull.rebase / pull.ff setting. The merge path is also
+	// what lets gitattributes merge=union drivers run on conflicting
+	// append-only files like .sx/usage/*.jsonl.
+	cmd := execGitCommand(ctx, c.sshKeyPath, "pull", "--no-rebase", "--no-edit", "--quiet")
 	cmd.Dir = repoPath
 
 	output, err := cmd.CombinedOutput()

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -296,7 +296,18 @@ func (g *GitVault) cloneOrUpdate(ctx context.Context) error {
 		if err := g.clone(ctx); err != nil {
 			return err
 		}
+		if err := g.ensureUsageMergeAttributes(); err != nil {
+			return err
+		}
 	} else {
+		// Ensure the union-merge attribute for usage JSONL is in place
+		// BEFORE pulling: two writers appending to the same monthly
+		// file would otherwise produce a real merge conflict and stall
+		// the pull. The attribute lives in .git/info/attributes (per-
+		// clone, not committed) so it costs no churn on the vault.
+		if err := g.ensureUsageMergeAttributes(); err != nil {
+			return err
+		}
 		// Repository exists — but skip pull if it's empty (no commits yet)
 		empty, err := g.gitClient.IsEmpty(ctx, g.repoPath)
 		if err != nil {
@@ -311,6 +322,40 @@ func (g *GitVault) cloneOrUpdate(ctx context.Context) error {
 
 	g.hasSynced = true
 	return nil
+}
+
+// usageMergeAttributesLine is the gitattributes entry that tells git
+// to use the built-in `union` merge driver for usage JSONL files.
+// `union` concatenates both sides' lines on conflict — exactly the
+// right semantics for an append-only event log written concurrently
+// from multiple machines.
+const usageMergeAttributesLine = ".sx/usage/*.jsonl merge=union"
+
+// ensureUsageMergeAttributes appends usageMergeAttributesLine to the
+// clone's .git/info/attributes if it isn't already present. The file
+// is per-clone and not part of the commit graph, so this is safe to
+// run repeatedly and creates no churn on the vault.
+func (g *GitVault) ensureUsageMergeAttributes() error {
+	infoDir := filepath.Join(g.repoPath, ".git", "info")
+	if err := os.MkdirAll(infoDir, 0755); err != nil {
+		return err
+	}
+	attrPath := filepath.Join(infoDir, "attributes")
+	existing, err := os.ReadFile(attrPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if strings.Contains(string(existing), usageMergeAttributesLine) {
+		return nil
+	}
+	var buf bytes.Buffer
+	buf.Write(existing)
+	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(usageMergeAttributesLine)
+	buf.WriteByte('\n')
+	return utils.WriteFileAtomic(attrPath, buf.Bytes(), 0644)
 }
 
 // clone clones the Git repository

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -332,15 +332,45 @@ func (g *GitVault) usagePushSentinelPath() (string, error) {
 	return filepath.Join(cacheDir, "git-repos", filepath.Base(g.repoPath)+".usage-pushed"), nil
 }
 
-// maybePushUsage commits and pushes pending .sx/usage entries when
+// maybePushUsage commits any pending .sx/usage changes and, when
 // more than usagePushInterval has elapsed since the last successful
-// push. The caller must already hold the vault file lock and have
-// already synced the working tree via cloneOrUpdate.
+// push, pushes the local branch to the remote. The caller must
+// already hold the vault file lock and have already synced the
+// working tree via cloneOrUpdate.
+//
+// Committing is unconditional even inside the throttle window:
+// leaving uncommitted appends in the working tree across fresh
+// `report-usage` processes would wedge the next pull as soon as a
+// concurrent writer touched the same monthly file. Throttling only
+// the push keeps the tree clean while still bounding remote-history
+// volume.
 func (g *GitVault) maybePushUsage(ctx context.Context) error {
 	sentinel, err := g.usagePushSentinelPath()
 	if err != nil {
 		return err
 	}
+
+	// Stage only .sx/usage so a stale or partial write elsewhere in
+	// the working tree doesn't ride along with the usage commit.
+	usageDir := filepath.Join(g.repoPath, mgmt.UsageDirName)
+	if _, statErr := os.Stat(usageDir); !os.IsNotExist(statErr) {
+		if err := g.gitClient.Add(ctx, g.repoPath, mgmt.UsageDirName); err != nil {
+			return err
+		}
+		hasChanges, err := g.gitClient.HasStagedChanges(ctx, g.repoPath)
+		if err != nil {
+			return err
+		}
+		if hasChanges {
+			if err := g.gitClient.Commit(ctx, g.repoPath, "Record usage events"); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Throttle only the push. Any local commits made above stay in
+	// place; pushWithRebaseRetry will batch them on the next call
+	// past the throttle window.
 	if info, statErr := os.Stat(sentinel); statErr == nil {
 		if time.Since(info.ModTime()) < usagePushInterval {
 			return nil
@@ -349,27 +379,6 @@ func (g *GitVault) maybePushUsage(ctx context.Context) error {
 		return statErr
 	}
 
-	// Stage only .sx/usage so a stale or partial write elsewhere in
-	// the working tree doesn't ride along with the usage commit.
-	usageDir := filepath.Join(g.repoPath, mgmt.UsageDirName)
-	if _, statErr := os.Stat(usageDir); os.IsNotExist(statErr) {
-		return touchSentinel(sentinel)
-	}
-	if err := g.gitClient.Add(ctx, g.repoPath, mgmt.UsageDirName); err != nil {
-		return err
-	}
-
-	hasChanges, err := g.gitClient.HasStagedChanges(ctx, g.repoPath)
-	if err != nil {
-		return err
-	}
-	if !hasChanges {
-		return touchSentinel(sentinel)
-	}
-
-	if err := g.gitClient.Commit(ctx, g.repoPath, "Record usage events"); err != nil {
-		return err
-	}
 	if err := g.pushWithRebaseRetry(ctx); err != nil {
 		return err
 	}

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -10,10 +10,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sleuth-io/sx/internal/cache"
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
 )
+
+// usagePushInterval is the minimum gap between successive
+// commit-and-push cycles for usage events. Picked to balance
+// freshness against git history volume — at one hour, even an
+// always-on user produces at most ~24 usage commits per day.
+var usagePushInterval = time.Hour
 
 // runInVaultTx is the git vault's transactional wrapper for management
 // mutations. Contract:
@@ -255,14 +262,22 @@ func (g *GitVault) ClearAssetInstallations(ctx context.Context, assetName string
 	})
 }
 
-// RecordUsageEvents appends usage events to the local JSONL log without
-// committing or pushing. Under active use this can run hundreds of times
-// per hour, and a commit-per-call would spam the git history and turn a
-// background observation channel into a noisy multi-writer workload. The
-// next management mutation (team, install, etc.) runs runInVaultTx,
-// which sweeps .sx/ into its commit and picks up any queued usage files
-// on the way through. Queries on the same machine see the events
-// immediately because GetUsageStats reads the local working tree.
+// RecordUsageEvents appends usage events to the local JSONL log and,
+// at most once per usagePushInterval, commits and pushes the queued
+// .sx/usage files to the remote.
+//
+// Under active use this can run hundreds of times per hour, and a
+// commit-per-call would spam the git history and turn a background
+// observation channel into a noisy multi-writer workload. Originally
+// the design relied on the next management mutation (team, install,
+// etc.) running runInVaultTx to sweep .sx/ into its commit, but
+// users who only consume assets never trigger such a mutation, so
+// their usage events would accumulate locally and never reach the
+// remote. Throttled push closes that gap without per-call spam.
+//
+// Queries on the same machine see events immediately because
+// GetUsageStats reads the local working tree regardless of push
+// state.
 func (g *GitVault) RecordUsageEvents(ctx context.Context, events []mgmt.UsageEvent) error {
 	if len(events) == 0 {
 		return nil
@@ -288,7 +303,97 @@ func (g *GitVault) RecordUsageEvents(ctx context.Context, events []mgmt.UsageEve
 	if err != nil {
 		return err
 	}
-	return commonRecordUsageEvents(g.repoPath, actor, events)
+	if err := commonRecordUsageEvents(g.repoPath, actor, events); err != nil {
+		return err
+	}
+
+	if err := g.maybePushUsage(ctx); err != nil {
+		// Push failures shouldn't drop the events — they remain on
+		// disk and will be retried on the next call. Log and return
+		// nil so the hook caller doesn't error out.
+		logger.Get().Warn("usage push failed; events remain queued locally",
+			"error", err,
+			"repo_path", g.repoPath)
+	}
+	return nil
+}
+
+// usagePushSentinelPath returns the path of the per-clone marker
+// whose mtime records the last successful usage push. The sentinel
+// lives under the cache dir (not the working tree) so it isn't
+// accidentally swept into a runInVaultTx commit and propagated to
+// other clones.
+func (g *GitVault) usagePushSentinelPath() (string, error) {
+	cacheDir, err := cache.GetCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, "git-repos", filepath.Base(g.repoPath)+".usage-pushed"), nil
+}
+
+// maybePushUsage commits and pushes pending .sx/usage entries when
+// more than usagePushInterval has elapsed since the last successful
+// push. The caller must already hold the vault file lock.
+func (g *GitVault) maybePushUsage(ctx context.Context) error {
+	sentinel, err := g.usagePushSentinelPath()
+	if err != nil {
+		return err
+	}
+	if info, statErr := os.Stat(sentinel); statErr == nil {
+		if time.Since(info.ModTime()) < usagePushInterval {
+			return nil
+		}
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+
+	if err := g.cloneOrUpdate(ctx); err != nil {
+		return fmt.Errorf("failed to clone/update repository: %w", err)
+	}
+
+	// Stage only .sx/usage so a stale or partial write elsewhere in
+	// the working tree doesn't ride along with the usage commit.
+	usageDir := filepath.Join(g.repoPath, mgmt.UsageDirName)
+	if _, statErr := os.Stat(usageDir); os.IsNotExist(statErr) {
+		return touchSentinel(sentinel)
+	}
+	if err := g.gitClient.Add(ctx, g.repoPath, mgmt.UsageDirName); err != nil {
+		return err
+	}
+
+	hasChanges, err := g.gitClient.HasStagedChanges(ctx, g.repoPath)
+	if err != nil {
+		return err
+	}
+	if !hasChanges {
+		return touchSentinel(sentinel)
+	}
+
+	if err := g.gitClient.Commit(ctx, g.repoPath, "Record usage events"); err != nil {
+		return err
+	}
+	if err := g.pushWithRebaseRetry(ctx); err != nil {
+		return err
+	}
+	return touchSentinel(sentinel)
+}
+
+// touchSentinel updates (or creates) the sentinel file with the
+// current mtime. Failures are returned to the caller so a flaky
+// filesystem doesn't silently degrade us into push-on-every-call.
+func touchSentinel(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	now := time.Now()
+	if err := os.Chtimes(path, now, now); err == nil {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
 }
 
 func (g *GitVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (*mgmt.UsageSummary, error) {

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -288,13 +288,14 @@ func (g *GitVault) RecordUsageEvents(ctx context.Context, events []mgmt.UsageEve
 	}
 	defer func() { _ = fileLock.Unlock() }()
 
-	// Ensure the working tree exists before appending; if it doesn't,
-	// fall through to a full tx so the first-ever event still gets
-	// written and pushed.
-	if _, statErr := os.Stat(g.repoPath); statErr != nil {
-		if err := g.cloneOrUpdate(ctx); err != nil {
-			return fmt.Errorf("failed to clone/update repository: %w", err)
-		}
+	// Sync to remote BEFORE dirtying the working tree. If we appended
+	// first and pulled later, a remote commit touching the same monthly
+	// JSONL would make `git pull` refuse the merge ("local changes
+	// would be overwritten") and pushes would stall — under multi-
+	// writer contention this is the common case, not the edge case.
+	// This matches runInVaultTx's clone-then-mutate ordering.
+	if err := g.cloneOrUpdate(ctx); err != nil {
+		return fmt.Errorf("failed to clone/update repository: %w", err)
 	}
 	if err := ensureSxDir(g.repoPath); err != nil {
 		return err
@@ -333,7 +334,8 @@ func (g *GitVault) usagePushSentinelPath() (string, error) {
 
 // maybePushUsage commits and pushes pending .sx/usage entries when
 // more than usagePushInterval has elapsed since the last successful
-// push. The caller must already hold the vault file lock.
+// push. The caller must already hold the vault file lock and have
+// already synced the working tree via cloneOrUpdate.
 func (g *GitVault) maybePushUsage(ctx context.Context) error {
 	sentinel, err := g.usagePushSentinelPath()
 	if err != nil {
@@ -345,10 +347,6 @@ func (g *GitVault) maybePushUsage(ctx context.Context) error {
 		}
 	} else if !os.IsNotExist(statErr) {
 		return statErr
-	}
-
-	if err := g.cloneOrUpdate(ctx); err != nil {
-		return fmt.Errorf("failed to clone/update repository: %w", err)
 	}
 
 	// Stage only .sx/usage so a stale or partial write elsewhere in
@@ -379,21 +377,23 @@ func (g *GitVault) maybePushUsage(ctx context.Context) error {
 }
 
 // touchSentinel updates (or creates) the sentinel file with the
-// current mtime. Failures are returned to the caller so a flaky
-// filesystem doesn't silently degrade us into push-on-every-call.
+// current mtime. Always creates-then-Chtimes so a transient Chtimes
+// failure on an existing file isn't masked by a successful OpenFile —
+// a stale mtime would expire the throttle on every subsequent call.
+// Errors are returned to the caller.
 func touchSentinel(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
-	}
-	now := time.Now()
-	if err := os.Chtimes(path, now, now); err == nil {
-		return nil
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
-	return f.Close()
+	if err := f.Close(); err != nil {
+		return err
+	}
+	now := time.Now()
+	return os.Chtimes(path, now, now)
 }
 
 func (g *GitVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (*mgmt.UsageSummary, error) {

--- a/internal/vault/gitrepo_usage_e2e_test.go
+++ b/internal/vault/gitrepo_usage_e2e_test.go
@@ -1,0 +1,166 @@
+package vault
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sleuth-io/sx/internal/mgmt"
+)
+
+// TestGitVault_RecordUsageEvents_PushesToRemote covers the regression
+// reported when usage events were appended locally but never made it
+// to the vault remote. It seeds a bare git repo as the "remote",
+// records usage events through GitVault, and asserts that the events
+// land in a pushed commit on the bare repo. Then it records again
+// immediately and asserts the throttle suppresses the second push,
+// and finally rewinds the sentinel mtime to confirm the next call
+// after the throttle window does push.
+func TestGitVault_RecordUsageEvents_PushesToRemote(t *testing.T) {
+	mgmt.ResetActorCache()
+
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	remoteDir := filepath.Join(t.TempDir(), "vault.git")
+	gitRun(t, "", "init", "--bare", "-b", "main", remoteDir)
+
+	// Seed an initial commit so cloneOrUpdate has something to pull.
+	seedDir := filepath.Join(t.TempDir(), "seed")
+	gitRun(t, "", "init", "-b", "main", seedDir)
+	gitRun(t, seedDir, "config", "user.email", "seed@example.com")
+	gitRun(t, seedDir, "config", "user.name", "Seed")
+	if err := os.WriteFile(filepath.Join(seedDir, "README.md"), []byte("seed\n"), 0644); err != nil {
+		t.Fatalf("write seed README: %v", err)
+	}
+	gitRun(t, seedDir, "add", ".")
+	gitRun(t, seedDir, "commit", "-m", "seed")
+	gitRun(t, seedDir, "remote", "add", "origin", remoteDir)
+	gitRun(t, seedDir, "push", "origin", "main")
+
+	repoURL := "file://" + remoteDir
+	v, err := NewGitVault(repoURL)
+	if err != nil {
+		t.Fatalf("NewGitVault: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Force the initial clone so we can pin git identity inside it
+	// before the actor lookup runs.
+	if _, _, _, err := v.GetLockFile(ctx, ""); err != nil {
+		t.Fatalf("GetLockFile (forces clone): %v", err)
+	}
+	gitRun(t, v.repoPath, "config", "user.email", "alice@example.com")
+	gitRun(t, v.repoPath, "config", "user.name", "Alice")
+
+	// 1. First record-usage call should push to the remote.
+	events := []mgmt.UsageEvent{
+		{Actor: "alice@example.com", AssetName: "my-skill", AssetVersion: "1.0.0", AssetType: "skill"},
+	}
+	if err := v.RecordUsageEvents(ctx, events); err != nil {
+		t.Fatalf("RecordUsageEvents (first): %v", err)
+	}
+
+	if !remoteHasUsageCommit(t, remoteDir) {
+		t.Fatal("expected remote to have a usage commit after first RecordUsageEvents")
+	}
+	commitsAfterFirst := remoteCommitCount(t, remoteDir)
+
+	// 2. A second call inside the throttle window must NOT produce a
+	//    new commit on the remote.
+	events2 := []mgmt.UsageEvent{
+		{Actor: "alice@example.com", AssetName: "my-skill", AssetVersion: "1.0.0", AssetType: "skill"},
+	}
+	if err := v.RecordUsageEvents(ctx, events2); err != nil {
+		t.Fatalf("RecordUsageEvents (throttled): %v", err)
+	}
+	if got := remoteCommitCount(t, remoteDir); got != commitsAfterFirst {
+		t.Fatalf("expected throttled call to not push; commits before=%d after=%d",
+			commitsAfterFirst, got)
+	}
+
+	// 3. Rewind the sentinel mtime past the throttle window — next
+	//    call should push again.
+	sentinel, err := v.usagePushSentinelPath()
+	if err != nil {
+		t.Fatalf("usagePushSentinelPath: %v", err)
+	}
+	old := time.Now().Add(-2 * usagePushInterval)
+	if err := os.Chtimes(sentinel, old, old); err != nil {
+		t.Fatalf("rewind sentinel mtime: %v", err)
+	}
+
+	events3 := []mgmt.UsageEvent{
+		{Actor: "alice@example.com", AssetName: "other-skill", AssetVersion: "1.0.0", AssetType: "skill"},
+	}
+	if err := v.RecordUsageEvents(ctx, events3); err != nil {
+		t.Fatalf("RecordUsageEvents (after window): %v", err)
+	}
+	if got := remoteCommitCount(t, remoteDir); got <= commitsAfterFirst {
+		t.Fatalf("expected post-throttle call to push; commits before=%d after=%d",
+			commitsAfterFirst, got)
+	}
+
+	// Sanity: cache dir is the one we set, so the sentinel lives there.
+	if !strings.HasPrefix(sentinel, cacheDir) {
+		t.Fatalf("sentinel %q expected to live under cache dir %q", sentinel, cacheDir)
+	}
+	// And it's not under the working tree.
+	if strings.HasPrefix(sentinel, v.repoPath+string(os.PathSeparator)) {
+		t.Fatalf("sentinel %q must not live inside the working tree", sentinel)
+	}
+}
+
+// remoteHasUsageCommit returns true when the remote bare repo contains
+// a commit whose subject matches the pusher's "Record usage events"
+// message.
+func remoteHasUsageCommit(t *testing.T, bareDir string) bool {
+	t.Helper()
+	out := gitOut(t, bareDir, "log", "--pretty=%s")
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.TrimSpace(line) == "Record usage events" {
+			return true
+		}
+	}
+	return false
+}
+
+func remoteCommitCount(t *testing.T, bareDir string) int {
+	t.Helper()
+	out := strings.TrimSpace(gitOut(t, bareDir, "rev-list", "--count", "HEAD"))
+	n := 0
+	for _, c := range out {
+		if c < '0' || c > '9' {
+			t.Fatalf("unexpected rev-list output %q", out)
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}

--- a/internal/vault/gitrepo_usage_e2e_test.go
+++ b/internal/vault/gitrepo_usage_e2e_test.go
@@ -215,6 +215,153 @@ func TestGitVault_RecordUsageEvents_ConcurrentWriterRemoteAhead(t *testing.T) {
 	}
 }
 
+// TestGitVault_RecordUsageEvents_ThrottledThenConcurrentWriter is a
+// regression test for the steady-state production scenario flagged
+// in PR review: under multi-writer load each `report-usage` is a
+// fresh process, so a previous throttled call must NOT leave the
+// working tree dirty. Sequence:
+//
+//  1. Record (push) — sentinel set; tree clean afterwards.
+//  2. Record (throttled, fresh process) — commit must still happen
+//     so the tree stays clean; only the push is suppressed.
+//  3. Concurrent writer pushes a commit touching the same monthly
+//     file.
+//  4. Record again (still fresh process, sentinel rewound past the
+//     window) — pull must succeed against a clean tree, the queued
+//     local commits must merge with the concurrent writer's, and
+//     the final push must land.
+//
+// Pre-fix maybePushUsage skipped the commit when throttled, leaving
+// .sx/usage/YYYY-MM.jsonl dirty across processes. Step 4's pull
+// would then fail with "local changes would be overwritten" and
+// pushes would stall indefinitely.
+func TestGitVault_RecordUsageEvents_ThrottledThenConcurrentWriter(t *testing.T) {
+	mgmt.ResetActorCache()
+
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	remoteDir := filepath.Join(t.TempDir(), "vault.git")
+	gitRun(t, "", "init", "--bare", "-b", "main", remoteDir)
+
+	monthFile := time.Now().UTC().Format("2006-01") + ".jsonl"
+	monthRel := filepath.Join(".sx", "usage", monthFile)
+
+	// Initial seed so the remote has a main branch to pull from.
+	seedDir := filepath.Join(t.TempDir(), "seed")
+	gitRun(t, "", "init", "-b", "main", seedDir)
+	gitRun(t, seedDir, "config", "user.email", "seed@example.com")
+	gitRun(t, seedDir, "config", "user.name", "Seed")
+	if err := os.WriteFile(filepath.Join(seedDir, "README.md"), []byte("seed\n"), 0644); err != nil {
+		t.Fatalf("write seed README: %v", err)
+	}
+	gitRun(t, seedDir, "add", ".")
+	gitRun(t, seedDir, "commit", "-m", "seed")
+	gitRun(t, seedDir, "remote", "add", "origin", remoteDir)
+	gitRun(t, seedDir, "push", "origin", "main")
+
+	repoURL := "file://" + remoteDir
+	v, err := NewGitVault(repoURL)
+	if err != nil {
+		t.Fatalf("NewGitVault: %v", err)
+	}
+	ctx := context.Background()
+
+	if _, _, _, err := v.GetLockFile(ctx, ""); err != nil {
+		t.Fatalf("GetLockFile (priming clone): %v", err)
+	}
+	gitRun(t, v.repoPath, "config", "user.email", "alice@example.com")
+	gitRun(t, v.repoPath, "config", "user.name", "Alice")
+
+	// Step 1: first record-usage pushes and sets the sentinel.
+	if err := v.RecordUsageEvents(ctx, []mgmt.UsageEvent{
+		{Actor: "alice@example.com", AssetName: "skill-a", AssetVersion: "1.0.0", AssetType: "skill"},
+	}); err != nil {
+		t.Fatalf("RecordUsageEvents step 1: %v", err)
+	}
+	if dirty := workingTreeStatus(t, v.repoPath); dirty != "" {
+		t.Fatalf("expected working tree clean after step 1, got:\n%s", dirty)
+	}
+
+	// Step 2: simulate a fresh process inside the throttle window.
+	// Sentinel is fresh, so push is suppressed; the commit must still
+	// happen so the tree stays clean.
+	v.hasSynced = false
+	if err := v.RecordUsageEvents(ctx, []mgmt.UsageEvent{
+		{Actor: "alice@example.com", AssetName: "skill-b", AssetVersion: "1.0.0", AssetType: "skill"},
+	}); err != nil {
+		t.Fatalf("RecordUsageEvents step 2 (throttled): %v", err)
+	}
+	if dirty := workingTreeStatus(t, v.repoPath); dirty != "" {
+		t.Fatalf("expected working tree clean after throttled step 2 — dirty tree wedges future pulls, got:\n%s", dirty)
+	}
+
+	// Step 3: concurrent writer pushes a commit touching the same
+	// monthly file via the seed clone.
+	gitRun(t, seedDir, "pull", "origin", "main")
+	if err := os.MkdirAll(filepath.Join(seedDir, ".sx", "usage"), 0755); err != nil {
+		t.Fatalf("mkdir seed usage: %v", err)
+	}
+	concurrentLine := `{"ts":"2026-05-08T00:00:00Z","actor":"bob@example.com","asset_name":"skill-c","asset_version":"1.0.0","asset_type":"skill"}` + "\n"
+	f, err := os.OpenFile(filepath.Join(seedDir, monthRel), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open seed monthly file for append: %v", err)
+	}
+	if _, err := f.WriteString(concurrentLine); err != nil {
+		t.Fatalf("append concurrent line: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close seed monthly file: %v", err)
+	}
+	gitRun(t, seedDir, "add", monthRel)
+	gitRun(t, seedDir, "commit", "-m", "concurrent writer adds line")
+	gitRun(t, seedDir, "push", "origin", "main")
+
+	// Step 4: rewind the sentinel past the throttle window AND drop
+	// hasSynced so the next call must pull. Pre-fix the dirty tree
+	// from step 2 would now wedge cloneOrUpdate; post-fix the tree
+	// is clean and the pull succeeds.
+	sentinel, err := v.usagePushSentinelPath()
+	if err != nil {
+		t.Fatalf("usagePushSentinelPath: %v", err)
+	}
+	old := time.Now().Add(-2 * usagePushInterval)
+	if err := os.Chtimes(sentinel, old, old); err != nil {
+		t.Fatalf("rewind sentinel mtime: %v", err)
+	}
+	v.hasSynced = false
+
+	if err := v.RecordUsageEvents(ctx, []mgmt.UsageEvent{
+		{Actor: "alice@example.com", AssetName: "skill-d", AssetVersion: "1.0.0", AssetType: "skill"},
+	}); err != nil {
+		t.Fatalf("RecordUsageEvents step 4 (concurrent writer ahead): %v", err)
+	}
+
+	// Remote must contain the concurrent writer's line AND alice's
+	// queued events; otherwise we either lost a merge or never pushed.
+	finalRemote := gitOut(t, remoteDir, "show", "HEAD:"+monthRel)
+	if !strings.Contains(finalRemote, "bob@example.com") {
+		t.Fatalf("concurrent writer's line missing from remote after merge:\n%s", finalRemote)
+	}
+	for _, asset := range []string{"skill-a", "skill-b", "skill-d"} {
+		if !strings.Contains(finalRemote, asset) {
+			t.Fatalf("expected %s in pushed monthly file:\n%s", asset, finalRemote)
+		}
+	}
+}
+
+// workingTreeStatus returns the porcelain status of the .sx/usage
+// path inside the given working tree (empty when clean). The full
+// tree may legitimately contain other untracked files (e.g.
+// sx.toml synthesized by GetLockFile during priming) — those don't
+// wedge a pull. The bug we're guarding against is uncommitted
+// changes on the monthly JSONL specifically, since that's the file
+// concurrent writers also touch.
+func workingTreeStatus(t *testing.T, repoPath string) string {
+	t.Helper()
+	return strings.TrimSpace(gitOut(t, repoPath, "status", "--porcelain", "--", ".sx/usage"))
+}
+
 // remoteHasUsageCommit returns true when the remote bare repo contains
 // a commit whose subject matches the pusher's "Record usage events"
 // message.

--- a/internal/vault/gitrepo_usage_e2e_test.go
+++ b/internal/vault/gitrepo_usage_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -116,6 +117,104 @@ func TestGitVault_RecordUsageEvents_PushesToRemote(t *testing.T) {
 	}
 }
 
+// TestGitVault_RecordUsageEvents_ConcurrentWriterRemoteAhead is a
+// regression test for the multi-writer dirty-tree race. Setup:
+//   - Local clone is at commit A, which seeded the monthly usage file.
+//   - A concurrent writer pushes commit B touching the same monthly
+//     file before we run record-usage again.
+//   - We then call RecordUsageEvents in a fresh-process state
+//     (hasSynced=false) so a pull is required.
+//
+// Pre-fix ordering: append → pull. The pull would refuse to merge B
+// because our local monthly file is dirty, RecordUsageEvents would
+// log a warning and bail, the sentinel would never advance, and
+// pushes would stall on every subsequent call. Post-fix: pull → append
+// → push, so B merges into a clean tree and our append + push lands.
+func TestGitVault_RecordUsageEvents_ConcurrentWriterRemoteAhead(t *testing.T) {
+	mgmt.ResetActorCache()
+
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	remoteDir := filepath.Join(t.TempDir(), "vault.git")
+	gitRun(t, "", "init", "--bare", "-b", "main", remoteDir)
+
+	monthFile := time.Now().UTC().Format("2006-01") + ".jsonl"
+	monthRel := filepath.Join(".sx", "usage", monthFile)
+
+	// Seed commit A: monthly usage file with one entry.
+	seedDir := filepath.Join(t.TempDir(), "seed")
+	gitRun(t, "", "init", "-b", "main", seedDir)
+	gitRun(t, seedDir, "config", "user.email", "seed@example.com")
+	gitRun(t, seedDir, "config", "user.name", "Seed")
+	if err := os.MkdirAll(filepath.Join(seedDir, ".sx", "usage"), 0755); err != nil {
+		t.Fatalf("mkdir seed usage: %v", err)
+	}
+	seedLine := `{"ts":"2026-01-01T00:00:00Z","actor":"seed@example.com","asset_name":"seed-skill","asset_version":"1.0.0","asset_type":"skill"}` + "\n"
+	if err := os.WriteFile(filepath.Join(seedDir, monthRel), []byte(seedLine), 0644); err != nil {
+		t.Fatalf("write seed monthly file: %v", err)
+	}
+	gitRun(t, seedDir, "add", ".")
+	gitRun(t, seedDir, "commit", "-m", "seed monthly usage")
+	gitRun(t, seedDir, "remote", "add", "origin", remoteDir)
+	gitRun(t, seedDir, "push", "origin", "main")
+
+	repoURL := "file://" + remoteDir
+	v, err := NewGitVault(repoURL)
+	if err != nil {
+		t.Fatalf("NewGitVault: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Prime: clone the remote into our cache so we land at commit A.
+	if _, _, _, err := v.GetLockFile(ctx, ""); err != nil {
+		t.Fatalf("GetLockFile (priming clone): %v", err)
+	}
+	gitRun(t, v.repoPath, "config", "user.email", "alice@example.com")
+	gitRun(t, v.repoPath, "config", "user.name", "Alice")
+
+	// Concurrent-writer commit B: append another line to the same
+	// monthly file from the seed clone and push. After this push, our
+	// clone at v.repoPath is one commit behind on a file that
+	// record-usage is about to touch.
+	concurrentLine := `{"ts":"2026-01-02T00:00:00Z","actor":"bob@example.com","asset_name":"seed-skill","asset_version":"1.0.0","asset_type":"skill"}` + "\n"
+	f, err := os.OpenFile(filepath.Join(seedDir, monthRel), os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open seed monthly file for append: %v", err)
+	}
+	if _, err := f.WriteString(concurrentLine); err != nil {
+		t.Fatalf("append concurrent line: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close seed monthly file: %v", err)
+	}
+	gitRun(t, seedDir, "add", monthRel)
+	gitRun(t, seedDir, "commit", "-m", "concurrent writer adds line")
+	gitRun(t, seedDir, "push", "origin", "main")
+
+	// Fresh-process semantics: drop the sync latch so RecordUsageEvents
+	// must actually pull commit B.
+	v.hasSynced = false
+
+	events := []mgmt.UsageEvent{
+		{Actor: "alice@example.com", AssetName: "my-skill", AssetVersion: "1.0.0", AssetType: "skill"},
+	}
+	if err := v.RecordUsageEvents(ctx, events); err != nil {
+		t.Fatalf("RecordUsageEvents with concurrent writer: %v", err)
+	}
+
+	if !remoteHasUsageCommit(t, remoteDir) {
+		t.Fatal("expected remote to receive a usage commit when remote was ahead on monthly file")
+	}
+	// And the concurrent writer's line must still be present on the
+	// remote — i.e. we merged, not overwrote.
+	headFile := gitOut(t, remoteDir, "show", "HEAD~1:"+monthRel)
+	if !strings.Contains(headFile, "bob@example.com") {
+		t.Fatalf("expected concurrent writer's line preserved on remote; got %q", headFile)
+	}
+}
+
 // remoteHasUsageCommit returns true when the remote bare repo contains
 // a commit whose subject matches the pusher's "Record usage events"
 // message.
@@ -133,12 +232,9 @@ func remoteHasUsageCommit(t *testing.T, bareDir string) bool {
 func remoteCommitCount(t *testing.T, bareDir string) int {
 	t.Helper()
 	out := strings.TrimSpace(gitOut(t, bareDir, "rev-list", "--count", "HEAD"))
-	n := 0
-	for _, c := range out {
-		if c < '0' || c > '9' {
-			t.Fatalf("unexpected rev-list output %q", out)
-		}
-		n = n*10 + int(c-'0')
+	n, err := strconv.Atoi(out)
+	if err != nil {
+		t.Fatalf("unexpected rev-list output %q: %v", out, err)
 	}
 	return n
 }


### PR DESCRIPTION
## Summary
- A user reported their git vault was receiving no usage data despite active use. Root cause: `GitVault.RecordUsageEvents` appended events to `.sx/usage/YYYY-MM.jsonl` in the local clone but never committed or pushed them. The original design relied on the next `runInVaultTx` mutation (team/install) to sweep `.sx/` into a commit — users who only consume assets never trigger such a mutation, so usage data sat stranded locally.
- Fix: after appending, throttled commit-and-push of `.sx/usage` on a 1h cadence. Throttle marker is a sentinel file in the cache dir (kept out of the working tree so it doesn't propagate to other clones). Push errors are logged; events remain queued on disk for the next attempt.

## Test plan
- [x] `make prepush` clean (format, lint, tests, build)
- [x] New e2e test `TestGitVault_RecordUsageEvents_PushesToRemote` covers first-call push, throttle suppression inside the window, and re-push after the window
- [x] Existing `TestPathVault_*` tests still pass (path/sleuth paths unchanged)