### PR TITLE
SK-497: Fix `sx uninstall` scope filtering and `--clients` flag for hooks

### DIFF
--- a/cmd/sx/main.go
+++ b/cmd/sx/main.go
@@ -30,6 +30,64 @@ func joinStrings(items []string, sep string) string {
 	return strings.Join(items, sep)
 }
 
+// colorizeFlags returns a template function that colors flag names in cobra's
+// FlagUsages output while leaving descriptions in the default color.
+// Each line looks like: "      --flag-name string   Description text"
+func colorizeFlags(render func(...string) string) func(string) string {
+	return func(flagUsages string) string {
+		var result strings.Builder
+		for i, line := range strings.Split(flagUsages, "\n") {
+			if i > 0 {
+				result.WriteByte('\n')
+			}
+			// Find where the description starts: two or more consecutive spaces
+			// after the flag+type portion. Flag lines have leading whitespace,
+			// then the flag (e.g. "-h, --help" or "    --all"), optionally
+			// followed by a type word like "string", then 2+ spaces before desc.
+			trimmed := strings.TrimLeft(line, " ")
+			if trimmed == "" || !strings.HasPrefix(trimmed, "-") {
+				result.WriteString(line)
+				continue
+			}
+
+			// Walk past the flag and optional type to find the description gap
+			leadingSpaces := len(line) - len(trimmed)
+			descIdx := -1
+			inGap := false
+			gapStart := 0
+			for j := leadingSpaces; j < len(line); j++ {
+				if line[j] == ' ' {
+					if !inGap {
+						inGap = true
+						gapStart = j
+					}
+					if j-gapStart >= 2 {
+						// Check there's actually content after the gap
+						rest := strings.TrimLeft(line[j:], " ")
+						if rest != "" {
+							descIdx = len(line) - len(rest)
+						}
+						break
+					}
+				} else {
+					inGap = false
+				}
+			}
+
+			if descIdx > 0 {
+				result.WriteString(line[:leadingSpaces])
+				result.WriteString(render(line[leadingSpaces:descIdx]))
+				result.WriteString(line[descIdx:])
+			} else {
+				// No description found, color the whole flag part
+				result.WriteString(line[:leadingSpaces])
+				result.WriteString(render(line[leadingSpaces:]))
+			}
+		}
+		return result.String()
+	}
+}
+
 func main() {
 	// Log command invocation with context
 	log := logger.Get()
@@ -112,6 +170,7 @@ Capture what your best AI users have learned and spread it to everyone automatic
 	cobra.AddTemplateFunc("muted", styles.Muted.Render)
 	cobra.AddTemplateFunc("header", styles.Header.Render)
 	cobra.AddTemplateFunc("join", joinStrings)
+	cobra.AddTemplateFunc("colorizeFlags", colorizeFlags(styles.Emphasis.Render))
 
 	rootCmd.SetHelpTemplate(`{{if .Long}}{{.Long}}{{else}}{{.Short}}{{end}}{{if .Version}}
 {{muted .Version}}{{end}}
@@ -133,10 +192,10 @@ Capture what your best AI users have learned and spread it to everyone automatic
   {{emphasis (rpad .Name .NamePadding)}} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 {{header "Flags:"}}
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces | colorizeFlags}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 {{header "Global Flags:"}}
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces | colorizeFlags}}{{end}}{{if .HasHelpSubCommands}}
 
 {{header "Additional help topics:"}}{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{emphasis (rpad .CommandPath .CommandPathPadding)}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -200,7 +200,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 		}
 	}
 
-	// Step 5: Display plan and confirm
+	// Step 6: Display plan and confirm
 	displayUninstallPlan(plan, styledOut)
 
 	if opts.All {
@@ -219,26 +219,26 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 		return nil
 	}
 
-	// Step 5: Execute uninstall
+	// Step 7: Execute uninstall
 	styledOut.Newline()
 	styledOut.Header("Uninstalling assets...")
 	results := executeUninstall(ctx, plan, opts, styledOut)
 
-	// Step 6: Update tracker
+	// Step 8: Update tracker
 	if err := updateTracker(results, plan, out); err != nil {
 		out.printfErr("Warning: failed to update tracker: %v\n", err)
 		logger.Get().Error("failed to update tracker", "error", err)
 	}
 
-	// Step 7: Regenerate client support
+	// Step 9: Regenerate client support
 	regenerateClientSupport(ctx, plan, results, out)
 
-	// Step 8: Uninstall system hooks if --all flag is passed
+	// Step 10: Uninstall system hooks if --all flag is passed
 	if opts.All {
 		uninstallSystemHooks(ctx, opts.ClientsFlag, styledOut)
 	}
 
-	// Step 9: Report results
+	// Step 11: Report results
 	reportResults(results, styledOut)
 
 	return nil
@@ -406,8 +406,8 @@ func filterUninstallPlanByScope(plan UninstallPlan, all bool) UninstallPlan {
 		return plan
 	}
 
-	// Outside a repo: no-op
-	if !plan.GitContext.IsRepo {
+	// Outside a repo (or no git context): no-op
+	if plan.GitContext == nil || !plan.GitContext.IsRepo {
 		plan.Assets = nil
 		return plan
 	}
@@ -702,20 +702,7 @@ func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui
 
 	// Filter to specified clients if --clients flag is set
 	if clientsFlag != "" {
-		wantedClients := make(map[string]bool)
-		for id := range strings.SplitSeq(clientsFlag, ",") {
-			id = strings.TrimSpace(id)
-			if id != "" {
-				wantedClients[id] = true
-			}
-		}
-		var filtered []clients.Client
-		for _, c := range installedClients {
-			if wantedClients[c.ID()] {
-				filtered = append(filtered, c)
-			}
-		}
-		installedClients = filtered
+		installedClients = filterClientsByFlag(installedClients, clientsFlag)
 	}
 
 	// Load config to get enabled bootstrap options

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -73,7 +73,7 @@ func NewUninstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Uninstall assets from the current repo or all scopes",
-		Long: uninstallLongHelp(),
+		Long:  uninstallLongHelp(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := UninstallOptions{
 				All:         all,
@@ -175,16 +175,23 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 	// Step 3: Build uninstall plan
 	plan := buildUninstallPlanFromTracker(lockFile, tracker, gitContext, trackingBase)
 
+	// Step 4: Filter plan by scope (without --all, only current repo's assets)
+	plan = filterUninstallPlanByScope(plan, opts.All)
+
 	if len(plan.Assets) == 0 {
 		// No assets to uninstall, but if --all is passed, still remove system hooks
 		if opts.All {
 			return handleAllFlagWithoutAssets(ctx, opts, styledOut)
 		}
-		styledOut.Info("No assets to uninstall")
+		if !gitContext.IsRepo {
+			styledOut.Info("Not in a repository. Use --all to uninstall from all scopes.")
+		} else {
+			styledOut.Info("No assets to uninstall in this repository")
+		}
 		return nil
 	}
 
-	// Step 4: Filter plan by client flag if provided
+	// Step 5: Filter plan by client flag if provided
 	if opts.ClientsFlag != "" {
 		plan = filterUninstallPlanByClients(plan, opts.ClientsFlag)
 		if len(plan.Assets) == 0 {
@@ -228,7 +235,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 
 	// Step 8: Uninstall system hooks if --all flag is passed
 	if opts.All {
-		uninstallSystemHooks(ctx, styledOut)
+		uninstallSystemHooks(ctx, opts.ClientsFlag, styledOut)
 	}
 
 	// Step 9: Report results
@@ -254,7 +261,7 @@ func handleAllFlagWithoutAssets(ctx context.Context, opts UninstallOptions, styl
 		return nil
 	}
 
-	uninstallSystemHooks(ctx, styledOut)
+	uninstallSystemHooks(ctx, opts.ClientsFlag, styledOut)
 	styledOut.Success("System hooks removed")
 	return nil
 }
@@ -387,6 +394,33 @@ func buildUninstallPlanFromTracker(lockFile *lockfile.LockFile, tracker *assets.
 		})
 	}
 
+	return plan
+}
+
+// filterUninstallPlanByScope filters the plan based on git context and --all flag.
+// Without --all: only repo-scoped assets matching the current repo (global assets are never included).
+// Outside a repo without --all: returns an empty plan (no-op).
+// With --all: returns all assets unfiltered.
+func filterUninstallPlanByScope(plan UninstallPlan, all bool) UninstallPlan {
+	if all {
+		return plan
+	}
+
+	// Outside a repo: no-op
+	if !plan.GitContext.IsRepo {
+		plan.Assets = nil
+		return plan
+	}
+
+	// Inside a repo: only assets matching this repo
+	repoURL := plan.GitContext.RepoURL
+	var filtered []AssetUninstallPlan
+	for _, a := range plan.Assets {
+		if !a.IsGlobal && a.Repository == repoURL {
+			filtered = append(filtered, a)
+		}
+	}
+	plan.Assets = filtered
 	return plan
 }
 
@@ -657,13 +691,32 @@ func confirmUninstall(styledOut *ui.Output) bool {
 	return response == "y" || response == "yes"
 }
 
-// uninstallSystemHooks removes system hooks from all installed clients
-func uninstallSystemHooks(ctx context.Context, styledOut *ui.Output) {
+// uninstallSystemHooks removes system hooks from installed clients.
+// If clientsFlag is non-empty, only hooks for those clients are removed.
+func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui.Output) {
 	styledOut.Newline()
 	styledOut.Header("Removing system hooks...")
 
 	registry := clients.Global()
 	installedClients := registry.DetectInstalled()
+
+	// Filter to specified clients if --clients flag is set
+	if clientsFlag != "" {
+		wantedClients := make(map[string]bool)
+		for id := range strings.SplitSeq(clientsFlag, ",") {
+			id = strings.TrimSpace(id)
+			if id != "" {
+				wantedClients[id] = true
+			}
+		}
+		var filtered []clients.Client
+		for _, c := range installedClients {
+			if wantedClients[c.ID()] {
+				filtered = append(filtered, c)
+			}
+		}
+		installedClients = filtered
+	}
 
 	// Load config to get enabled bootstrap options
 	mpc, _ := config.LoadMultiProfile()

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -22,8 +22,45 @@ import (
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/ui"
 	"github.com/sleuth-io/sx/internal/ui/components"
+	"github.com/sleuth-io/sx/internal/ui/theme"
 	vaultpkg "github.com/sleuth-io/sx/internal/vault"
 )
+
+func uninstallLongHelp() string {
+	s := theme.Current().Styles()
+	e := s.Emphasis.Render
+	m := s.Muted.Render
+
+	return `Uninstall removes installed assets based on where you run it:
+
+  ` + m("Inside a repo") + `: removes only that repo's assets (global assets are not touched)
+  ` + m("Outside a repo") + `: does nothing unless --all is passed
+
+Use ` + e("--all") + ` to remove assets from all scopes (global + all repositories) and
+also remove system hooks from all clients.
+
+Use ` + e("--clients") + ` to limit which clients are affected (applies to both asset
+removal and hook removal).
+
+Note: ` + e("--profile") + ` has no effect on uninstall. All installed assets are removed
+regardless of which profile originally installed them.
+
+` + s.Header.Render("Examples:") + `
+  ` + m("# Uninstall repo assets (must be inside a repo)") + `
+  ` + e("sx uninstall") + `
+
+  ` + m("# Uninstall everything (global + all repos) and remove hooks") + `
+  ` + e("sx uninstall --all") + `
+
+  ` + m("# Uninstall everything but only from specific clients") + `
+  ` + e("sx uninstall --all --clients claude-code,cursor") + `
+
+  ` + m("# Preview what would be uninstalled") + `
+  ` + e("sx uninstall --dry-run") + `
+
+  ` + m("# Skip confirmation prompt") + `
+  ` + e("sx uninstall --yes")
+}
 
 // NewUninstallCommand creates the uninstall command
 func NewUninstallCommand() *cobra.Command {
@@ -35,24 +72,8 @@ func NewUninstallCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
-		Short: "Uninstall all assets from the current scope or all scopes",
-		Long: `Uninstall removes all installed assets from the current scope (global, repository, or path).
-
-Examples:
-  # Uninstall from current scope (prompts for confirmation)
-  sx uninstall
-
-  # Uninstall from all scopes (global + all repositories)
-  sx uninstall --all
-
-  # Preview what would be uninstalled without making changes
-  sx uninstall --dry-run
-
-  # Skip confirmation prompt
-  sx uninstall --yes
-
-  # Uninstall from all scopes without confirmation
-  sx uninstall --all --yes`,
+		Short: "Uninstall assets from the current repo or all scopes",
+		Long: uninstallLongHelp(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := UninstallOptions{
 				All:         all,
@@ -65,7 +86,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().BoolVar(&all, "all", false, "Uninstall from all scopes (global + all repositories)")
+	cmd.Flags().BoolVar(&all, "all", false, "Uninstall from all scopes (global + all repositories) and remove system hooks")
 	cmd.Flags().BoolVar(&yes, "yes", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be uninstalled without removing")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose output")

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -708,9 +708,11 @@ func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui
 	// Load config to get enabled bootstrap options
 	mpc, _ := config.LoadMultiProfile()
 
-	// Get vault for its bootstrap options
-	cfg, _ := config.Load()
-	v, _ := vaultpkg.NewFromConfig(cfg)
+	// Get vault for its bootstrap options (guard against nil config)
+	var v vaultpkg.Vault
+	if cfg, err := config.Load(); err == nil {
+		v, _ = vaultpkg.NewFromConfig(cfg)
+	}
 
 	for _, client := range installedClients {
 		// Gather all options from vault and client

--- a/internal/commands/uninstall_test.go
+++ b/internal/commands/uninstall_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -8,8 +9,52 @@ import (
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/assets"
+	"github.com/sleuth-io/sx/internal/bootstrap"
+	"github.com/sleuth-io/sx/internal/clients"
 	"github.com/sleuth-io/sx/internal/gitutil"
+	"github.com/sleuth-io/sx/internal/lockfile"
 )
+
+// stubClient is a minimal clients.Client implementation for testing
+type stubClient struct {
+	id string
+}
+
+func (s *stubClient) ID() string          { return s.id }
+func (s *stubClient) DisplayName() string { return s.id }
+func (s *stubClient) IsInstalled() bool   { return true }
+func (s *stubClient) GetVersion() string  { return "" }
+func (s *stubClient) SupportsAssetType(asset.Type) bool {
+	return true
+}
+func (s *stubClient) InstallAssets(context.Context, clients.InstallRequest) (clients.InstallResponse, error) {
+	return clients.InstallResponse{}, nil
+}
+func (s *stubClient) UninstallAssets(context.Context, clients.UninstallRequest) (clients.UninstallResponse, error) {
+	return clients.UninstallResponse{}, nil
+}
+func (s *stubClient) ListAssets(context.Context, *clients.InstallScope) ([]clients.InstalledSkill, error) {
+	return nil, nil
+}
+func (s *stubClient) ReadSkill(context.Context, string, *clients.InstallScope) (*clients.SkillContent, error) {
+	return &clients.SkillContent{}, nil
+}
+func (s *stubClient) EnsureAssetSupport(context.Context, *clients.InstallScope) error { return nil }
+func (s *stubClient) GetBootstrapOptions(context.Context) []bootstrap.Option          { return nil }
+func (s *stubClient) GetBootstrapPath() string                                        { return "" }
+func (s *stubClient) InstallBootstrap(context.Context, []bootstrap.Option) error      { return nil }
+func (s *stubClient) UninstallBootstrap(context.Context, []bootstrap.Option) error    { return nil }
+func (s *stubClient) ShouldInstall(context.Context) (bool, error)                     { return true, nil }
+func (s *stubClient) VerifyAssets(context.Context, []*lockfile.Asset, *clients.InstallScope) []clients.VerifyResult {
+	return nil
+}
+func (s *stubClient) ScanInstalledAssets(context.Context, *clients.InstallScope) ([]clients.InstalledAsset, error) {
+	return nil, nil
+}
+func (s *stubClient) GetAssetPath(context.Context, string, asset.Type, *clients.InstallScope) (string, error) {
+	return "", nil
+}
+func (s *stubClient) RuleCapabilities() *clients.RuleCapabilities { return nil }
 
 func TestFilterUninstallPlanByScope(t *testing.T) {
 	// Shared tracker data: 2 global, 2 repo-A (one path-scoped), 1 repo-B
@@ -512,6 +557,68 @@ func TestUpdateTrackerPartialClientRemoval(t *testing.T) {
 			for key := range tt.expectedClients {
 				if !slices.Contains(tt.expectedRemoved, key) {
 					t.Errorf("expected asset %q not found in tracker", key)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterClientsByFlag(t *testing.T) {
+	allClients := []clients.Client{
+		&stubClient{id: "claude-code"},
+		&stubClient{id: "cursor"},
+		&stubClient{id: "gemini"},
+	}
+
+	tests := []struct {
+		name    string
+		flag    string
+		wantIDs []string
+	}{
+		{
+			name:    "single client",
+			flag:    "cursor",
+			wantIDs: []string{"cursor"},
+		},
+		{
+			name:    "multiple clients",
+			flag:    "claude-code,gemini",
+			wantIDs: []string{"claude-code", "gemini"},
+		},
+		{
+			name:    "with spaces",
+			flag:    "claude-code , cursor",
+			wantIDs: []string{"claude-code", "cursor"},
+		},
+		{
+			name:    "no match",
+			flag:    "unknown",
+			wantIDs: []string{},
+		},
+		{
+			name:    "all clients",
+			flag:    "claude-code,cursor,gemini",
+			wantIDs: []string{"claude-code", "cursor", "gemini"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterClientsByFlag(allClients, tt.flag)
+
+			gotIDs := make([]string, len(result))
+			for i, c := range result {
+				gotIDs[i] = c.ID()
+			}
+
+			if len(gotIDs) != len(tt.wantIDs) {
+				t.Errorf("got %d clients %v, want %d clients %v", len(gotIDs), gotIDs, len(tt.wantIDs), tt.wantIDs)
+				return
+			}
+
+			for i, id := range tt.wantIDs {
+				if gotIDs[i] != id {
+					t.Errorf("client[%d] = %q, want %q", i, gotIDs[i], id)
 				}
 			}
 		})

--- a/internal/commands/uninstall_test.go
+++ b/internal/commands/uninstall_test.go
@@ -8,7 +8,193 @@ import (
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/assets"
+	"github.com/sleuth-io/sx/internal/gitutil"
 )
+
+func TestFilterUninstallPlanByScope(t *testing.T) {
+	// Shared tracker data: 2 global, 2 repo-A (one path-scoped), 1 repo-B
+	allAssets := []AssetUninstallPlan{
+		{Name: "global-skill-1", Type: asset.TypeSkill, IsGlobal: true, Clients: []string{"claude-code"}},
+		{Name: "global-skill-2", Type: asset.TypeSkill, IsGlobal: true, Clients: []string{"claude-code", "cursor"}},
+		{Name: "repo-a-skill", Type: asset.TypeSkill, IsGlobal: false, Repository: "https://github.com/org/repo-a", Clients: []string{"claude-code"}},
+		{Name: "repo-a-path-skill", Type: asset.TypeSkill, IsGlobal: false, Repository: "https://github.com/org/repo-a", Path: "services/api", Clients: []string{"claude-code", "cursor"}},
+		{Name: "repo-b-skill", Type: asset.TypeSkill, IsGlobal: false, Repository: "https://github.com/org/repo-b", Clients: []string{"cursor"}},
+	}
+
+	tests := []struct {
+		name       string
+		gitContext *gitutil.GitContext
+		all        bool
+		wantNames  []string
+	}{
+		{
+			name:       "inside repo without --all: only that repo's assets",
+			gitContext: &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-a", RepoRoot: "/work/repo-a", RelativePath: "."},
+			all:        false,
+			wantNames:  []string{"repo-a-skill", "repo-a-path-skill"},
+		},
+		{
+			name:       "inside repo with --all: all assets",
+			gitContext: &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-a", RepoRoot: "/work/repo-a", RelativePath: "."},
+			all:        true,
+			wantNames:  []string{"global-skill-1", "global-skill-2", "repo-a-skill", "repo-a-path-skill", "repo-b-skill"},
+		},
+		{
+			name:       "outside repo without --all: no-op",
+			gitContext: &gitutil.GitContext{IsRepo: false},
+			all:        false,
+			wantNames:  []string{},
+		},
+		{
+			name:       "outside repo with --all: all assets",
+			gitContext: &gitutil.GitContext{IsRepo: false},
+			all:        true,
+			wantNames:  []string{"global-skill-1", "global-skill-2", "repo-a-skill", "repo-a-path-skill", "repo-b-skill"},
+		},
+		{
+			name:       "inside repo-b without --all: only repo-b assets",
+			gitContext: &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-b", RepoRoot: "/work/repo-b", RelativePath: "."},
+			all:        false,
+			wantNames:  []string{"repo-b-skill"},
+		},
+		{
+			name:       "inside unknown repo without --all: no matching assets",
+			gitContext: &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-c", RepoRoot: "/work/repo-c", RelativePath: "."},
+			all:        false,
+			wantNames:  []string{},
+		},
+		{
+			name:       "inside repo-a subdirectory without --all: still matches repo-a assets",
+			gitContext: &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-a", RepoRoot: "/work/repo-a", RelativePath: "services/api"},
+			all:        false,
+			wantNames:  []string{"repo-a-skill", "repo-a-path-skill"},
+		},
+		{
+			name:       "inside unknown repo with --all: all assets",
+			gitContext: &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-c", RepoRoot: "/work/repo-c", RelativePath: "."},
+			all:        true,
+			wantNames:  []string{"global-skill-1", "global-skill-2", "repo-a-skill", "repo-a-path-skill", "repo-b-skill"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := UninstallPlan{
+				Assets:     append([]AssetUninstallPlan{}, allAssets...),
+				GitContext: tt.gitContext,
+			}
+
+			result := filterUninstallPlanByScope(plan, tt.all)
+
+			gotNames := make([]string, len(result.Assets))
+			for i, a := range result.Assets {
+				gotNames[i] = a.Name
+			}
+
+			if len(gotNames) != len(tt.wantNames) {
+				t.Errorf("got %d assets %v, want %d assets %v", len(gotNames), gotNames, len(tt.wantNames), tt.wantNames)
+				return
+			}
+
+			for i, name := range tt.wantNames {
+				if gotNames[i] != name {
+					t.Errorf("asset[%d] = %q, want %q", i, gotNames[i], name)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterUninstallPlanByScopeThenClients(t *testing.T) {
+	allAssets := []AssetUninstallPlan{
+		{Name: "global-skill", Type: asset.TypeSkill, IsGlobal: true, Clients: []string{"claude-code", "cursor"}},
+		{Name: "repo-skill", Type: asset.TypeSkill, IsGlobal: false, Repository: "https://github.com/org/repo-a", Clients: []string{"claude-code", "cursor"}},
+	}
+
+	tests := []struct {
+		name        string
+		gitContext  *gitutil.GitContext
+		all         bool
+		clientsFlag string
+		wantNames   []string
+		wantClients map[string][]string
+	}{
+		{
+			name:        "inside repo, no --all, --clients cursor: only repo assets for cursor",
+			gitContext:  &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-a", RepoRoot: "/work/repo-a", RelativePath: "."},
+			all:         false,
+			clientsFlag: "cursor",
+			wantNames:   []string{"repo-skill"},
+			wantClients: map[string][]string{"repo-skill": {"cursor"}},
+		},
+		{
+			name:        "inside repo, --all, --clients cursor: all assets for cursor",
+			gitContext:  &gitutil.GitContext{IsRepo: true, RepoURL: "https://github.com/org/repo-a", RepoRoot: "/work/repo-a", RelativePath: "."},
+			all:         true,
+			clientsFlag: "cursor",
+			wantNames:   []string{"global-skill", "repo-skill"},
+			wantClients: map[string][]string{"global-skill": {"cursor"}, "repo-skill": {"cursor"}},
+		},
+		{
+			name:        "outside repo, no --all, --clients cursor: no-op",
+			gitContext:  &gitutil.GitContext{IsRepo: false},
+			all:         false,
+			clientsFlag: "cursor",
+			wantNames:   []string{},
+			wantClients: map[string][]string{},
+		},
+		{
+			name:        "outside repo, --all, --clients cursor: all assets for cursor",
+			gitContext:  &gitutil.GitContext{IsRepo: false},
+			all:         true,
+			clientsFlag: "cursor",
+			wantNames:   []string{"global-skill", "repo-skill"},
+			wantClients: map[string][]string{"global-skill": {"cursor"}, "repo-skill": {"cursor"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := UninstallPlan{
+				Assets:     append([]AssetUninstallPlan{}, allAssets...),
+				GitContext: tt.gitContext,
+			}
+
+			// Apply scope filter first, then clients filter (same order as runUninstall)
+			result := filterUninstallPlanByScope(plan, tt.all)
+			if tt.clientsFlag != "" {
+				result = filterUninstallPlanByClients(result, tt.clientsFlag)
+			}
+
+			gotNames := make([]string, len(result.Assets))
+			for i, a := range result.Assets {
+				gotNames[i] = a.Name
+			}
+
+			if len(gotNames) != len(tt.wantNames) {
+				t.Errorf("got %d assets %v, want %d assets %v", len(gotNames), gotNames, len(tt.wantNames), tt.wantNames)
+				return
+			}
+
+			for i, name := range tt.wantNames {
+				if gotNames[i] != name {
+					t.Errorf("asset[%d] = %q, want %q", i, gotNames[i], name)
+				}
+			}
+
+			for _, a := range result.Assets {
+				expected, ok := tt.wantClients[a.Name]
+				if !ok {
+					t.Errorf("unexpected asset %q", a.Name)
+					continue
+				}
+				if len(a.Clients) != len(expected) {
+					t.Errorf("asset %q: got clients %v, want %v", a.Name, a.Clients, expected)
+				}
+			}
+		})
+	}
+}
 
 func TestFilterUninstallPlanByClients(t *testing.T) {
 	tests := []struct {

--- a/internal/commands/uninstall_test.go
+++ b/internal/commands/uninstall_test.go
@@ -56,6 +56,16 @@ func (s *stubClient) GetAssetPath(context.Context, string, asset.Type, *clients.
 }
 func (s *stubClient) RuleCapabilities() *clients.RuleCapabilities { return nil }
 
+// keys returns sorted keys from a map for readable error messages
+func keys(m map[string]bool) []string {
+	result := make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	slices.Sort(result)
+	return result
+}
+
 func TestFilterUninstallPlanByScope(t *testing.T) {
 	// Shared tracker data: 2 global, 2 repo-A (one path-scoped), 1 repo-B
 	allAssets := []AssetUninstallPlan{
@@ -131,19 +141,24 @@ func TestFilterUninstallPlanByScope(t *testing.T) {
 
 			result := filterUninstallPlanByScope(plan, tt.all)
 
-			gotNames := make([]string, len(result.Assets))
-			for i, a := range result.Assets {
-				gotNames[i] = a.Name
+			gotNames := make(map[string]bool)
+			for _, a := range result.Assets {
+				gotNames[a.Name] = true
 			}
 
-			if len(gotNames) != len(tt.wantNames) {
-				t.Errorf("got %d assets %v, want %d assets %v", len(gotNames), gotNames, len(tt.wantNames), tt.wantNames)
+			wantNames := make(map[string]bool)
+			for _, name := range tt.wantNames {
+				wantNames[name] = true
+			}
+
+			if len(gotNames) != len(wantNames) {
+				t.Errorf("got %d assets %v, want %d assets %v", len(gotNames), keys(gotNames), len(wantNames), keys(wantNames))
 				return
 			}
 
-			for i, name := range tt.wantNames {
-				if gotNames[i] != name {
-					t.Errorf("asset[%d] = %q, want %q", i, gotNames[i], name)
+			for name := range wantNames {
+				if !gotNames[name] {
+					t.Errorf("missing expected asset %q", name)
 				}
 			}
 		})
@@ -211,19 +226,24 @@ func TestFilterUninstallPlanByScopeThenClients(t *testing.T) {
 				result = filterUninstallPlanByClients(result, tt.clientsFlag)
 			}
 
-			gotNames := make([]string, len(result.Assets))
-			for i, a := range result.Assets {
-				gotNames[i] = a.Name
+			gotNames := make(map[string]bool)
+			for _, a := range result.Assets {
+				gotNames[a.Name] = true
 			}
 
-			if len(gotNames) != len(tt.wantNames) {
-				t.Errorf("got %d assets %v, want %d assets %v", len(gotNames), gotNames, len(tt.wantNames), tt.wantNames)
+			wantNames := make(map[string]bool)
+			for _, name := range tt.wantNames {
+				wantNames[name] = true
+			}
+
+			if len(gotNames) != len(wantNames) {
+				t.Errorf("got %d assets %v, want %d assets %v", len(gotNames), keys(gotNames), len(wantNames), keys(wantNames))
 				return
 			}
 
-			for i, name := range tt.wantNames {
-				if gotNames[i] != name {
-					t.Errorf("asset[%d] = %q, want %q", i, gotNames[i], name)
+			for name := range wantNames {
+				if !gotNames[name] {
+					t.Errorf("missing expected asset %q", name)
 				}
 			}
 
@@ -606,19 +626,24 @@ func TestFilterClientsByFlag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := filterClientsByFlag(allClients, tt.flag)
 
-			gotIDs := make([]string, len(result))
-			for i, c := range result {
-				gotIDs[i] = c.ID()
+			gotIDs := make(map[string]bool)
+			for _, c := range result {
+				gotIDs[c.ID()] = true
 			}
 
-			if len(gotIDs) != len(tt.wantIDs) {
-				t.Errorf("got %d clients %v, want %d clients %v", len(gotIDs), gotIDs, len(tt.wantIDs), tt.wantIDs)
+			wantIDs := make(map[string]bool)
+			for _, id := range tt.wantIDs {
+				wantIDs[id] = true
+			}
+
+			if len(gotIDs) != len(wantIDs) {
+				t.Errorf("got %d clients %v, want %d clients %v", len(gotIDs), keys(gotIDs), len(wantIDs), keys(wantIDs))
 				return
 			}
 
-			for i, id := range tt.wantIDs {
-				if gotIDs[i] != id {
-					t.Errorf("client[%d] = %q, want %q", i, gotIDs[i], id)
+			for id := range wantIDs {
+				if !gotIDs[id] {
+					t.Errorf("missing expected client %q", id)
 				}
 			}
 		})


### PR DESCRIPTION
New help text:
<img width="1387" height="1005" alt="image" src="https://github.com/user-attachments/assets/152dd7dc-3c0a-4eda-9e39-16bfb9c0bed5" />



- `sx uninstall` (no flags): remove only repo-scoped assets for the current repo. Global assets are never touched without `--all`.
  - Inside a repo → only that repo's assets (not global assets)
  - Outside a repo → no-op (nothing to uninstall)
- `sx uninstall --all`: remove assets from all scopes + remove system hooks
- `sx uninstall --all --clients claude-code`: remove assets from all scopes for Claude Code only + remove hooks from Claude Code only

| Command                            | Inside repo                                       | Outside repo                                      |
|------------------------------------|---------------------------------------------------|---------------------------------------------------|
| `sx uninstall`                     | repo assets only, no hooks                        | no-op                                             |
| `sx uninstall --all`               | all assets (repo + global) + hooks                | all assets (all repos + global) + hooks           |
| `sx uninstall --clients a,b`       | repo assets from clients a,b only, no hooks       | no-op                                             |
| `sx uninstall --all --clients a,b` | all assets from clients a,b + hooks from a,b only | all assets (all repos + global) from clients a,b + hooks from a,b only |