### PR TITLE
SK-494: Loosen lock file validation

### DIFF
--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -142,6 +142,26 @@ func TestValidateLockFile(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "asset name with dots",
+			lockFile: &LockFile{
+				LockVersion: "1.0",
+				Version:     "abc",
+				CreatedBy:   "test",
+				Assets: []Asset{
+					{
+						Name:    "sx-sleuth-io-skills-repository-myagent.md",
+						Version: "1.0.0",
+						Type:    asset.TypeSkill,
+						SourceHTTP: &SourceHTTP{
+							URL:    "https://example.com/test.zip",
+							Hashes: map[string]string{"sha256": "abc"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "missing asset name",
 			lockFile: &LockFile{
 				LockVersion: "1.0",

--- a/internal/lockfile/validation.go
+++ b/internal/lockfile/validation.go
@@ -11,9 +11,6 @@ import (
 var (
 	// gitCommitSHARegex matches full 40-character Git commit SHAs
 	gitCommitSHARegex = regexp.MustCompile(`^[0-9a-f]{40}$`)
-
-	// nameRegex matches valid asset names (alphanumeric, dashes, underscores)
-	nameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 )
 
 // Validate validates the entire lock file
@@ -68,10 +65,6 @@ func (a *Asset) Validate() error {
 	// Validate required fields
 	if a.Name == "" {
 		return errors.New("name is required")
-	}
-
-	if !nameRegex.MatchString(a.Name) {
-		return errors.New("name must contain only alphanumeric characters, dashes, and underscores")
 	}
 
 	if a.Version == "" {

--- a/internal/metadata/validation.go
+++ b/internal/metadata/validation.go
@@ -35,9 +35,6 @@ func SortedValidClientIDs() []string {
 }
 
 var (
-	// nameRegex matches valid asset names (alphanumeric, dashes, underscores)
-	nameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
-
 	// Valid hook events (canonical AI client events)
 	validHookEvents = map[string]bool{
 		"session-start":         true,
@@ -142,10 +139,6 @@ func (a *Asset) Validate() error {
 	// Validate required fields
 	if a.Name == "" {
 		return errors.New("name is required")
-	}
-
-	if !nameRegex.MatchString(a.Name) {
-		return errors.New("name must contain only alphanumeric characters, dashes, and underscores")
 	}
 
 	if a.Version == "" {


### PR DESCRIPTION
no need to validate asset names.

The name is set by the server (or by whoever pushes to the vault). The client's job is to install it, not to have opinions about what characters belong in a name. The structural checks (required fields, valid semver, valid sources, no circular deps) catch actual corruption. The name regex was just an aesthetic constraint masquerading as validation.

If we ever need to restrict names, that belongs on the write path (publishing/sharing), not the read path (installing).