### PR TITLE
SK-498: Add a command that uninstalls `sx`

### DIFF
--- a/cmd/sx/main.go
+++ b/cmd/sx/main.go
@@ -214,6 +214,7 @@ Use "{{muted (printf "%s [command] --help" .CommandPath)}}" for more information
 	rootCmd.AddCommand(commands.NewProfileCommand())
 	rootCmd.AddCommand(commands.NewInstallCommand())
 	rootCmd.AddCommand(commands.NewUninstallCommand())
+	rootCmd.AddCommand(commands.NewSelfUninstallCommand())
 	rootCmd.AddCommand(commands.NewRemoveCommand())
 	rootCmd.AddCommand(commands.NewAddCommand())
 	rootCmd.AddCommand(commands.NewUpdateTemplatesCommand())

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -149,18 +149,15 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 	// Step 1: uninstall all assets via the existing flow. If this fails,
 	// abort before deleting config/cache/binary so the user can retry — once
 	// the binary is gone, the recovery path is gone too. --force overrides.
-	//
-	// RemoveAllHooks bypasses the per-config enabled filter so any sx hook
-	// the user has since disabled in config still gets cleared — otherwise
-	// it would be left pointing at a binary we're about to delete.
+	// 'sx uninstall --all' also clears every sx-installed hook, so nothing
+	// is left pointing at the binary we're about to delete.
 	if !opts.KeepAssets {
 		styledOut.Newline()
 		styledOut.Header("Uninstalling assets...")
 		assetOpts := UninstallOptions{
-			All:            true,
-			Yes:            true,
-			Verbose:        opts.Verbose,
-			RemoveAllHooks: true,
+			All:     true,
+			Yes:     true,
+			Verbose: opts.Verbose,
 		}
 		if err := assetCleanupFn(cmd, nil, assetOpts); err != nil {
 			if !opts.Force {

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -12,8 +12,52 @@ import (
 
 	"github.com/sleuth-io/sx/internal/cache"
 	"github.com/sleuth-io/sx/internal/ui"
+	"github.com/sleuth-io/sx/internal/ui/theme"
 	"github.com/sleuth-io/sx/internal/utils"
 )
+
+// selfUninstallLongHelp renders the long help text for sx self-uninstall
+// using the same theme styles as uninstallLongHelp so both --help outputs
+// look consistent.
+func selfUninstallLongHelp() string {
+	s := theme.Current().Styles()
+	e := s.Emphasis.Render
+	m := s.Muted.Render
+
+	return `Completely remove sx from your machine.
+
+This is the inverse of the curl|bash installer. It will:
+  1. Uninstall every asset sx has installed across all scopes and clients
+     (skills, MCP servers, hooks, etc. — same as ` + e("sx uninstall --all") + `).
+  2. Delete the sx config directory.
+  3. Delete the sx cache directory.
+  4. Delete the sx binary itself.
+
+If asset cleanup fails, the command aborts before touching the config, cache,
+or binary so you can investigate and retry. Pass ` + e("--force") + ` to continue anyway.
+
+On Windows, the binary cannot delete itself while it is running; you will be
+shown the path to remove manually.
+
+This action is irreversible. Use ` + e("--dry-run") + ` to preview, or ` + e("--keep-assets") + ` to
+leave installed assets in place.
+
+` + s.Header.Render("Examples:") + `
+  ` + m("# Preview what would be removed without making changes") + `
+  ` + e("sx self-uninstall --dry-run") + `
+
+  ` + m("# Run interactively (prompts for confirmation)") + `
+  ` + e("sx self-uninstall") + `
+
+  ` + m("# Skip the confirmation prompt") + `
+  ` + e("sx self-uninstall --yes") + `
+
+  ` + m("# Remove sx but leave installed assets in place in your editors") + `
+  ` + e("sx self-uninstall --keep-assets") + `
+
+  ` + m("# Continue even if asset cleanup reports an error") + `
+  ` + e("sx self-uninstall --force")
+}
 
 // executableFn is the function used to locate the running sx binary.
 // Overridable by tests so they don't try to delete the real test binary.
@@ -41,39 +85,7 @@ func NewSelfUninstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "self-uninstall",
 		Short: "Completely remove sx, its config, cache, and all installed assets",
-		Long: `Completely remove sx from your machine.
-
-This is the inverse of the curl|bash installer. It will:
-  1. Uninstall every asset sx has installed across all scopes and clients
-     (skills, MCP servers, hooks, etc. — same as 'sx uninstall --all').
-  2. Delete the sx config directory.
-  3. Delete the sx cache directory.
-  4. Delete the sx binary itself.
-
-If asset cleanup fails, the command aborts before touching the config, cache,
-or binary so you can investigate and retry. Pass --force to continue anyway.
-
-On Windows, the binary cannot delete itself while it is running; you will be
-shown the path to remove manually.
-
-This action is irreversible. Use --dry-run to preview, or --keep-assets to
-leave installed assets in place.
-
-Examples:
-  # Preview what would be removed without making changes
-  sx self-uninstall --dry-run
-
-  # Run interactively (prompts for confirmation)
-  sx self-uninstall
-
-  # Skip the confirmation prompt
-  sx self-uninstall --yes
-
-  # Remove sx but leave installed assets in place in your editors
-  sx self-uninstall --keep-assets
-
-  # Continue even if asset cleanup reports an error
-  sx self-uninstall --force`,
+		Long:  selfUninstallLongHelp(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSelfUninstall(cmd, opts)
 		},
@@ -108,6 +120,13 @@ func resolveSelfUninstallPaths() selfUninstallPaths {
 
 func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+
+	// --force only matters during asset cleanup; with --keep-assets that step
+	// is skipped entirely, so the combination is a silent no-op. Reject it
+	// upfront so the user notices they passed an inert flag.
+	if opts.Force && opts.KeepAssets {
+		return errors.New("--force has no effect with --keep-assets (asset cleanup is already skipped)")
+	}
 
 	paths := resolveSelfUninstallPaths()
 

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -57,7 +57,23 @@ On Windows, the binary cannot delete itself while it is running; you will be
 shown the path to remove manually.
 
 This action is irreversible. Use --dry-run to preview, or --keep-assets to
-leave installed assets in place.`,
+leave installed assets in place.
+
+Examples:
+  # Preview what would be removed without making changes
+  sx self-uninstall --dry-run
+
+  # Run interactively (prompts for confirmation)
+  sx self-uninstall
+
+  # Skip the confirmation prompt
+  sx self-uninstall --yes
+
+  # Remove sx but leave installed assets in place in your editors
+  sx self-uninstall --keep-assets
+
+  # Continue even if asset cleanup reports an error
+  sx self-uninstall --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSelfUninstall(cmd, opts)
 		},

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -19,11 +19,16 @@ import (
 // Overridable by tests so they don't try to delete the real test binary.
 var executableFn = os.Executable
 
+// assetCleanupFn invokes the existing asset uninstall flow. Overridable by
+// tests that need to assert the call was made or simulate a failure.
+var assetCleanupFn = runUninstall
+
 // SelfUninstallOptions controls the self-uninstall flow.
 type SelfUninstallOptions struct {
 	Yes         bool
 	DryRun      bool
 	KeepAssets  bool
+	Force       bool
 	Verbose     bool
 	keepBinary  bool // test hook: skip the binary-removal step
 	skipConfirm bool // test hook: skip the confirmation prompt
@@ -45,6 +50,12 @@ This is the inverse of the curl|bash installer. It will:
   3. Delete the sx cache directory.
   4. Delete the sx binary itself.
 
+If asset cleanup fails, the command aborts before touching the config, cache,
+or binary so you can investigate and retry. Pass --force to continue anyway.
+
+On Windows, the binary cannot delete itself while it is running; you will be
+shown the path to remove manually.
+
 This action is irreversible. Use --dry-run to preview, or --keep-assets to
 leave installed assets in place.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,6 +66,7 @@ leave installed assets in place.`,
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be removed without making changes")
 	cmd.Flags().BoolVar(&opts.KeepAssets, "keep-assets", false, "Do not uninstall assets — only remove sx itself")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Continue with config, cache, and binary removal even if asset cleanup fails")
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Verbose output")
 
 	return cmd
@@ -95,7 +107,11 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 	}
 	styledOut.ListItem("•", "Config:  "+displayPath(paths.configDir, paths.configErr))
 	styledOut.ListItem("•", "Cache:   "+displayPath(paths.cacheDir, paths.cacheErr))
-	styledOut.ListItem("•", "Binary:  "+displayPath(paths.binary, paths.binaryErr))
+	binaryLine := "Binary:  " + displayPath(paths.binary, paths.binaryErr)
+	if runtime.GOOS == "windows" && paths.binary != "" && paths.binaryErr == nil {
+		binaryLine += " (manual removal required on Windows)"
+	}
+	styledOut.ListItem("•", binaryLine)
 	styledOut.Newline()
 	styledOut.Warning("This action is irreversible.")
 	styledOut.Newline()
@@ -114,7 +130,9 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 		}
 	}
 
-	// Step 1: uninstall all assets via the existing flow.
+	// Step 1: uninstall all assets via the existing flow. If this fails,
+	// abort before deleting config/cache/binary so the user can retry — once
+	// the binary is gone, the recovery path is gone too. --force overrides.
 	if !opts.KeepAssets {
 		styledOut.Newline()
 		styledOut.Header("Uninstalling assets...")
@@ -123,9 +141,16 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 			Yes:     true,
 			Verbose: opts.Verbose,
 		}
-		if err := runUninstall(cmd, nil, assetOpts); err != nil {
-			styledOut.Warning(fmt.Sprintf("Asset cleanup reported: %v", err))
-			styledOut.Muted("Continuing with config, cache, and binary removal.")
+		if err := assetCleanupFn(cmd, nil, assetOpts); err != nil {
+			if !opts.Force {
+				styledOut.Newline()
+				styledOut.Error(fmt.Sprintf("Asset cleanup failed: %v", err))
+				styledOut.Muted("Config, cache, and the sx binary were left in place so you can retry.")
+				styledOut.Muted("Fix the underlying error and re-run, or pass --force to remove sx anyway.")
+				return fmt.Errorf("asset cleanup failed: %w", err)
+			}
+			styledOut.Warning(fmt.Sprintf("Asset cleanup failed: %v", err))
+			styledOut.Warning("Continuing because --force was passed; some assets may be left behind.")
 		}
 	}
 
@@ -189,16 +214,13 @@ func removeBinary(paths selfUninstallPaths, styledOut *ui.Output) {
 	styledOut.SuccessItem("Removed " + paths.binary)
 }
 
-// removeDirIfExists is RemoveAll that ignores a missing target.
+// removeDirIfExists wraps os.RemoveAll. os.RemoveAll already returns nil for a
+// missing target, so the only thing we add is an empty-path guard.
 func removeDirIfExists(path string) error {
 	if path == "" {
 		return nil
 	}
-	err := os.RemoveAll(path)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
+	return os.RemoveAll(path)
 }
 
 // displayPath returns a printable representation of a resolved path, or a

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -133,13 +133,18 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 	// Step 1: uninstall all assets via the existing flow. If this fails,
 	// abort before deleting config/cache/binary so the user can retry — once
 	// the binary is gone, the recovery path is gone too. --force overrides.
+	//
+	// RemoveAllHooks bypasses the per-config enabled filter so any sx hook
+	// the user has since disabled in config still gets cleared — otherwise
+	// it would be left pointing at a binary we're about to delete.
 	if !opts.KeepAssets {
 		styledOut.Newline()
 		styledOut.Header("Uninstalling assets...")
 		assetOpts := UninstallOptions{
-			All:     true,
-			Yes:     true,
-			Verbose: opts.Verbose,
+			All:            true,
+			Yes:            true,
+			Verbose:        opts.Verbose,
+			RemoveAllHooks: true,
 		}
 		if err := assetCleanupFn(cmd, nil, assetOpts); err != nil {
 			if !opts.Force {

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -1,0 +1,227 @@
+package commands
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/internal/cache"
+	"github.com/sleuth-io/sx/internal/ui"
+	"github.com/sleuth-io/sx/internal/utils"
+)
+
+// executableFn is the function used to locate the running sx binary.
+// Overridable by tests so they don't try to delete the real test binary.
+var executableFn = os.Executable
+
+// SelfUninstallOptions controls the self-uninstall flow.
+type SelfUninstallOptions struct {
+	Yes         bool
+	DryRun      bool
+	KeepAssets  bool
+	Verbose     bool
+	keepBinary  bool // test hook: skip the binary-removal step
+	skipConfirm bool // test hook: skip the confirmation prompt
+}
+
+// NewSelfUninstallCommand creates the self-uninstall command.
+func NewSelfUninstallCommand() *cobra.Command {
+	opts := SelfUninstallOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "self-uninstall",
+		Short: "Completely remove sx, its config, cache, and all installed assets",
+		Long: `Completely remove sx from your machine.
+
+This is the inverse of the curl|bash installer. It will:
+  1. Uninstall every asset sx has installed across all scopes and clients
+     (skills, MCP servers, hooks, etc. — same as 'sx uninstall --all').
+  2. Delete the sx config directory.
+  3. Delete the sx cache directory.
+  4. Delete the sx binary itself.
+
+This action is irreversible. Use --dry-run to preview, or --keep-assets to
+leave installed assets in place.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSelfUninstall(cmd, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be removed without making changes")
+	cmd.Flags().BoolVar(&opts.KeepAssets, "keep-assets", false, "Do not uninstall assets — only remove sx itself")
+	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Verbose output")
+
+	return cmd
+}
+
+// selfUninstallPaths captures the on-disk locations sx owns.
+type selfUninstallPaths struct {
+	binary    string // empty if it could not be resolved
+	binaryErr error
+	configDir string
+	configErr error
+	cacheDir  string
+	cacheErr  error
+}
+
+func resolveSelfUninstallPaths() selfUninstallPaths {
+	p := selfUninstallPaths{}
+	p.binary, p.binaryErr = executableFn()
+	p.configDir, p.configErr = utils.GetConfigDir()
+	p.cacheDir, p.cacheErr = cache.GetCacheDir()
+	return p
+}
+
+func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
+	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+
+	paths := resolveSelfUninstallPaths()
+
+	// Display the plan up front.
+	styledOut.Header("This will completely remove sx from your machine.")
+	styledOut.Newline()
+	styledOut.Println("The following will be removed:")
+	styledOut.Newline()
+	if !opts.KeepAssets {
+		styledOut.ListItem("•", "All installed assets (skills, MCP servers, hooks) across every scope and client")
+	} else {
+		styledOut.ListItem("•", "Installed assets: kept (--keep-assets)")
+	}
+	styledOut.ListItem("•", "Config:  "+displayPath(paths.configDir, paths.configErr))
+	styledOut.ListItem("•", "Cache:   "+displayPath(paths.cacheDir, paths.cacheErr))
+	styledOut.ListItem("•", "Binary:  "+displayPath(paths.binary, paths.binaryErr))
+	styledOut.Newline()
+	styledOut.Warning("This action is irreversible.")
+	styledOut.Newline()
+
+	// Dry run: stop here.
+	if opts.DryRun {
+		styledOut.Muted("No changes made (dry run).")
+		return nil
+	}
+
+	// Confirm.
+	if !opts.Yes && !opts.skipConfirm {
+		if !confirmSelfUninstall(styledOut) {
+			styledOut.Muted("Cancelled. Nothing was removed.")
+			return nil
+		}
+	}
+
+	// Step 1: uninstall all assets via the existing flow.
+	if !opts.KeepAssets {
+		styledOut.Newline()
+		styledOut.Header("Uninstalling assets...")
+		assetOpts := UninstallOptions{
+			All:     true,
+			Yes:     true,
+			Verbose: opts.Verbose,
+		}
+		if err := runUninstall(cmd, nil, assetOpts); err != nil {
+			styledOut.Warning(fmt.Sprintf("Asset cleanup reported: %v", err))
+			styledOut.Muted("Continuing with config, cache, and binary removal.")
+		}
+	}
+
+	// Step 2: remove config directory.
+	styledOut.Newline()
+	styledOut.Header("Removing config and cache...")
+	if paths.configErr != nil {
+		styledOut.Warning(fmt.Sprintf("Could not determine config dir: %v", paths.configErr))
+	} else if err := removeDirIfExists(paths.configDir); err != nil {
+		styledOut.Warning(fmt.Sprintf("Failed to remove config dir %s: %v", paths.configDir, err))
+	} else {
+		styledOut.SuccessItem("Removed " + paths.configDir)
+	}
+
+	// Step 3: remove cache directory.
+	if paths.cacheErr != nil {
+		styledOut.Warning(fmt.Sprintf("Could not determine cache dir: %v", paths.cacheErr))
+	} else if err := removeDirIfExists(paths.cacheDir); err != nil {
+		styledOut.Warning(fmt.Sprintf("Failed to remove cache dir %s: %v", paths.cacheDir, err))
+	} else {
+		styledOut.SuccessItem("Removed " + paths.cacheDir)
+	}
+
+	// Step 4: remove the binary itself.
+	if !opts.keepBinary {
+		styledOut.Newline()
+		styledOut.Header("Removing binary...")
+		removeBinary(paths, styledOut)
+	}
+
+	styledOut.Newline()
+	styledOut.Success("sx has been removed.")
+	styledOut.Muted("If you added the install directory to your shell's PATH, you can remove that line from your shell rc file.")
+	return nil
+}
+
+// removeBinary deletes the running sx executable. On Unix this works while
+// the process is still running because the kernel keeps the open inode alive
+// until the process exits. On Windows the OS holds an exclusive lock, so we
+// print a manual instruction instead.
+func removeBinary(paths selfUninstallPaths, styledOut *ui.Output) {
+	if paths.binaryErr != nil || paths.binary == "" {
+		styledOut.Warning(fmt.Sprintf("Could not locate sx binary: %v", paths.binaryErr))
+		return
+	}
+
+	if runtime.GOOS == "windows" {
+		styledOut.Warning("Cannot self-delete on Windows. Please remove the binary manually: " + paths.binary)
+		return
+	}
+
+	if err := os.Remove(paths.binary); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			styledOut.SuccessItem("Binary already gone: " + paths.binary)
+			return
+		}
+		styledOut.Warning(fmt.Sprintf("Failed to remove binary %s: %v", paths.binary, err))
+		styledOut.Muted("Please remove it manually.")
+		return
+	}
+	styledOut.SuccessItem("Removed " + paths.binary)
+}
+
+// removeDirIfExists is RemoveAll that ignores a missing target.
+func removeDirIfExists(path string) error {
+	if path == "" {
+		return nil
+	}
+	err := os.RemoveAll(path)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// displayPath returns a printable representation of a resolved path, or a
+// placeholder when resolution failed.
+func displayPath(path string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("<unresolved: %v>", err)
+	}
+	if path == "" {
+		return "<not set>"
+	}
+	return path
+}
+
+// confirmSelfUninstall prompts the user; default is No.
+func confirmSelfUninstall(styledOut *ui.Output) bool {
+	reader := bufio.NewReader(os.Stdin)
+	styledOut.Printf("Continue with self-uninstall? [y/N]: ")
+
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
+}

--- a/internal/commands/self_uninstall_test.go
+++ b/internal/commands/self_uninstall_test.go
@@ -19,8 +19,8 @@ func stubAssetCleanup(t *testing.T, returnErr error) *int {
 	prev := assetCleanupFn
 	assetCleanupFn = func(_ *cobra.Command, _ []string, opts UninstallOptions) error {
 		calls++
-		if !opts.All || !opts.Yes || !opts.RemoveAllHooks {
-			t.Errorf("expected asset cleanup to be invoked with All=true, Yes=true, RemoveAllHooks=true; got %+v", opts)
+		if !opts.All || !opts.Yes {
+			t.Errorf("expected asset cleanup to be invoked with All=true, Yes=true; got %+v", opts)
 		}
 		return returnErr
 	}

--- a/internal/commands/self_uninstall_test.go
+++ b/internal/commands/self_uninstall_test.go
@@ -304,6 +304,37 @@ func TestSelfUninstall_AssetCleanupFailureWithForceProceeds(t *testing.T) {
 	}
 }
 
+func TestSelfUninstall_RejectsForceWithKeepAssets(t *testing.T) {
+	t.Setenv("SX_CONFIG_DIR", t.TempDir())
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	cmd, _ := newSelfUninstallTestCmd(t, stubBinary)
+	opts := SelfUninstallOptions{
+		Yes:         true,
+		KeepAssets:  true,
+		Force:       true,
+		keepBinary:  true,
+		skipConfirm: true,
+	}
+	err := runSelfUninstall(cmd, opts)
+	if err == nil {
+		t.Fatal("expected runSelfUninstall to reject --force + --keep-assets")
+	}
+	if !strings.Contains(err.Error(), "--force") || !strings.Contains(err.Error(), "--keep-assets") {
+		t.Errorf("expected error to mention both flags, got %v", err)
+	}
+
+	// Binary must remain — we bailed before any side effects.
+	if _, err := os.Stat(stubBinary); err != nil {
+		t.Errorf("rejected combination should not touch the filesystem: %v", err)
+	}
+}
+
 func TestRemoveDirIfExists(t *testing.T) {
 	t.Run("ignores missing", func(t *testing.T) {
 		if err := removeDirIfExists(filepath.Join(t.TempDir(), "nope")); err != nil {

--- a/internal/commands/self_uninstall_test.go
+++ b/internal/commands/self_uninstall_test.go
@@ -1,0 +1,196 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newSelfUninstallTestCmd wires up a cobra.Command with buffered output and a
+// stub executableFn pointing at a temp file so the test can observe binary
+// removal without touching the actual test binary.
+func newSelfUninstallTestCmd(t *testing.T, stubBinary string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+
+	prev := executableFn
+	executableFn = func() (string, error) { return stubBinary, nil }
+	t.Cleanup(func() { executableFn = prev })
+
+	return cmd, out
+}
+
+func TestSelfUninstall_DryRunMakesNoChanges(t *testing.T) {
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", configDir)
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	// Drop a marker file into each dir so we can prove dry-run preserved them.
+	configMarker := filepath.Join(configDir, "config.json")
+	cacheMarker := filepath.Join(cacheDir, "marker")
+	if err := os.WriteFile(configMarker, []byte("{}"), 0600); err != nil {
+		t.Fatalf("setup config marker: %v", err)
+	}
+	if err := os.WriteFile(cacheMarker, []byte("x"), 0600); err != nil {
+		t.Fatalf("setup cache marker: %v", err)
+	}
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	cmd, out := newSelfUninstallTestCmd(t, stubBinary)
+	if err := runSelfUninstall(cmd, SelfUninstallOptions{DryRun: true, KeepAssets: true}); err != nil {
+		t.Fatalf("runSelfUninstall returned error: %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{configDir, cacheDir, stubBinary, "dry run"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected output to contain %q\noutput:\n%s", want, output)
+		}
+	}
+
+	// Files must still exist.
+	for _, p := range []string{configMarker, cacheMarker, stubBinary} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("dry-run deleted %s: %v", p, err)
+		}
+	}
+}
+
+func TestSelfUninstall_KeepAssetsRemovesConfigCacheAndBinary(t *testing.T) {
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", configDir)
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{}"), 0600); err != nil {
+		t.Fatalf("setup config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "marker"), []byte("x"), 0600); err != nil {
+		t.Fatalf("setup cache: %v", err)
+	}
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	cmd, out := newSelfUninstallTestCmd(t, stubBinary)
+	opts := SelfUninstallOptions{
+		Yes:         true,
+		KeepAssets:  true,
+		skipConfirm: true,
+	}
+	if err := runSelfUninstall(cmd, opts); err != nil {
+		t.Fatalf("runSelfUninstall returned error: %v", err)
+	}
+
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Errorf("config dir not removed: stat err = %v", err)
+	}
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Errorf("cache dir not removed: stat err = %v", err)
+	}
+	if _, err := os.Stat(stubBinary); !os.IsNotExist(err) {
+		t.Errorf("binary not removed: stat err = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "sx has been removed") {
+		t.Errorf("expected success message in output:\n%s", out.String())
+	}
+}
+
+func TestSelfUninstall_KeepBinaryPreservesIt(t *testing.T) {
+	t.Setenv("SX_CONFIG_DIR", t.TempDir())
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	cmd, _ := newSelfUninstallTestCmd(t, stubBinary)
+	opts := SelfUninstallOptions{
+		Yes:         true,
+		KeepAssets:  true,
+		keepBinary:  true,
+		skipConfirm: true,
+	}
+	if err := runSelfUninstall(cmd, opts); err != nil {
+		t.Fatalf("runSelfUninstall returned error: %v", err)
+	}
+
+	if _, err := os.Stat(stubBinary); err != nil {
+		t.Errorf("binary removed even though keepBinary=true: %v", err)
+	}
+}
+
+func TestSelfUninstall_HandlesMissingDirsGracefully(t *testing.T) {
+	// Point to dirs that have never existed.
+	tmp := t.TempDir()
+	missingConfig := filepath.Join(tmp, "never-created-config")
+	missingCache := filepath.Join(tmp, "never-created-cache")
+	t.Setenv("SX_CONFIG_DIR", missingConfig)
+	t.Setenv("SX_CACHE_DIR", missingCache)
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	cmd, out := newSelfUninstallTestCmd(t, stubBinary)
+	opts := SelfUninstallOptions{
+		Yes:         true,
+		KeepAssets:  true,
+		keepBinary:  true,
+		skipConfirm: true,
+	}
+	if err := runSelfUninstall(cmd, opts); err != nil {
+		t.Fatalf("runSelfUninstall returned error on missing dirs: %v", err)
+	}
+
+	output := out.String()
+	if strings.Contains(strings.ToLower(output), "failed to remove") {
+		t.Errorf("missing dirs should not produce failure warnings:\n%s", output)
+	}
+}
+
+func TestRemoveDirIfExists(t *testing.T) {
+	t.Run("ignores missing", func(t *testing.T) {
+		if err := removeDirIfExists(filepath.Join(t.TempDir(), "nope")); err != nil {
+			t.Errorf("expected nil for missing path, got %v", err)
+		}
+	})
+	t.Run("removes existing", func(t *testing.T) {
+		dir := t.TempDir()
+		nested := filepath.Join(dir, "child")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(nested, "f"), []byte("x"), 0600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		if err := removeDirIfExists(dir); err != nil {
+			t.Errorf("remove failed: %v", err)
+		}
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("dir not removed: %v", err)
+		}
+	})
+	t.Run("empty path is a no-op", func(t *testing.T) {
+		if err := removeDirIfExists(""); err != nil {
+			t.Errorf("expected nil for empty path, got %v", err)
+		}
+	})
+}

--- a/internal/commands/self_uninstall_test.go
+++ b/internal/commands/self_uninstall_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,23 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+// stubAssetCleanup swaps assetCleanupFn for the duration of a test so we can
+// assert it was invoked and control whether it succeeds or fails.
+func stubAssetCleanup(t *testing.T, returnErr error) *int {
+	t.Helper()
+	calls := 0
+	prev := assetCleanupFn
+	assetCleanupFn = func(_ *cobra.Command, _ []string, opts UninstallOptions) error {
+		calls++
+		if !opts.All || !opts.Yes {
+			t.Errorf("expected asset cleanup to be invoked with All=true, Yes=true; got %+v", opts)
+		}
+		return returnErr
+	}
+	t.Cleanup(func() { assetCleanupFn = prev })
+	return &calls
+}
 
 // newSelfUninstallTestCmd wires up a cobra.Command with buffered output and a
 // stub executableFn pointing at a temp file so the test can observe binary
@@ -163,6 +181,126 @@ func TestSelfUninstall_HandlesMissingDirsGracefully(t *testing.T) {
 	output := out.String()
 	if strings.Contains(strings.ToLower(output), "failed to remove") {
 		t.Errorf("missing dirs should not produce failure warnings:\n%s", output)
+	}
+}
+
+func TestSelfUninstall_AssetCleanupSuccessProceeds(t *testing.T) {
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", configDir)
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{}"), 0600); err != nil {
+		t.Fatalf("setup config: %v", err)
+	}
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	calls := stubAssetCleanup(t, nil)
+
+	cmd, _ := newSelfUninstallTestCmd(t, stubBinary)
+	opts := SelfUninstallOptions{
+		Yes:         true,
+		skipConfirm: true,
+	}
+	if err := runSelfUninstall(cmd, opts); err != nil {
+		t.Fatalf("runSelfUninstall returned error: %v", err)
+	}
+
+	if *calls != 1 {
+		t.Errorf("expected asset cleanup to be called exactly once, got %d", *calls)
+	}
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Errorf("config dir not removed after successful asset cleanup: %v", err)
+	}
+	if _, err := os.Stat(stubBinary); !os.IsNotExist(err) {
+		t.Errorf("binary not removed after successful asset cleanup: %v", err)
+	}
+}
+
+func TestSelfUninstall_AssetCleanupFailureAbortsWithoutForce(t *testing.T) {
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", configDir)
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	configFile := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(configFile, []byte("{}"), 0600); err != nil {
+		t.Fatalf("setup config: %v", err)
+	}
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	stubAssetCleanup(t, errors.New("simulated client failure"))
+
+	cmd, out := newSelfUninstallTestCmd(t, stubBinary)
+	opts := SelfUninstallOptions{
+		Yes:         true,
+		skipConfirm: true,
+	}
+	err := runSelfUninstall(cmd, opts)
+	if err == nil {
+		t.Fatal("expected runSelfUninstall to return an error when asset cleanup fails without --force")
+	}
+	if !strings.Contains(err.Error(), "asset cleanup failed") {
+		t.Errorf("expected error to mention asset cleanup, got %v", err)
+	}
+
+	// Nothing else should have been touched.
+	if _, err := os.Stat(configFile); err != nil {
+		t.Errorf("config file deleted despite asset cleanup failure: %v", err)
+	}
+	if _, err := os.Stat(stubBinary); err != nil {
+		t.Errorf("binary deleted despite asset cleanup failure: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Asset cleanup failed") {
+		t.Errorf("expected user-facing error message; got:\n%s", output)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Errorf("expected output to mention --force escape hatch; got:\n%s", output)
+	}
+}
+
+func TestSelfUninstall_AssetCleanupFailureWithForceProceeds(t *testing.T) {
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", configDir)
+	t.Setenv("SX_CACHE_DIR", cacheDir)
+
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte("{}"), 0600); err != nil {
+		t.Fatalf("setup config: %v", err)
+	}
+
+	stubBinary := filepath.Join(t.TempDir(), "sx")
+	if err := os.WriteFile(stubBinary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("setup stub binary: %v", err)
+	}
+
+	stubAssetCleanup(t, errors.New("simulated client failure"))
+
+	cmd, _ := newSelfUninstallTestCmd(t, stubBinary)
+	opts := SelfUninstallOptions{
+		Yes:         true,
+		Force:       true,
+		skipConfirm: true,
+	}
+	if err := runSelfUninstall(cmd, opts); err != nil {
+		t.Fatalf("expected --force to override failure, got error: %v", err)
+	}
+
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Errorf("config dir not removed with --force: %v", err)
+	}
+	if _, err := os.Stat(stubBinary); !os.IsNotExist(err) {
+		t.Errorf("binary not removed with --force: %v", err)
 	}
 }
 

--- a/internal/commands/self_uninstall_test.go
+++ b/internal/commands/self_uninstall_test.go
@@ -19,8 +19,8 @@ func stubAssetCleanup(t *testing.T, returnErr error) *int {
 	prev := assetCleanupFn
 	assetCleanupFn = func(_ *cobra.Command, _ []string, opts UninstallOptions) error {
 		calls++
-		if !opts.All || !opts.Yes {
-			t.Errorf("expected asset cleanup to be invoked with All=true, Yes=true; got %+v", opts)
+		if !opts.All || !opts.Yes || !opts.RemoveAllHooks {
+			t.Errorf("expected asset cleanup to be invoked with All=true, Yes=true, RemoveAllHooks=true; got %+v", opts)
 		}
 		return returnErr
 	}

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -102,11 +102,6 @@ type UninstallOptions struct {
 	DryRun      bool
 	Verbose     bool
 	ClientsFlag string
-	// RemoveAllHooks removes every sx-installed hook from every detected
-	// client regardless of which bootstrap options are currently enabled in
-	// config. Used by self-uninstall to clear orphaned hooks that point at
-	// the sx binary we're about to delete.
-	RemoveAllHooks bool
 }
 
 // AssetUninstallPlan contains info needed to uninstall one asset
@@ -240,7 +235,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 
 	// Step 10: Uninstall system hooks if --all flag is passed
 	if opts.All {
-		uninstallSystemHooks(ctx, opts.ClientsFlag, opts.RemoveAllHooks, styledOut)
+		uninstallSystemHooks(ctx, opts.ClientsFlag, styledOut)
 	}
 
 	// Step 11: Report results
@@ -266,7 +261,7 @@ func handleAllFlagWithoutAssets(ctx context.Context, opts UninstallOptions, styl
 		return nil
 	}
 
-	uninstallSystemHooks(ctx, opts.ClientsFlag, opts.RemoveAllHooks, styledOut)
+	uninstallSystemHooks(ctx, opts.ClientsFlag, styledOut)
 	styledOut.Success("System hooks removed")
 	return nil
 }
@@ -696,12 +691,11 @@ func confirmUninstall(styledOut *ui.Output) bool {
 	return response == "y" || response == "yes"
 }
 
-// uninstallSystemHooks removes system hooks from installed clients.
-// If clientsFlag is non-empty, only hooks for those clients are removed.
-// If removeAll is true, every hook the client knows how to install is targeted
-// for removal — bypassing the per-config enabled filter so we also clear hooks
-// for options the user has since disabled.
-func uninstallSystemHooks(ctx context.Context, clientsFlag string, removeAll bool, styledOut *ui.Output) {
+// uninstallSystemHooks removes every sx-installed hook from each detected
+// client. Hooks for options the user has since disabled in config are still
+// targeted so nothing is left referencing the sx binary. If clientsFlag is
+// non-empty, only hooks for those clients are removed.
+func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui.Output) {
 	styledOut.Newline()
 	styledOut.Header("Removing system hooks...")
 
@@ -713,12 +707,6 @@ func uninstallSystemHooks(ctx context.Context, clientsFlag string, removeAll boo
 		installedClients = filterClientsByFlag(installedClients, clientsFlag)
 	}
 
-	// Load config to get enabled bootstrap options (only needed when filtering)
-	var mpc *config.MultiProfileConfig
-	if !removeAll {
-		mpc, _ = config.LoadMultiProfile()
-	}
-
 	// Get vault for its bootstrap options (guard against nil config)
 	var v vaultpkg.Vault
 	if cfg, err := config.Load(); err == nil {
@@ -726,24 +714,16 @@ func uninstallSystemHooks(ctx context.Context, clientsFlag string, removeAll boo
 	}
 
 	for _, client := range installedClients {
-		// Gather all options from vault and client
+		// Gather every bootstrap option from vault and client so we attempt
+		// removal of all hooks the client knows about — including ones for
+		// options the user has since disabled in config.
 		var allOpts []bootstrap.Option
 		if v != nil {
 			allOpts = append(allOpts, v.GetBootstrapOptions(ctx)...)
 		}
 		allOpts = append(allOpts, client.GetBootstrapOptions(ctx)...)
 
-		// Decide which options to target. removeAll uses every known option so
-		// orphan hooks for disabled-in-config options also get removed.
-		var optsToUninstall []bootstrap.Option
-		switch {
-		case removeAll, mpc == nil:
-			optsToUninstall = allOpts
-		default:
-			optsToUninstall = bootstrap.Filter(allOpts, mpc.GetBootstrapOption)
-		}
-
-		if err := client.UninstallBootstrap(ctx, optsToUninstall); err != nil {
+		if err := client.UninstallBootstrap(ctx, allOpts); err != nil {
 			styledOut.ErrorItem("Failed to remove hooks from " + client.DisplayName() + ": " + err.Error())
 		} else {
 			styledOut.SuccessItem("Removed hooks from " + client.DisplayName())

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -713,10 +713,17 @@ func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui
 		v, _ = vaultpkg.NewFromConfig(cfg)
 	}
 
+	uninstallHooksFromClients(ctx, installedClients, v, styledOut)
+}
+
+// uninstallHooksFromClients passes every bootstrap option each client knows
+// about — plus any vault-supplied options — to client.UninstallBootstrap.
+// No per-config "enabled" filter is applied: orphaned hooks whose option has
+// since been disabled in config would otherwise be left referencing the sx
+// binary. Extracted from uninstallSystemHooks so the contract can be
+// regression-tested with stub clients.
+func uninstallHooksFromClients(ctx context.Context, installedClients []clients.Client, v vaultpkg.Vault, styledOut *ui.Output) {
 	for _, client := range installedClients {
-		// Gather every bootstrap option from vault and client so we attempt
-		// removal of all hooks the client knows about — including ones for
-		// options the user has since disabled in config.
 		var allOpts []bootstrap.Option
 		if v != nil {
 			allOpts = append(allOpts, v.GetBootstrapOptions(ctx)...)

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -102,6 +102,11 @@ type UninstallOptions struct {
 	DryRun      bool
 	Verbose     bool
 	ClientsFlag string
+	// RemoveAllHooks removes every sx-installed hook from every detected
+	// client regardless of which bootstrap options are currently enabled in
+	// config. Used by self-uninstall to clear orphaned hooks that point at
+	// the sx binary we're about to delete.
+	RemoveAllHooks bool
 }
 
 // AssetUninstallPlan contains info needed to uninstall one asset
@@ -235,7 +240,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 
 	// Step 10: Uninstall system hooks if --all flag is passed
 	if opts.All {
-		uninstallSystemHooks(ctx, opts.ClientsFlag, styledOut)
+		uninstallSystemHooks(ctx, opts.ClientsFlag, opts.RemoveAllHooks, styledOut)
 	}
 
 	// Step 11: Report results
@@ -261,7 +266,7 @@ func handleAllFlagWithoutAssets(ctx context.Context, opts UninstallOptions, styl
 		return nil
 	}
 
-	uninstallSystemHooks(ctx, opts.ClientsFlag, styledOut)
+	uninstallSystemHooks(ctx, opts.ClientsFlag, opts.RemoveAllHooks, styledOut)
 	styledOut.Success("System hooks removed")
 	return nil
 }
@@ -693,7 +698,10 @@ func confirmUninstall(styledOut *ui.Output) bool {
 
 // uninstallSystemHooks removes system hooks from installed clients.
 // If clientsFlag is non-empty, only hooks for those clients are removed.
-func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui.Output) {
+// If removeAll is true, every hook the client knows how to install is targeted
+// for removal — bypassing the per-config enabled filter so we also clear hooks
+// for options the user has since disabled.
+func uninstallSystemHooks(ctx context.Context, clientsFlag string, removeAll bool, styledOut *ui.Output) {
 	styledOut.Newline()
 	styledOut.Header("Removing system hooks...")
 
@@ -705,8 +713,11 @@ func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui
 		installedClients = filterClientsByFlag(installedClients, clientsFlag)
 	}
 
-	// Load config to get enabled bootstrap options
-	mpc, _ := config.LoadMultiProfile()
+	// Load config to get enabled bootstrap options (only needed when filtering)
+	var mpc *config.MultiProfileConfig
+	if !removeAll {
+		mpc, _ = config.LoadMultiProfile()
+	}
 
 	// Get vault for its bootstrap options (guard against nil config)
 	var v vaultpkg.Vault
@@ -722,15 +733,17 @@ func uninstallSystemHooks(ctx context.Context, clientsFlag string, styledOut *ui
 		}
 		allOpts = append(allOpts, client.GetBootstrapOptions(ctx)...)
 
-		// Filter to enabled options (nil config = all enabled for backwards compat)
-		var enabledOpts []bootstrap.Option
-		if mpc == nil {
-			enabledOpts = allOpts
-		} else {
-			enabledOpts = bootstrap.Filter(allOpts, mpc.GetBootstrapOption)
+		// Decide which options to target. removeAll uses every known option so
+		// orphan hooks for disabled-in-config options also get removed.
+		var optsToUninstall []bootstrap.Option
+		switch {
+		case removeAll, mpc == nil:
+			optsToUninstall = allOpts
+		default:
+			optsToUninstall = bootstrap.Filter(allOpts, mpc.GetBootstrapOption)
 		}
 
-		if err := client.UninstallBootstrap(ctx, enabledOpts); err != nil {
+		if err := client.UninstallBootstrap(ctx, optsToUninstall); err != nil {
 			styledOut.ErrorItem("Failed to remove hooks from " + client.DisplayName() + ": " + err.Error())
 		} else {
 			styledOut.SuccessItem("Removed hooks from " + client.DisplayName())

--- a/internal/commands/uninstall_test.go
+++ b/internal/commands/uninstall_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/sleuth-io/sx/internal/clients"
 	"github.com/sleuth-io/sx/internal/gitutil"
 	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/ui"
 )
 
 // stubClient is a minimal clients.Client implementation for testing
@@ -55,6 +57,56 @@ func (s *stubClient) GetAssetPath(context.Context, string, asset.Type, *clients.
 	return "", nil
 }
 func (s *stubClient) RuleCapabilities() *clients.RuleCapabilities { return nil }
+
+// recordingClient is a stubClient that captures the bootstrap options it
+// receives via UninstallBootstrap so tests can assert what was passed in.
+type recordingClient struct {
+	stubClient
+	options       []bootstrap.Option // returned from GetBootstrapOptions
+	uninstallSeen []bootstrap.Option // captured by UninstallBootstrap
+}
+
+func (r *recordingClient) GetBootstrapOptions(context.Context) []bootstrap.Option {
+	return r.options
+}
+
+func (r *recordingClient) UninstallBootstrap(_ context.Context, opts []bootstrap.Option) error {
+	r.uninstallSeen = append([]bootstrap.Option(nil), opts...)
+	return nil
+}
+
+// TestUninstallHooksFromClients_PassesEveryOption pins the contract that
+// uninstallSystemHooks (via this helper) hands UninstallBootstrap every
+// option the client returns from GetBootstrapOptions, regardless of which
+// options are enabled in the user's MultiProfileConfig. If a future change
+// re-introduces an enabled-filter, this test fails.
+func TestUninstallHooksFromClients_PassesEveryOption(t *testing.T) {
+	rec := &recordingClient{
+		stubClient: stubClient{id: "stub"},
+		options: []bootstrap.Option{
+			{Key: bootstrap.SessionHookKey, Description: "session"},
+			{Key: bootstrap.AnalyticsHookKey, Description: "analytics"},
+			{Key: "custom-disabled-in-config", Description: "user disabled this in config"},
+		},
+	}
+
+	out := ui.NewOutput(&bytes.Buffer{}, &bytes.Buffer{})
+	uninstallHooksFromClients(context.Background(), []clients.Client{rec}, nil, out)
+
+	if len(rec.uninstallSeen) != len(rec.options) {
+		t.Fatalf("expected %d options passed to UninstallBootstrap, got %d (%+v)",
+			len(rec.options), len(rec.uninstallSeen), rec.uninstallSeen)
+	}
+	seen := make(map[string]bool, len(rec.uninstallSeen))
+	for _, o := range rec.uninstallSeen {
+		seen[o.Key] = true
+	}
+	for _, want := range rec.options {
+		if !seen[want.Key] {
+			t.Errorf("option %q was not passed to UninstallBootstrap — would be left as an orphan hook", want.Key)
+		}
+	}
+}
 
 // keys returns sorted keys from a map for readable error messages
 func keys(m map[string]bool) []string {


### PR DESCRIPTION
Adds a `sx self-uninstall` command that fully removes `sx` from the user's machine. Also removes the config, cache and sx-installed assets.

<img width="1194" height="435" alt="image" src="https://github.com/user-attachments/assets/e73c9b25-6ff8-4ee0-a464-9ebd29a4a6c3" />
