### PR TITLE
SK-504: Allow multiple active sx profiles at once

### DIFF
--- a/cmd/sx/main.go
+++ b/cmd/sx/main.go
@@ -208,7 +208,7 @@ Use "{{muted (printf "%s [command] --help" .CommandPath)}}" for more information
 	rootCmd.PersistentFlags().String("ssh-key", "",
 		"Path to SSH private key file or key content for git operations (can also use SX_SSH_KEY environment variable)")
 	rootCmd.PersistentFlags().String("profile", "",
-		"Use a specific profile (can also use SX_PROFILE environment variable)")
+		"Override the active profile set for this command (comma-separated for multi-active; can also use SX_PROFILE environment variable)")
 
 	// Add subcommands
 	rootCmd.AddCommand(commands.NewInitCommand())

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -2,231 +2,234 @@
 
 ## Overview
 
-Profiles allow you to maintain multiple sx configurations and switch between them. This is useful when you need to connect to different vaults for different contexts, such as:
+Profiles let you connect sx to multiple vaults. Common reasons to have
+more than one:
 
 - Personal projects vs. work projects
 - Different teams or organizations
 - Development vs. production vaults
 - Local testing vs. shared team vaults
 
-Each profile stores its own vault configuration (type, URL, authentication), while global settings like enabled clients are shared across all profiles.
+Profiles can be active one-at-a-time (the classic single-profile model)
+or several-at-once. When more than one profile is active, `sx install`
+fetches every active profile's lock file in parallel and merges the
+applicable assets into one installation pass.
+
+Each profile carries its own vault URL, auth, and an optional
+**identity email** used to resolve team/user scopes — so your work
+profile can resolve `--team backend` against your work email and your
+personal profile against your personal email on the same machine.
+
+## Active set vs. default
+
+Two profile-level concepts coexist:
+
+- **Active profiles** — every profile in this set contributes assets at
+  install time. `sx install` reads lock files from all of them.
+- **Default profile** — the single write target for mutating commands
+  (`sx add`, `sx team …`, `sx role …`) when `--profile` isn't passed.
+  Also the conflict tiebreaker: when two active profiles publish an
+  asset with the same name, the default profile's copy wins. If the
+  default isn't in the active set, the first-listed active profile
+  wins and sx prints a warning.
+
+The default profile is always part of the active set (sx auto-activates
+it when you change defaults). The active set always contains at least
+one profile — you can't deactivate the last one.
 
 ## Commands
 
-### List Profiles
-
-Show all configured profiles:
+### List profiles
 
 ```bash
 sx profile list
 ```
 
-**Output:**
+Output:
 
 ```
-✓ default  https://app.skills.new
-  work     git@github.com:company/skills.git
-  local    file:///Users/me/.sx/vault
+✓★ work     git@github.com:company/skills.git (alice@company.com)
+✓  personal git@github.com:alice/skills.git (alice@personal.com)
+   archive  file:///Users/alice/.sx/old-vault
+
+✓ = active   ★ = default
 ```
 
-The active profile is marked with a checkmark (`✓`).
-
-### Add a Profile
-
-Create a new profile:
+### Add a profile
 
 ```bash
 sx profile add <profile-name>
 ```
 
-**Example:**
+Launches the interactive vault-configuration flow, then prompts for the
+profile's identity email (defaulting to `git config user.email`).
+
+### Activate / deactivate
 
 ```bash
-sx profile add work
+sx profile activate <name>     # add to the active set
+sx profile deactivate <name>   # remove from the active set
 ```
 
-This launches the interactive configuration flow (same as `sx init`) to set up the new profile's vault connection. Your existing profiles and default profile setting are preserved.
+`activate` is additive: other profiles stay active. `deactivate` runs
+cleanup on the next `sx install` (its installed assets are removed).
+Cannot deactivate the last active profile.
 
-### Switch Profiles
-
-Change the active profile:
+### Default
 
 ```bash
-sx profile use <profile-name>
+sx profile default <name>      # set the default profile
 ```
 
-**Example:**
+Auto-activates the profile if it isn't already active. This is the
+profile that mutating commands target when `--profile` isn't passed,
+and the conflict tiebreaker for the install merge.
+
+### Use (exclusive switch)
 
 ```bash
-sx profile use work
+sx profile use <name>          # exclusive: deactivates all others
 ```
 
-This sets the default profile for all future sx commands.
+`use` is the original single-profile workflow: it sets `<name>` as the
+only active profile and the default. Equivalent to deactivating
+everything else and then `sx profile default <name>`.
 
-### Show Current Profile
-
-Display the currently active profile:
+### Edit identity
 
 ```bash
-sx profile current
+sx profile edit <name> --identity alice@company.com
+sx profile edit <name>          # interactive prompt
 ```
 
-**Output:**
+The identity email is used to resolve team and user scopes for this
+profile. When empty, sx falls back to `git config user.email`.
 
-```
-work
-```
-
-### Remove a Profile
-
-Delete a profile:
+### Remove a profile
 
 ```bash
 sx profile remove <profile-name>
 ```
 
-**Example:**
+You cannot remove the last remaining profile. If the removed profile
+was the default, sx picks a new default automatically.
+
+### Current
 
 ```bash
-sx profile remove old-profile
+sx profile current
 ```
 
-You cannot remove the last remaining profile.
+Prints every active profile, one per line, with `(default)` after the
+default profile.
 
-## Profile Selection Priority
+## Profile selection priority
 
-The active profile is determined by (in order of priority):
+For a single command:
 
-1. **`--profile` flag** - Explicit flag on any command
-2. **`SX_PROFILE` environment variable** - Session-level override
-3. **Default profile** - Configured via `sx profile use`
+1. **`--profile` flag** — explicit override (accepts comma-separated
+   names for multi-active, e.g. `--profile work,personal`).
+2. **`SX_PROFILE` env var** — session-level override, same syntax.
+3. **`ActiveProfiles` from config** — the persisted active set.
 
-### Using the `--profile` Flag
+When an override is provided, its order is preserved. Otherwise sx
+bubbles the default profile to the front of the active set so it wins
+conflicts.
 
-Run any sx command with a specific profile:
+## Conflict resolution between active profiles
 
-```bash
-sx install --profile work
-sx list --profile personal
-```
+When two active profiles publish an asset with the same name:
 
-### Using Environment Variables
+- If the default profile is one of them → the default wins silently
+  (info-level log entry).
+- If the default isn't in the active set → the first-listed active
+  profile wins, and sx prints a warning showing what was shadowed.
 
-Set the profile for an entire shell session:
+Shadowed assets aren't downloaded or installed; only the winner is.
 
-```bash
-export SX_PROFILE=work
-sx install  # Uses "work" profile
-sx list     # Uses "work" profile
-```
+### Cross-profile dependencies are not resolved
 
-This is useful for CI/CD environments or scripts.
+Dependency resolution runs **per profile**, against that profile's own
+lock file. If an asset in profile `work` declares a dependency on a
+skill that lives only in profile `personal`, `sx install` fails the
+work profile's resolve step rather than reaching across vaults. Bundle
+shared dependencies into the same vault if you need them to compose.
 
-## Configuration Storage
+## Configuration storage
 
-Profiles are stored in the sx configuration file at `~/.config/sx/config.json`:
+Profiles are stored in the sx configuration file at
+`~/.config/sx/config.json`:
 
 ```json
 {
-  "defaultProfile": "default",
+  "defaultProfile": "work",
+  "activeProfiles": ["work", "personal"],
   "profiles": {
-    "default": {
-      "type": "sleuth",
-      "repositoryUrl": "https://app.skills.new",
-      "authToken": "..."
-    },
     "work": {
       "type": "git",
-      "repositoryUrl": "git@github.com:company/skills.git"
+      "repositoryUrl": "git@github.com:company/skills.git",
+      "identity": "alice@company.com"
     },
-    "local": {
-      "type": "path",
-      "repositoryUrl": "file:///Users/me/.sx/vault"
+    "personal": {
+      "type": "git",
+      "repositoryUrl": "git@github.com:alice/skills.git",
+      "identity": "alice@personal.com"
     }
-  },
-  "enabledClients": ["claude-code", "cursor"]
+  }
 }
 ```
 
-### Profile Fields
-
-Each profile contains:
+### Profile fields
 
 | Field | Description |
 |-------|-------------|
 | `type` | Vault type: `sleuth`, `git`, or `path` |
 | `repositoryUrl` | Vault URL or path |
-| `serverUrl` | (Sleuth only) Server URL if different from repositoryUrl |
+| `serverUrl` | (Sleuth only) Server URL if different from `repositoryUrl` |
 | `authToken` | (Sleuth only) OAuth authentication token |
+| `identity` | Email used to resolve team/user scopes (defaults to `git config user.email` when empty) |
 
-### Global Settings
-
-These settings apply to all profiles:
+### Top-level fields
 
 | Field | Description |
 |-------|-------------|
-| `defaultProfile` | Name of the default profile |
-| `enabledClients` | List of AI clients to install assets to |
+| `defaultProfile` | Write-target profile and conflict tiebreaker |
+| `activeProfiles` | Ordered list of profiles `sx install` reads from |
+| `forceEnabledClients` / `forceDisabledClients` | Global client toggles |
 
 ## Examples
 
-### Example 1: Personal and Work Separation
-
-Set up separate profiles for personal and work projects:
+### Work + personal active at the same time
 
 ```bash
-# Initial setup creates "default" profile
-sx init
+sx profile add work       # configure work vault + identity
+sx profile add personal   # configure personal vault + identity
+sx profile activate personal  # add to active set alongside work
 
-# Add work profile connected to company vault
-sx profile add work
-# Select "Share with my team" -> "Git repository"
-# Enter: git@github.com:company/skills.git
-
-# Switch between them
-sx profile use default   # Personal projects
-sx profile use work      # Work projects
+# sx install now resolves assets from both vaults
+sx install
 ```
 
-### Example 2: Local Development
-
-Create a local profile for testing new skills:
+### One-off command against a single profile
 
 ```bash
-sx profile add local
-# Select "Just for myself"
-# Uses local vault at ~/.config/sx/vault
-
-# Test skills locally
-sx profile use local
-sx add ./my-new-skill
-
-# Switch back to shared vault
-sx profile use default
+sx install --profile work    # ignore other active profiles for this run
+sx add ./my-skill --profile personal  # publish to personal vault
 ```
 
-### Example 3: CI/CD Pipeline
+### Switch exclusively
 
-Use environment variables in CI:
+```bash
+sx profile use work    # work is now the only active profile
+```
+
+### CI/CD
 
 ```yaml
-# .github/workflows/deploy.yml
 jobs:
   deploy:
     env:
       SX_PROFILE: production
     steps:
       - run: sx install
-```
-
-### Example 4: Quick Profile Override
-
-Use a different profile for a single command:
-
-```bash
-# Install from work vault into current project
-sx install --profile work
-
-# List assets from personal vault
-sx list --profile personal
 ```

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -12,7 +12,7 @@ more than one:
 
 Profiles can be active one-at-a-time (the classic single-profile model)
 or several-at-once. When more than one profile is active, `sx install`
-fetches every active profile's lock file in sequence and merges the
+fetches every active profile's lock file in parallel and merges the
 applicable assets into one installation pass.
 
 Each profile carries its own vault URL, auth, and an optional

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -12,7 +12,7 @@ more than one:
 
 Profiles can be active one-at-a-time (the classic single-profile model)
 or several-at-once. When more than one profile is active, `sx install`
-fetches every active profile's lock file in parallel and merges the
+fetches every active profile's lock file in sequence and merges the
 applicable assets into one installation pass.
 
 Each profile carries its own vault URL, auth, and an optional

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -147,6 +147,16 @@ When two active profiles publish an asset with the same name:
 
 Shadowed assets aren't downloaded or installed; only the winner is.
 
+### Mutating commands target the default profile
+
+`sx add`, `sx install <asset> --org/--repo/--team/...`, `sx team`,
+`sx role`, and similar mutating commands write to the **default**
+profile's vault when no `--profile` flag is given. `sx install`'s
+set-target form verifies that the asset exists in that vault before
+writing and errors with a hint to use `--profile <name>` if it
+doesn't — so retargeting an asset that lives in a non-default active
+profile is a one-flag change.
+
 ### Cross-profile dependencies are not resolved
 
 Dependency resolution runs **per profile**, against that profile's own

--- a/internal/assets/fetcher.go
+++ b/internal/assets/fetcher.go
@@ -18,20 +18,25 @@ import (
 
 // AssetFetcher handles fetching assets from a vault
 type AssetFetcher struct {
-	vault vaultpkg.Vault
+	vault    vaultpkg.Vault
+	vaultKey string
 }
 
-// NewAssetFetcher creates a new asset fetcher
-func NewAssetFetcher(vault vaultpkg.Vault) *AssetFetcher {
+// NewAssetFetcher creates a new asset fetcher. vaultKey, when non-empty,
+// partitions the disk cache by vault so two vaults that publish the
+// same name@version don't collide. Empty key keeps the legacy global
+// cache layout.
+func NewAssetFetcher(vault vaultpkg.Vault, vaultKey string) *AssetFetcher {
 	return &AssetFetcher{
-		vault: vault,
+		vault:    vault,
+		vaultKey: vaultKey,
 	}
 }
 
 // FetchAsset downloads a single asset
 func (f *AssetFetcher) FetchAsset(ctx context.Context, asset *lockfile.Asset) (zipData []byte, meta *metadata.Metadata, err error) {
 	// Try disk cache first
-	zipData, err = cache.LoadAssetFromDisk(asset.Name, asset.Version)
+	zipData, err = cache.LoadAssetFromDisk(asset.Name, asset.Version, f.vaultKey)
 	if err == nil {
 		// Cache hit, extract metadata and return
 		metadataBytes, err := utils.ReadZipFile(zipData, "metadata.toml")
@@ -73,7 +78,7 @@ func (f *AssetFetcher) FetchAsset(ctx context.Context, asset *lockfile.Asset) (z
 	}
 
 	// Cache to disk for future use
-	_ = cache.SaveAssetToDisk(asset.Name, asset.Version, zipData)
+	_ = cache.SaveAssetToDisk(asset.Name, asset.Version, f.vaultKey, zipData)
 	// Ignore cache save errors - not critical
 
 	return zipData, meta, nil
@@ -82,7 +87,7 @@ func (f *AssetFetcher) FetchAsset(ctx context.Context, asset *lockfile.Asset) (z
 // FetchAssetWithProgress downloads a single asset with progress bar
 func (f *AssetFetcher) FetchAssetWithProgress(ctx context.Context, asset *lockfile.Asset, bar *progressbar.ProgressBar) (zipData []byte, meta *metadata.Metadata, err error) {
 	// Try disk cache first
-	zipData, err = cache.LoadAssetFromDisk(asset.Name, asset.Version)
+	zipData, err = cache.LoadAssetFromDisk(asset.Name, asset.Version, f.vaultKey)
 	if err == nil {
 		// Cache hit, extract metadata and return
 		metadataBytes, err := utils.ReadZipFile(zipData, "metadata.toml")
@@ -134,7 +139,7 @@ func (f *AssetFetcher) FetchAssetWithProgress(ctx context.Context, asset *lockfi
 	}
 
 	// Cache to disk for future use
-	_ = cache.SaveAssetToDisk(asset.Name, asset.Version, zipData)
+	_ = cache.SaveAssetToDisk(asset.Name, asset.Version, f.vaultKey, zipData)
 	// Ignore cache save errors - not critical
 
 	return zipData, meta, nil

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -127,15 +127,22 @@ func EnsureCacheDirs() error {
 	return nil
 }
 
-// GetAssetCachePath returns the cache path for a specific asset
-func GetAssetCachePath(name, version string) (string, error) {
+// GetAssetCachePath returns the cache path for a specific asset.
+// vaultKey, when non-empty, partitions the cache by vault so two
+// vaults that publish the same name@version don't collide. Empty
+// vaultKey keeps the legacy single-vault path so existing caches
+// remain valid.
+func GetAssetCachePath(name, version, vaultKey string) (string, error) {
 	assetCacheDir, err := GetAssetCacheDir()
 	if err != nil {
 		return "", err
 	}
 	// Use sanitized name for directory safety
 	safeName := filepath.Base(filepath.Clean(name))
-	return filepath.Join(assetCacheDir, safeName, version+".zip"), nil
+	if vaultKey == "" {
+		return filepath.Join(assetCacheDir, safeName, version+".zip"), nil
+	}
+	return filepath.Join(assetCacheDir, "by-vault", utils.URLHash(vaultKey), safeName, version+".zip"), nil
 }
 
 // GetGitRepoCachePath returns the cache path for a git repository
@@ -379,9 +386,9 @@ func GetTrackerCachePath(scopeKey string) (string, error) {
 	return filepath.Join(trackerDir, scopeKey+".json"), nil
 }
 
-// SaveAssetToDisk caches an asset zip to disk
-func SaveAssetToDisk(name, version string, data []byte) error {
-	cachePath, err := GetAssetCachePath(name, version)
+// SaveAssetToDisk caches an asset zip to disk under the given vault key.
+func SaveAssetToDisk(name, version, vaultKey string, data []byte) error {
+	cachePath, err := GetAssetCachePath(name, version, vaultKey)
 	if err != nil {
 		return err
 	}
@@ -399,9 +406,9 @@ func SaveAssetToDisk(name, version string, data []byte) error {
 	return os.WriteFile(cachePath, data, 0644)
 }
 
-// LoadAssetFromDisk loads a cached asset from disk
-func LoadAssetFromDisk(name, version string) ([]byte, error) {
-	cachePath, err := GetAssetCachePath(name, version)
+// LoadAssetFromDisk loads a cached asset from disk for the given vault.
+func LoadAssetFromDisk(name, version, vaultKey string) ([]byte, error) {
+	cachePath, err := GetAssetCachePath(name, version, vaultKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -485,8 +485,9 @@ func gatherUnifiedAssets(currentScope *scope.Scope, showAll bool) []ScopeAssets 
 		return nil
 	}
 
-	// Load lock file
-	lockFileData, err := cache.LoadLockFile(cfg.RepositoryURL)
+	// Load lock file (key by VaultIdentifier so legacy Sleuth profiles
+	// with only ServerURL set still find their cached entry).
+	lockFileData, err := cache.LoadLockFile(cfg.VaultIdentifier())
 	if err != nil || len(lockFileData) == 0 {
 		return nil
 	}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -445,10 +445,11 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 			profileOrder = append(profileOrder, pl.ProfileName)
 		}
 	}
-	// loadActiveLockFiles flipped the identity + audit overrides for each
-	// profile during the per-vault fetch. Restore both to the primary
-	// profile so any audit events emitted by the rest of the flow attribute
-	// correctly. Per-profile swaps happen again inside the download step.
+	// Lock-file fetches ran in parallel with identity scoped per goroutine
+	// via context, so the process-global override was not touched. Set
+	// it (and the audit tag) to the primary profile now so any audit
+	// events emitted by the rest of the flow attribute correctly. The
+	// download step swaps both again per vault group.
 	mgmt.SetIdentityOverride(primaryCfg.Identity)
 	mgmt.SetAuditProfileTag(primaryCfg.ProfileName)
 

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -912,12 +912,14 @@ func installClientHooks(ctx context.Context, targetClients []clients.Client, pro
 
 // collectActiveVaultBootstrapOptions visits every active profile's vault
 // in the configured order, swapping the process-global identity/audit
-// overrides per call, and returns the concatenated options. The primary
-// profile's overrides are restored before returning so the caller's
-// subsequent operations attribute correctly.
+// overrides per call, and returns the concatenated options deduplicated
+// by Option.Key (first occurrence wins, matching the asset conflict
+// policy). The primary profile's overrides are restored before
+// returning so the caller's subsequent operations attribute correctly.
 func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string) []bootstrap.Option {
 	log := logger.Get()
 	var allOpts []bootstrap.Option
+	seen := make(map[string]string) // key → winning profile name
 	for _, name := range profileOrder {
 		meta, ok := profileMeta[name]
 		if !ok || meta.Vault == nil {
@@ -925,8 +927,14 @@ func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[str
 		}
 		mgmt.SetIdentityOverride(meta.Identity)
 		mgmt.SetAuditProfileTag(meta.Profile)
-		if opts := meta.Vault.GetBootstrapOptions(ctx); opts != nil {
-			allOpts = append(allOpts, opts...)
+		opts := meta.Vault.GetBootstrapOptions(ctx)
+		for _, opt := range opts {
+			if winner, taken := seen[opt.Key]; taken {
+				log.Debug("bootstrap option shadowed by earlier profile", "key", opt.Key, "winner", winner, "shadowed", name)
+				continue
+			}
+			seen[opt.Key] = name
+			allOpts = append(allOpts, opt)
 		}
 	}
 	// Restore overrides to the primary profile so the surrounding flow

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/metadata"
+	"github.com/sleuth-io/sx/internal/mgmt"
 	"github.com/sleuth-io/sx/internal/scope"
 	"github.com/sleuth-io/sx/internal/ui"
 	"github.com/sleuth-io/sx/internal/ui/components"
@@ -324,21 +325,13 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 	// Handle Cursor workspace directory in hook mode
 	handleCursorWorkspace(hookMode, effectiveClientsFlag, log)
 
-	// Load and validate configuration
-	cfg, vault, err := loadConfigAndVault()
+	// Load every active profile's configuration and fetch their lock files.
+	profileLocks, mpc, primaryCfg, cfg, done, err := loadActiveProfilesAndLockFiles(ctx, status, styledOut)
 	if err != nil {
 		return err
 	}
-
-	// Fetch and parse lock file
-	lockFile, err := fetchLockFileWithCache(ctx, vault, cfg, status)
-	if err != nil {
-		if errors.Is(err, vaultpkg.ErrLockFileNotFound) {
-			styledOut.Info("No assets installed yet.")
-			styledOut.Muted("Add skills with 'sx add' or browse skills.sh with 'sx add --browse'.")
-			return nil
-		}
-		return err
+	if done {
+		return nil
 	}
 
 	// Detect environment (git context, scope, clients)
@@ -368,14 +361,22 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 		return nil
 	}
 
-	// Filter and resolve assets
+	// Filter and resolve assets across every active profile, applying
+	// the default-wins / first-active-wins conflict policy. Precedence
+	// for "first-active" is whichever profile appears first in
+	// profileLocks (already ordered per config.GetActiveProfileNames).
 	matcherScope := scope.NewMatcher(env.CurrentScope)
-	applicableAssets := filterAssetsByScope(lockFile, env.Clients, matcherScope)
-
-	sortedAssets, err := resolveAssetDependencies(lockFile, applicableAssets)
+	sortedAssets, assetVault, conflicts, err := mergeApplicableAssets(profileLocks, env.Clients, matcherScope)
 	if err != nil {
 		return err
 	}
+	if len(conflicts) > 0 {
+		reportConflicts(conflicts, mpc.DefaultProfile, styledOut)
+	}
+	// loadActiveLockFiles flipped the identity override for each profile
+	// during the per-vault fetch. Restore it to the primary profile for
+	// the rest of the flow.
+	mgmt.SetIdentityOverride(primaryCfg.Identity)
 
 	// --dry-run: print the resolved asset list and exit before we touch
 	// the tracker, download anything, or write to client directories.
@@ -403,8 +404,8 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 		return handleNothingToInstall(ctx, hookMode, tracker, sortedAssets, env, targetClientIDs, styledOut, out)
 	}
 
-	// Download assets
-	downloadResult, err := downloadAssetsWithStatus(ctx, vault, assetsToInstall, status, styledOut)
+	// Download assets, routing each to the vault of its origin profile.
+	downloadResult, err := downloadAssetsMultiVault(ctx, assetsToInstall, assetVault, status, styledOut)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -366,17 +366,26 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 	// for "first-active" is whichever profile appears first in
 	// profileLocks (already ordered per config.GetActiveProfileNames).
 	matcherScope := scope.NewMatcher(env.CurrentScope)
-	sortedAssets, assetVault, conflicts, err := mergeApplicableAssets(profileLocks, env.Clients, matcherScope)
+	sortedAssets, _, assetOrigin, conflicts, err := mergeApplicableAssets(profileLocks, env.Clients, matcherScope)
 	if err != nil {
 		return err
 	}
 	if len(conflicts) > 0 {
 		reportConflicts(conflicts, mpc.DefaultProfile, styledOut)
 	}
-	// loadActiveLockFiles flipped the identity override for each profile
-	// during the per-vault fetch. Restore it to the primary profile for
-	// the rest of the flow.
+	profileMeta := buildProfileMetadata(profileLocks)
+	profileOrder := make([]string, 0, len(profileLocks))
+	for _, pl := range profileLocks {
+		if pl.LockFile != nil {
+			profileOrder = append(profileOrder, pl.ProfileName)
+		}
+	}
+	// loadActiveLockFiles flipped the identity + audit overrides for each
+	// profile during the per-vault fetch. Restore both to the primary
+	// profile so any audit events emitted by the rest of the flow attribute
+	// correctly. Per-profile swaps happen again inside the download step.
 	mgmt.SetIdentityOverride(primaryCfg.Identity)
+	mgmt.SetAuditProfileTag(primaryCfg.ProfileName)
 
 	// --dry-run: print the resolved asset list and exit before we touch
 	// the tracker, download anything, or write to client directories.
@@ -404,11 +413,17 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 		return handleNothingToInstall(ctx, hookMode, tracker, sortedAssets, env, targetClientIDs, styledOut, out)
 	}
 
-	// Download assets, routing each to the vault of its origin profile.
-	downloadResult, err := downloadAssetsMultiVault(ctx, assetsToInstall, assetVault, status, styledOut)
+	// Download assets, routing each to its origin profile's vault and
+	// swapping the identity/audit overrides per group so attribution
+	// matches the originating profile.
+	downloadResult, err := downloadAssetsMultiVault(ctx, assetsToInstall, assetOrigin, profileMeta, profileOrder, status, styledOut)
 	if err != nil {
 		return err
 	}
+	// Restore primary overrides once downloads complete; remaining flow
+	// (install hooks, tracker save, bootstrap) belongs to the primary.
+	mgmt.SetIdentityOverride(primaryCfg.Identity)
+	mgmt.SetAuditProfileTag(primaryCfg.ProfileName)
 
 	// Install assets to their appropriate locations
 	installResult := installAssets(ctx, downloadResult.Downloads, env.GitContext, env.CurrentScope, env.Clients, styledOut, strict)

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -217,6 +217,11 @@ func runInstallSetTarget(cmd *cobra.Command, assetName string, f installTargetFl
 // a one-step --profile suggestion. Only called from the error path so
 // the identity override is left in whatever state was last set — the
 // command is about to terminate either way.
+//
+// The survey is best-effort: each per-vault lookup gets a short
+// timeout (so a typo on a Sleuth profile doesn't hang for the full
+// 5-minute install budget), and the loop bails on parent ctx
+// cancellation to keep Ctrl-C responsive.
 func findAssetOwningProfile(ctx context.Context, assetName string) string {
 	configs, _, err := config.LoadActive()
 	if err != nil {
@@ -227,6 +232,9 @@ func findAssetOwningProfile(ctx context.Context, assetName string) string {
 		defaultName = configs[0].ProfileName
 	}
 	for _, cfg := range configs {
+		if err := ctx.Err(); err != nil {
+			return ""
+		}
 		if cfg.ProfileName == defaultName {
 			continue
 		}
@@ -235,7 +243,10 @@ func findAssetOwningProfile(ctx context.Context, assetName string) string {
 		if err != nil {
 			continue
 		}
-		if _, err := vault.GetAssetDetails(ctx, assetName); err == nil {
+		probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		_, err = vault.GetAssetDetails(probeCtx, assetName)
+		cancel()
+		if err == nil {
 			return cfg.ProfileName
 		}
 	}
@@ -268,12 +279,13 @@ func buildInstallTarget(f installTargetFlags) (vaultpkg.InstallTarget, error) {
 // install context (scope, clients) without any side effects. Format
 // mirrors `pip freeze` — one line per asset with name, version, and
 // the matched scope — plus a header so the output is self-explanatory
-// when piped. When more than one profile contributed an asset
-// (multi-active mode), each line gets a `; profile=<name>` suffix so
-// users can see which vault each asset came from. Single-profile
-// output is left unchanged so existing scripts that parse the
-// `pip freeze`-style format keep working.
-func printDryRunPreview(w io.Writer, assets []*lockfile.Asset, env *installEnvironment, assetOrigin map[string]string) {
+// when piped. When the user has more than one active profile, each
+// line gets a `; profile=<name>` suffix so users can see which vault
+// each asset came from (and which profiles contributed zero is
+// implicit by absence). Single-profile output is left unchanged so
+// existing scripts that parse the `pip freeze`-style format keep
+// working.
+func printDryRunPreview(w io.Writer, assets []*lockfile.Asset, env *installEnvironment, assetOrigin map[string]string, multiActive bool) {
 	if len(assets) == 0 {
 		fmt.Fprintln(w, "# No assets resolved for this context.")
 		fmt.Fprintln(w, "# Checked clients:", strings.Join(getTargetClientIDs(env.Clients), ", "))
@@ -287,37 +299,15 @@ func printDryRunPreview(w io.Writer, assets []*lockfile.Asset, env *installEnvir
 	}
 	fmt.Fprintln(w)
 
-	showProfile := hasMultipleProfileOrigins(assets, assetOrigin)
 	for _, a := range assets {
 		scopeDesc := describeAssetScopeForDryRun(a)
-		if showProfile {
+		if multiActive {
 			origin := assetOrigin[a.Name]
 			fmt.Fprintf(w, "%s==%s  # %s; scope=%s; profile=%s\n", a.Name, a.Version, a.Type, scopeDesc, origin)
 		} else {
 			fmt.Fprintf(w, "%s==%s  # %s; scope=%s\n", a.Name, a.Version, a.Type, scopeDesc)
 		}
 	}
-}
-
-// hasMultipleProfileOrigins reports whether the assets in the slice
-// came from more than one profile, which is the signal to widen the
-// dry-run output with origin info.
-func hasMultipleProfileOrigins(assets []*lockfile.Asset, assetOrigin map[string]string) bool {
-	seen := ""
-	for _, a := range assets {
-		origin, ok := assetOrigin[a.Name]
-		if !ok || origin == "" {
-			continue
-		}
-		if seen == "" {
-			seen = origin
-			continue
-		}
-		if origin != seen {
-			return true
-		}
-	}
-	return false
 }
 
 // describeCurrentScope renders a short label for the caller's current
@@ -465,7 +455,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 	// --dry-run: print the resolved asset list and exit before we touch
 	// the tracker, download anything, or write to client directories.
 	if dryRun {
-		printDryRunPreview(cmd.OutOrStdout(), sortedAssets, env, assetOrigin)
+		printDryRunPreview(cmd.OutOrStdout(), sortedAssets, env, assetOrigin, len(profileOrder) > 1)
 		return nil
 	}
 
@@ -953,8 +943,10 @@ func installClientHooks(ctx context.Context, targetClients []clients.Client, pro
 
 	// Union vault bootstrap options across every active profile. Swap the
 	// identity + audit overrides per vault so any audit-emitting call
-	// inside GetBootstrapOptions attributes correctly.
-	vaultOpts := collectActiveVaultBootstrapOptions(ctx, profileMeta, profileOrder, primaryProfile, styledOut)
+	// inside GetBootstrapOptions attributes correctly. Shadowing is
+	// reported with the same severity policy as asset conflicts: muted
+	// when the default profile wins, warning otherwise.
+	vaultOpts := collectActiveVaultBootstrapOptions(ctx, profileMeta, profileOrder, primaryProfile, mpc.DefaultProfile, styledOut)
 
 	for _, client := range targetClients {
 		// Gather all options (every active vault + this client)
@@ -981,7 +973,7 @@ func installClientHooks(ctx context.Context, targetClients []clients.Client, pro
 // by Option.Key (first occurrence wins, matching the asset conflict
 // policy). The primary profile's overrides are restored before
 // returning so the caller's subsequent operations attribute correctly.
-func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string, styledOut *ui.Output) []bootstrap.Option {
+func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile, defaultProfile string, styledOut *ui.Output) []bootstrap.Option {
 	log := logger.Get()
 	var allOpts []bootstrap.Option
 	seen := make(map[string]string) // key → winning profile name
@@ -997,7 +989,12 @@ func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[str
 			if winner, taken := seen[opt.Key]; taken {
 				log.Debug("bootstrap option shadowed by earlier profile", "key", opt.Key, "winner", winner, "shadowed", name)
 				if styledOut != nil {
-					styledOut.Muted(fmt.Sprintf("bootstrap option %s shadowed: %s wins, %s ignored", opt.Key, winner, name))
+					msg := fmt.Sprintf("bootstrap option %s shadowed: %s wins, %s ignored", opt.Key, winner, name)
+					if defaultProfile != "" && winner == defaultProfile {
+						styledOut.Muted(msg)
+					} else {
+						styledOut.Warning(msg)
+					}
 				}
 				continue
 			}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -930,12 +930,30 @@ func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[str
 		}
 	}
 	// Restore overrides to the primary profile so the surrounding flow
-	// continues attributing audit events correctly.
+	// continues attributing audit events correctly. If primary isn't in
+	// the metadata (its fetch failed but the install proceeded via
+	// partial-failure tolerance), fall back to the first profile that
+	// did contribute — never leave the override pointing at whichever
+	// profile happened to be last in the loop above.
+	restored := false
 	if primary, ok := profileMeta[primaryProfile]; ok {
 		mgmt.SetIdentityOverride(primary.Identity)
 		mgmt.SetAuditProfileTag(primary.Profile)
-	} else {
-		log.Debug("primary profile missing from metadata when restoring overrides", "primary", primaryProfile)
+		restored = true
+	}
+	if !restored {
+		for _, name := range profileOrder {
+			if fallback, ok := profileMeta[name]; ok {
+				mgmt.SetIdentityOverride(fallback.Identity)
+				mgmt.SetAuditProfileTag(fallback.Profile)
+				log.Debug("primary profile missing from metadata; restored to fallback", "primary", primaryProfile, "fallback", name)
+				restored = true
+				break
+			}
+		}
+	}
+	if !restored {
+		log.Debug("no profiles in metadata to restore overrides", "primary", primaryProfile)
 	}
 	return allOpts
 }

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -177,6 +177,16 @@ func runInstallSetTarget(cmd *cobra.Command, assetName string, f installTargetFl
 		return err
 	}
 
+	// Verify the asset exists in the chosen vault before mutating. In
+	// multi-active setups the asset the user wants to retarget might be
+	// owned by a non-default profile's vault, and writing to the default
+	// vault would either fail mid-flight or (worse) succeed against an
+	// unrelated row with the same name. Catch this up front with a
+	// clear error pointing at --profile.
+	if _, err := v.GetAssetDetails(ctx, assetName); err != nil {
+		return fmt.Errorf("asset %q not found in the default profile's vault: %w (if it lives in another profile, retry with --profile <name>)", assetName, err)
+	}
+
 	target, err := buildInstallTarget(f)
 	if err != nil {
 		return err
@@ -366,7 +376,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 	// for "first-active" is whichever profile appears first in
 	// profileLocks (already ordered per config.GetActiveProfileNames).
 	matcherScope := scope.NewMatcher(env.CurrentScope)
-	sortedAssets, _, assetOrigin, conflicts, err := mergeApplicableAssets(profileLocks, env.Clients, matcherScope)
+	sortedAssets, assetOrigin, conflicts, err := mergeApplicableAssets(profileLocks, env.Clients, matcherScope)
 	if err != nil {
 		return err
 	}
@@ -405,8 +415,16 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 
 	assetsToInstall := determineAssetsToInstall(tracker, sortedAssets, env.CurrentScope, targetClientIDs, out)
 
-	// Clean up assets that were removed from lock file (must run even if no assets to install!)
-	cleanupRemovedAssets(ctx, tracker, sortedAssets, env.GitContext, env.CurrentScope, env.Clients, styledOut)
+	// Clean up assets that were removed from lock file — but only if every
+	// active profile produced a lock file. With multi-active profiles a
+	// transient fetch failure on one vault would otherwise look like
+	// "every asset from that vault was removed" and trigger wrongful
+	// uninstalls. Treat ErrLockFileNotFound (fresh setup) as benign.
+	if hadHardFetchFailure(profileLocks) {
+		styledOut.Warning("Skipping removed-asset cleanup because one or more profiles failed to fetch.")
+	} else {
+		cleanupRemovedAssets(ctx, tracker, sortedAssets, env.GitContext, env.CurrentScope, env.Clients, styledOut)
+	}
 
 	// Early exit if nothing to install
 	if len(assetsToInstall) == 0 {

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -410,7 +410,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 
 	// Early exit if nothing to install
 	if len(assetsToInstall) == 0 {
-		return handleNothingToInstall(ctx, hookMode, tracker, sortedAssets, env, targetClientIDs, styledOut, out)
+		return handleNothingToInstall(ctx, hookMode, tracker, sortedAssets, env, targetClientIDs, profileMeta, profileOrder, primaryCfg.ProfileName, styledOut, out)
 	}
 
 	// Download assets, routing each to its origin profile's vault and
@@ -441,7 +441,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 
 	// Install client-specific hooks (e.g., auto-update, usage tracking)
 	// env.Clients is already filtered by --client/--clients flag
-	installClientHooks(ctx, env.Clients, out)
+	installClientHooks(ctx, env.Clients, profileMeta, profileOrder, primaryCfg.ProfileName, out)
 
 	// Log summary
 	log.Info("install completed", "installed", len(installResult.Installed), "failed", len(installResult.Failed))
@@ -854,10 +854,13 @@ func processInstallationResults(allResults map[string]clients.InstallResponse, s
 
 // installClientHooks calls InstallHooks on all clients to install client-specific hooks.
 // Uses config's BootstrapOptions to determine which options to install.
-func installClientHooks(ctx context.Context, targetClients []clients.Client, out *outputHelper) {
+// Vault-side bootstrap items (session hooks, analytics hooks, MCP servers) are
+// gathered from every active profile so multi-active users still get the
+// bootstrap surface their non-default vaults publish.
+func installClientHooks(ctx context.Context, targetClients []clients.Client, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string, out *outputHelper) {
 	log := logger.Get()
 
-	// Load config to get bootstrap options
+	// Load config to get bootstrap option enable/disable settings.
 	mpc, err := config.LoadMultiProfile()
 	if err != nil {
 		log.Error("failed to load config for bootstrap options", "error", err)
@@ -865,17 +868,13 @@ func installClientHooks(ctx context.Context, targetClients []clients.Client, out
 		mpc = &config.MultiProfileConfig{}
 	}
 
-	// Load vault to get its bootstrap options
-	cfg, _ := config.Load()
-	var vaultOpts []bootstrap.Option
-	if cfg != nil {
-		if v, err := vaultpkg.NewFromConfig(cfg); err == nil {
-			vaultOpts = v.GetBootstrapOptions(ctx)
-		}
-	}
+	// Union vault bootstrap options across every active profile. Swap the
+	// identity + audit overrides per vault so any audit-emitting call
+	// inside GetBootstrapOptions attributes correctly.
+	vaultOpts := collectActiveVaultBootstrapOptions(ctx, profileMeta, profileOrder, primaryProfile)
 
 	for _, client := range targetClients {
-		// Gather all options (vault + this client)
+		// Gather all options (every active vault + this client)
 		var allOpts []bootstrap.Option
 		allOpts = append(allOpts, vaultOpts...)
 		if clientOpts := client.GetBootstrapOptions(ctx); clientOpts != nil {
@@ -891,6 +890,36 @@ func installClientHooks(ctx context.Context, targetClients []clients.Client, out
 			// Don't fail the install command if hook installation fails
 		}
 	}
+}
+
+// collectActiveVaultBootstrapOptions visits every active profile's vault
+// in the configured order, swapping the process-global identity/audit
+// overrides per call, and returns the concatenated options. The primary
+// profile's overrides are restored before returning so the caller's
+// subsequent operations attribute correctly.
+func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string) []bootstrap.Option {
+	log := logger.Get()
+	var allOpts []bootstrap.Option
+	for _, name := range profileOrder {
+		meta, ok := profileMeta[name]
+		if !ok || meta.Vault == nil {
+			continue
+		}
+		mgmt.SetIdentityOverride(meta.Identity)
+		mgmt.SetAuditProfileTag(meta.Profile)
+		if opts := meta.Vault.GetBootstrapOptions(ctx); opts != nil {
+			allOpts = append(allOpts, opts...)
+		}
+	}
+	// Restore overrides to the primary profile so the surrounding flow
+	// continues attributing audit events correctly.
+	if primary, ok := profileMeta[primaryProfile]; ok {
+		mgmt.SetIdentityOverride(primary.Identity)
+		mgmt.SetAuditProfileTag(primary.Profile)
+	} else {
+		log.Debug("primary profile missing from metadata when restoring overrides", "primary", primaryProfile)
+	}
+	return allOpts
 }
 
 // ensureAssetSupport calls EnsureAssetSupport on all clients to set up local rules files, etc.

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -181,9 +181,12 @@ func runInstallSetTarget(cmd *cobra.Command, assetName string, f installTargetFl
 	// multi-active setups the asset the user wants to retarget might be
 	// owned by a non-default profile's vault, and writing to the default
 	// vault would either fail mid-flight or (worse) succeed against an
-	// unrelated row with the same name. Catch this up front with a
-	// clear error pointing at --profile.
+	// unrelated row with the same name. Catch this up front and, when
+	// possible, name the profile that actually owns the asset.
 	if _, err := v.GetAssetDetails(ctx, assetName); err != nil {
+		if owner := findAssetOwningProfile(ctx, assetName); owner != "" {
+			return fmt.Errorf("asset %q not found in the default profile's vault: %w (asset lives in profile %q — retry with --profile %s)", assetName, err, owner, owner)
+		}
 		return fmt.Errorf("asset %q not found in the default profile's vault: %w (if it lives in another profile, retry with --profile <name>)", assetName, err)
 	}
 
@@ -206,6 +209,37 @@ func runInstallSetTarget(cmd *cobra.Command, assetName string, f installTargetFl
 	}
 	status.Done("Updated installation target for " + assetName)
 	return nil
+}
+
+// findAssetOwningProfile surveys the other active profiles' vaults for
+// an asset by name. Returns the first matching profile name, or empty
+// when none have it. Used to turn the set-target "not found" error into
+// a one-step --profile suggestion. Only called from the error path so
+// the identity override is left in whatever state was last set — the
+// command is about to terminate either way.
+func findAssetOwningProfile(ctx context.Context, assetName string) string {
+	configs, _, err := config.LoadActive()
+	if err != nil {
+		return ""
+	}
+	defaultName := ""
+	if len(configs) > 0 {
+		defaultName = configs[0].ProfileName
+	}
+	for _, cfg := range configs {
+		if cfg.ProfileName == defaultName {
+			continue
+		}
+		mgmt.SetIdentityOverride(cfg.Identity)
+		vault, err := vaultpkg.NewFromConfig(cfg)
+		if err != nil {
+			continue
+		}
+		if _, err := vault.GetAssetDetails(ctx, assetName); err == nil {
+			return cfg.ProfileName
+		}
+	}
+	return ""
 }
 
 func buildInstallTarget(f installTargetFlags) (vaultpkg.InstallTarget, error) {
@@ -234,8 +268,12 @@ func buildInstallTarget(f installTargetFlags) (vaultpkg.InstallTarget, error) {
 // install context (scope, clients) without any side effects. Format
 // mirrors `pip freeze` — one line per asset with name, version, and
 // the matched scope — plus a header so the output is self-explanatory
-// when piped.
-func printDryRunPreview(w io.Writer, assets []*lockfile.Asset, env *installEnvironment) {
+// when piped. When more than one profile contributed an asset
+// (multi-active mode), each line gets a `; profile=<name>` suffix so
+// users can see which vault each asset came from. Single-profile
+// output is left unchanged so existing scripts that parse the
+// `pip freeze`-style format keep working.
+func printDryRunPreview(w io.Writer, assets []*lockfile.Asset, env *installEnvironment, assetOrigin map[string]string) {
 	if len(assets) == 0 {
 		fmt.Fprintln(w, "# No assets resolved for this context.")
 		fmt.Fprintln(w, "# Checked clients:", strings.Join(getTargetClientIDs(env.Clients), ", "))
@@ -249,10 +287,37 @@ func printDryRunPreview(w io.Writer, assets []*lockfile.Asset, env *installEnvir
 	}
 	fmt.Fprintln(w)
 
+	showProfile := hasMultipleProfileOrigins(assets, assetOrigin)
 	for _, a := range assets {
 		scopeDesc := describeAssetScopeForDryRun(a)
-		fmt.Fprintf(w, "%s==%s  # %s; scope=%s\n", a.Name, a.Version, a.Type, scopeDesc)
+		if showProfile {
+			origin := assetOrigin[a.Name]
+			fmt.Fprintf(w, "%s==%s  # %s; scope=%s; profile=%s\n", a.Name, a.Version, a.Type, scopeDesc, origin)
+		} else {
+			fmt.Fprintf(w, "%s==%s  # %s; scope=%s\n", a.Name, a.Version, a.Type, scopeDesc)
+		}
 	}
+}
+
+// hasMultipleProfileOrigins reports whether the assets in the slice
+// came from more than one profile, which is the signal to widen the
+// dry-run output with origin info.
+func hasMultipleProfileOrigins(assets []*lockfile.Asset, assetOrigin map[string]string) bool {
+	seen := ""
+	for _, a := range assets {
+		origin, ok := assetOrigin[a.Name]
+		if !ok || origin == "" {
+			continue
+		}
+		if seen == "" {
+			seen = origin
+			continue
+		}
+		if origin != seen {
+			return true
+		}
+	}
+	return false
 }
 
 // describeCurrentScope renders a short label for the caller's current
@@ -400,7 +465,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 	// --dry-run: print the resolved asset list and exit before we touch
 	// the tracker, download anything, or write to client directories.
 	if dryRun {
-		printDryRunPreview(cmd.OutOrStdout(), sortedAssets, env)
+		printDryRunPreview(cmd.OutOrStdout(), sortedAssets, env, assetOrigin)
 		return nil
 	}
 
@@ -459,7 +524,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 
 	// Install client-specific hooks (e.g., auto-update, usage tracking)
 	// env.Clients is already filtered by --client/--clients flag
-	installClientHooks(ctx, env.Clients, profileMeta, profileOrder, primaryCfg.ProfileName, out)
+	installClientHooks(ctx, env.Clients, profileMeta, profileOrder, primaryCfg.ProfileName, styledOut, out)
 
 	// Log summary
 	log.Info("install completed", "installed", len(installResult.Installed), "failed", len(installResult.Failed))
@@ -875,7 +940,7 @@ func processInstallationResults(allResults map[string]clients.InstallResponse, s
 // Vault-side bootstrap items (session hooks, analytics hooks, MCP servers) are
 // gathered from every active profile so multi-active users still get the
 // bootstrap surface their non-default vaults publish.
-func installClientHooks(ctx context.Context, targetClients []clients.Client, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string, out *outputHelper) {
+func installClientHooks(ctx context.Context, targetClients []clients.Client, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string, styledOut *ui.Output, out *outputHelper) {
 	log := logger.Get()
 
 	// Load config to get bootstrap option enable/disable settings.
@@ -889,7 +954,7 @@ func installClientHooks(ctx context.Context, targetClients []clients.Client, pro
 	// Union vault bootstrap options across every active profile. Swap the
 	// identity + audit overrides per vault so any audit-emitting call
 	// inside GetBootstrapOptions attributes correctly.
-	vaultOpts := collectActiveVaultBootstrapOptions(ctx, profileMeta, profileOrder, primaryProfile)
+	vaultOpts := collectActiveVaultBootstrapOptions(ctx, profileMeta, profileOrder, primaryProfile, styledOut)
 
 	for _, client := range targetClients {
 		// Gather all options (every active vault + this client)
@@ -916,7 +981,7 @@ func installClientHooks(ctx context.Context, targetClients []clients.Client, pro
 // by Option.Key (first occurrence wins, matching the asset conflict
 // policy). The primary profile's overrides are restored before
 // returning so the caller's subsequent operations attribute correctly.
-func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string) []bootstrap.Option {
+func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[string]profileMetadata, profileOrder []string, primaryProfile string, styledOut *ui.Output) []bootstrap.Option {
 	log := logger.Get()
 	var allOpts []bootstrap.Option
 	seen := make(map[string]string) // key → winning profile name
@@ -931,6 +996,9 @@ func collectActiveVaultBootstrapOptions(ctx context.Context, profileMeta map[str
 		for _, opt := range opts {
 			if winner, taken := seen[opt.Key]; taken {
 				log.Debug("bootstrap option shadowed by earlier profile", "key", opt.Key, "winner", winner, "shadowed", name)
+				if styledOut != nil {
+					styledOut.Muted(fmt.Sprintf("bootstrap option %s shadowed: %s wins, %s ignored", opt.Key, winner, name))
+				}
 				continue
 			}
 			seen[opt.Key] = name

--- a/internal/commands/install_assets.go
+++ b/internal/commands/install_assets.go
@@ -1,51 +1,20 @@
 package commands
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/sleuth-io/sx/internal/assets"
-	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/scope"
 	"github.com/sleuth-io/sx/internal/ui"
-	"github.com/sleuth-io/sx/internal/ui/components"
-	vaultpkg "github.com/sleuth-io/sx/internal/vault"
 )
 
 // downloadAssetsResult holds the result of downloading assets
 type downloadAssetsResult struct {
 	Downloads []*assets.AssetWithMetadata
 	Errors    []error
-}
-
-// downloadAssetsWithStatus downloads assets and returns successful downloads
-func downloadAssetsWithStatus(
-	ctx context.Context,
-	vault vaultpkg.Vault,
-	assetsToInstall []*lockfile.Asset,
-	status *components.Status,
-	styledOut *ui.Output,
-) (*downloadAssetsResult, error) {
-	status.Start(fmt.Sprintf("Downloading %d assets", len(assetsToInstall)))
-
-	fetcher := assets.NewAssetFetcher(vault)
-	results, err := fetcher.FetchAssets(ctx, assetsToInstall, 10)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch assets: %w", err)
-	}
-
-	result := processDownloadResults(results, styledOut)
-	status.Clear()
-
-	if len(result.Downloads) == 0 {
-		styledOut.Error("No assets downloaded successfully")
-		return nil, errors.New("no assets downloaded successfully")
-	}
-
-	return result, nil
 }
 
 // processDownloadResults separates successful downloads from errors

--- a/internal/commands/install_context.go
+++ b/internal/commands/install_context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sleuth-io/sx/internal/gitutil"
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
+	"github.com/sleuth-io/sx/internal/mgmt"
 	"github.com/sleuth-io/sx/internal/scope"
 	"github.com/sleuth-io/sx/internal/ui"
 	"github.com/sleuth-io/sx/internal/ui/components"
@@ -209,7 +210,10 @@ func handleCursorWorkspace(hookMode bool, effectiveClient string, log *slog.Logg
 	}
 }
 
-// loadConfigAndVault loads configuration and creates vault instance
+// loadConfigAndVault loads configuration and creates vault instance.
+// Also installs the profile's identity override into mgmt so vault
+// operations resolve team/user scopes against the profile email instead
+// of the system git config.
 func loadConfigAndVault() (*config.Config, vaultpkg.Vault, error) {
 	cfg, err := config.Load()
 	if err != nil {
@@ -219,6 +223,9 @@ func loadConfigAndVault() (*config.Config, vaultpkg.Vault, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, nil, fmt.Errorf("invalid configuration: %w", err)
 	}
+
+	mgmt.SetIdentityOverride(cfg.Identity)
+	mgmt.SetAuditProfileTag(cfg.ProfileName)
 
 	vault, err := vaultpkg.NewFromConfig(cfg)
 	if err != nil {

--- a/internal/commands/install_context.go
+++ b/internal/commands/install_context.go
@@ -268,7 +268,7 @@ func handleNothingToInstall(
 
 	// Install client-specific hooks
 	// env.Clients is already filtered by --client/--clients flag
-	installClientHooks(ctx, env.Clients, profileMeta, profileOrder, primaryProfile, out)
+	installClientHooks(ctx, env.Clients, profileMeta, profileOrder, primaryProfile, styledOut, out)
 
 	// Ensure asset support is configured for target clients
 	ensureAssetSupport(ctx, env.Clients, buildInstallScope(env.CurrentScope, env.GitContext), out)

--- a/internal/commands/install_context.go
+++ b/internal/commands/install_context.go
@@ -257,6 +257,9 @@ func handleNothingToInstall(
 	sortedAssets []*lockfile.Asset,
 	env *installEnvironment,
 	targetClientIDs []string,
+	profileMeta map[string]profileMetadata,
+	profileOrder []string,
+	primaryProfile string,
 	styledOut *ui.Output,
 	out *outputHelper,
 ) error {
@@ -265,7 +268,7 @@ func handleNothingToInstall(
 
 	// Install client-specific hooks
 	// env.Clients is already filtered by --client/--clients flag
-	installClientHooks(ctx, env.Clients, out)
+	installClientHooks(ctx, env.Clients, profileMeta, profileOrder, primaryProfile, out)
 
 	// Ensure asset support is configured for target clients
 	ensureAssetSupport(ctx, env.Clients, buildInstallScope(env.CurrentScope, env.GitContext), out)

--- a/internal/commands/install_lockfile.go
+++ b/internal/commands/install_lockfile.go
@@ -9,42 +9,42 @@ import (
 	"github.com/sleuth-io/sx/internal/config"
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
-	"github.com/sleuth-io/sx/internal/ui/components"
 	vaultpkg "github.com/sleuth-io/sx/internal/vault"
 )
 
-// fetchLockFileWithCache fetches the lock file, using cache when possible.
-// It handles ETag-based caching, parsing, and validation.
-func fetchLockFileWithCache(ctx context.Context, vault vaultpkg.Vault, cfg *config.Config, status *components.Status) (*lockfile.LockFile, error) {
-	status.Start("Fetching lock file")
-
+// fetchLockFile fetches and parses the lock file for a single profile,
+// using the on-disk ETag cache when the vault reports notModified. It
+// does not touch the shared status component, so callers running it
+// from goroutines (see loadActiveLockFiles) don't fight for the
+// spinner. Returns ErrLockFileNotFound for the pristine "new vault"
+// case so callers can short-circuit without treating it as a hard
+// failure.
+func fetchLockFile(ctx context.Context, vault vaultpkg.Vault, cfg *config.Config) (*lockfile.LockFile, error) {
 	cachedETag, _ := cache.LoadETag(cfg.RepositoryURL)
 	lockFileData, newETag, notModified, err := vault.GetLockFile(ctx, cachedETag)
 	if err != nil {
 		if errors.Is(err, vaultpkg.ErrLockFileNotFound) {
-			status.Clear()
 			return nil, vaultpkg.ErrLockFileNotFound
 		}
-		status.Fail("Failed to fetch lock file")
 		return nil, fmt.Errorf("failed to fetch lock file: %w", err)
 	}
 
 	if notModified {
 		lockFileData, err = cache.LoadLockFile(cfg.RepositoryURL)
 		if err != nil {
-			status.Fail("Failed to load cached lock file")
 			return nil, fmt.Errorf("failed to load cached lock file: %w", err)
 		}
 	} else {
 		saveLockFileToCache(cfg.RepositoryURL, newETag, lockFileData)
 	}
 
-	lf, err := parseLockFile(lockFileData, status)
+	lf, err := lockfile.Parse(lockFileData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse lock file: %w", err)
 	}
-
-	status.Clear()
+	if err := lf.Validate(); err != nil {
+		return nil, fmt.Errorf("lock file validation failed: %w", err)
+	}
 	return lf, nil
 }
 
@@ -59,20 +59,4 @@ func saveLockFileToCache(repoURL, etag string, data []byte) {
 	if err := cache.SaveLockFile(repoURL, data); err != nil {
 		log.Error("failed to cache lock file", "error", err)
 	}
-}
-
-// parseLockFile parses and validates the lock file data
-func parseLockFile(data []byte, status *components.Status) (*lockfile.LockFile, error) {
-	lf, err := lockfile.Parse(data)
-	if err != nil {
-		status.Fail("Failed to parse lock file")
-		return nil, fmt.Errorf("failed to parse lock file: %w", err)
-	}
-
-	if err := lf.Validate(); err != nil {
-		status.Fail("Lock file validation failed")
-		return nil, fmt.Errorf("lock file validation failed: %w", err)
-	}
-
-	return lf, nil
 }

--- a/internal/commands/install_lockfile.go
+++ b/internal/commands/install_lockfile.go
@@ -20,7 +20,13 @@ import (
 // case so callers can short-circuit without treating it as a hard
 // failure.
 func fetchLockFile(ctx context.Context, vault vaultpkg.Vault, cfg *config.Config) (*lockfile.LockFile, error) {
-	cachedETag, _ := cache.LoadETag(cfg.RepositoryURL)
+	// Key the cache by VaultIdentifier rather than raw RepositoryURL so
+	// legacy Sleuth profiles (ServerURL set, RepositoryURL empty) get
+	// distinct cache paths. Two such profiles in the same active set
+	// would otherwise share cache entries and — under the parallel
+	// fan-out in loadActiveLockFiles — race on the same cache file.
+	cacheKey := cfg.VaultIdentifier()
+	cachedETag, _ := cache.LoadETag(cacheKey)
 	lockFileData, newETag, notModified, err := vault.GetLockFile(ctx, cachedETag)
 	if err != nil {
 		if errors.Is(err, vaultpkg.ErrLockFileNotFound) {
@@ -30,12 +36,12 @@ func fetchLockFile(ctx context.Context, vault vaultpkg.Vault, cfg *config.Config
 	}
 
 	if notModified {
-		lockFileData, err = cache.LoadLockFile(cfg.RepositoryURL)
+		lockFileData, err = cache.LoadLockFile(cacheKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load cached lock file: %w", err)
 		}
 	} else {
-		saveLockFileToCache(cfg.RepositoryURL, newETag, lockFileData)
+		saveLockFileToCache(cacheKey, newETag, lockFileData)
 	}
 
 	lf, err := lockfile.Parse(lockFileData)

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -1,0 +1,286 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/sleuth-io/sx/internal/assets"
+	"github.com/sleuth-io/sx/internal/clients"
+	"github.com/sleuth-io/sx/internal/config"
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/logger"
+	"github.com/sleuth-io/sx/internal/mgmt"
+	"github.com/sleuth-io/sx/internal/scope"
+	"github.com/sleuth-io/sx/internal/ui"
+	"github.com/sleuth-io/sx/internal/ui/components"
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+// profileLockFile pairs a fetched lock file with the profile and vault
+// it came from. Used by the multi-active install flow to route asset
+// downloads back to the originating vault and to attribute conflicts.
+type profileLockFile struct {
+	ProfileName string
+	Config      *config.Config
+	Vault       vaultpkg.Vault
+	LockFile    *lockfile.LockFile
+	FetchErr    error
+}
+
+// loadActiveProfilesAndLockFiles is the top-level helper for runInstall's
+// per-profile bootstrap. It loads every active profile, fetches each
+// vault's lock file, applies the partial-failure policy, and returns
+// the data the rest of the install flow needs. The done bool is true
+// when runInstall should return nil (e.g. all profiles report no lock
+// file yet — fresh setup).
+func loadActiveProfilesAndLockFiles(
+	ctx context.Context,
+	status *components.Status,
+	styledOut *ui.Output,
+) (profileLocks []profileLockFile, mpc *config.MultiProfileConfig, primaryCfg *config.Config, cfg *config.Config, done bool, err error) {
+	activeConfigs, mpc, err := config.LoadActive()
+	if err != nil {
+		return nil, nil, nil, nil, false, fmt.Errorf("failed to load configuration: %w\nRun 'sx init' to configure", err)
+	}
+	if len(activeConfigs) == 0 {
+		return nil, nil, nil, nil, false, errors.New("no active profiles configured — run 'sx profile activate <name>'")
+	}
+	primaryCfg = activeConfigs[0]
+	if validateErr := primaryCfg.Validate(); validateErr != nil {
+		return nil, nil, nil, nil, false, fmt.Errorf("invalid configuration for profile %s: %w", primaryCfg.ProfileName, validateErr)
+	}
+	mgmt.SetIdentityOverride(primaryCfg.Identity)
+
+	profileLocks = loadActiveLockFiles(ctx, activeConfigs, status)
+	if !reportFetchErrors(profileLocks, styledOut) {
+		// All profiles failed. A pristine "no lock file yet" outcome is
+		// the new-user case (every profile reports ErrLockFileNotFound).
+		// Anything else means the warnings just printed by
+		// reportFetchErrors are the diagnostic; bail with a non-zero
+		// status but skip re-rendering the underlying errors.
+		for _, pl := range profileLocks {
+			if pl.FetchErr == nil {
+				continue
+			}
+			if !errors.Is(pl.FetchErr, vaultpkg.ErrLockFileNotFound) {
+				return nil, nil, nil, nil, false, errors.New("no active profile produced a lock file (see warnings above)")
+			}
+		}
+		styledOut.Info("No assets installed yet.")
+		styledOut.Muted("Add skills with 'sx add' or browse skills.sh with 'sx add --browse'.")
+		return nil, nil, nil, nil, true, nil
+	}
+
+	// Primary config (used for downstream env detection) comes from the
+	// first profile that successfully fetched a lock file. Asset-level
+	// vault routing happens later via mergeApplicableAssets.
+	cfg = primaryCfg
+	for _, pl := range profileLocks {
+		if pl.LockFile != nil {
+			cfg = pl.Config
+			break
+		}
+	}
+	return profileLocks, mpc, primaryCfg, cfg, false, nil
+}
+
+// loadActiveLockFiles fetches lock files for every active profile,
+// honoring per-profile identity overrides so team/user scope resolution
+// happens against the right email. Individual fetch failures are
+// captured per-profile rather than failing the whole call so partial
+// installs can proceed.
+func loadActiveLockFiles(ctx context.Context, configs []*config.Config, status *components.Status) []profileLockFile {
+	results := make([]profileLockFile, 0, len(configs))
+	for _, cfg := range configs {
+		entry := profileLockFile{ProfileName: cfg.ProfileName, Config: cfg}
+		if err := cfg.Validate(); err != nil {
+			entry.FetchErr = fmt.Errorf("invalid configuration for profile %s: %w", cfg.ProfileName, err)
+			results = append(results, entry)
+			continue
+		}
+		// Switch identity context to this profile before any vault op that
+		// resolves the caller's actor.
+		mgmt.SetIdentityOverride(cfg.Identity)
+		mgmt.SetAuditProfileTag(cfg.ProfileName)
+		vault, err := vaultpkg.NewFromConfig(cfg)
+		if err != nil {
+			entry.FetchErr = fmt.Errorf("failed to create vault for profile %s: %w", cfg.ProfileName, err)
+			results = append(results, entry)
+			continue
+		}
+		entry.Vault = vault
+		lf, err := fetchLockFileWithCache(ctx, vault, cfg, status)
+		if err != nil {
+			entry.FetchErr = err
+		} else {
+			entry.LockFile = lf
+		}
+		results = append(results, entry)
+	}
+	return results
+}
+
+// assetConflict records that two or more active profiles publish an
+// asset with the same name. Winner is the profile whose copy is being
+// installed; Shadowed is the rest.
+type assetConflict struct {
+	AssetName string
+	Winner    string
+	Shadowed  []string
+}
+
+// mergeApplicableAssets runs scope filtering + dependency resolution per
+// profile, then folds the results into a single ordered list. The
+// caller controls precedence by ordering profileLocks (default-first
+// for the persisted case, user-specified for --profile overrides). On
+// name collision the first encountered wins; later occurrences are
+// reported via conflicts so reportConflicts can decide how loudly to
+// surface them.
+//
+// Per-profile identity was already applied during lock fetch in
+// loadActiveLockFiles; the resolver only reads lockfile bytes, so it
+// doesn't touch the identity override here.
+func mergeApplicableAssets(
+	profileLocks []profileLockFile,
+	targetClients []clients.Client,
+	matcherScope *scope.Matcher,
+) (sortedAssets []*lockfile.Asset, assetVault map[string]vaultpkg.Vault, conflicts []assetConflict, err error) {
+	assetVault = make(map[string]vaultpkg.Vault)
+	assetOrigin := make(map[string]string)
+	conflictByName := make(map[string]*assetConflict)
+
+	for _, pl := range profileLocks {
+		if pl.LockFile == nil {
+			continue
+		}
+		applicable := filterAssetsByScope(pl.LockFile, targetClients, matcherScope)
+		sorted, resolveErr := resolveAssetDependencies(pl.LockFile, applicable)
+		if resolveErr != nil {
+			return nil, nil, nil, fmt.Errorf("dependency resolution for profile %s: %w", pl.ProfileName, resolveErr)
+		}
+		for _, asset := range sorted {
+			if existing, taken := assetOrigin[asset.Name]; taken {
+				rec, ok := conflictByName[asset.Name]
+				if !ok {
+					rec = &assetConflict{AssetName: asset.Name, Winner: existing}
+					conflictByName[asset.Name] = rec
+				}
+				rec.Shadowed = append(rec.Shadowed, pl.ProfileName)
+				continue
+			}
+			sortedAssets = append(sortedAssets, asset)
+			assetVault[asset.Name] = pl.Vault
+			assetOrigin[asset.Name] = pl.ProfileName
+		}
+	}
+
+	if len(conflictByName) > 0 {
+		names := make([]string, 0, len(conflictByName))
+		for n := range conflictByName {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			conflicts = append(conflicts, *conflictByName[n])
+		}
+	}
+	return sortedAssets, assetVault, conflicts, nil
+}
+
+// reportFetchErrors surfaces per-profile lock file fetch failures as
+// warnings. Returns true if at least one profile fetched successfully.
+func reportFetchErrors(profileLocks []profileLockFile, styledOut *ui.Output) bool {
+	log := logger.Get()
+	successCount := 0
+	for _, pl := range profileLocks {
+		if pl.LockFile != nil {
+			successCount++
+			continue
+		}
+		if pl.FetchErr == nil || errors.Is(pl.FetchErr, vaultpkg.ErrLockFileNotFound) {
+			continue
+		}
+		styledOut.Warning(fmt.Sprintf("profile %s: %v", pl.ProfileName, pl.FetchErr))
+		log.Error("profile lockfile fetch failed", "profile", pl.ProfileName, "error", pl.FetchErr)
+	}
+	return successCount > 0
+}
+
+// reportConflicts emits a per-shadowed-asset notice. The agreed policy
+// is "default wins silently, otherwise first-active wins with a
+// warning" — so we suppress the loud warning only when the winner is
+// actually the persisted default profile.
+func reportConflicts(conflicts []assetConflict, defaultProfile string, styledOut *ui.Output) {
+	log := logger.Get()
+	for _, c := range conflicts {
+		shadowed := c.Shadowed
+		msg := fmt.Sprintf("asset %s: kept from %s, shadowed in %v", c.AssetName, c.Winner, shadowed)
+		log.Warn("asset conflict between profiles", "asset", c.AssetName, "winner", c.Winner, "shadowed", shadowed)
+		if defaultProfile != "" && c.Winner == defaultProfile {
+			styledOut.Muted(msg)
+			continue
+		}
+		styledOut.Warning(msg)
+	}
+}
+
+// downloadAssetsMultiVault downloads each asset from the vault its
+// origin profile points at, then aggregates the results into the same
+// shape as the single-vault downloader so the rest of the install flow
+// is unchanged.
+func downloadAssetsMultiVault(
+	ctx context.Context,
+	assetsToInstall []*lockfile.Asset,
+	assetVault map[string]vaultpkg.Vault,
+	status *components.Status,
+	styledOut *ui.Output,
+) (*downloadAssetsResult, error) {
+	if len(assetsToInstall) == 0 {
+		return &downloadAssetsResult{}, nil
+	}
+
+	// Group assets by their backing vault so we issue one batched fetch
+	// per vault (preserving the existing per-vault concurrency limit).
+	type group struct {
+		vault  vaultpkg.Vault
+		assets []*lockfile.Asset
+	}
+	groups := make(map[vaultpkg.Vault]*group)
+	for _, asset := range assetsToInstall {
+		v, ok := assetVault[asset.Name]
+		if !ok || v == nil {
+			return nil, fmt.Errorf("no vault routing for asset %s", asset.Name)
+		}
+		g, exists := groups[v]
+		if !exists {
+			g = &group{vault: v}
+			groups[v] = g
+		}
+		g.assets = append(g.assets, asset)
+	}
+
+	status.Start(fmt.Sprintf("Downloading %d assets", len(assetsToInstall)))
+
+	var merged []assets.DownloadResult
+	for _, g := range groups {
+		fetcher := assets.NewAssetFetcher(g.vault)
+		results, err := fetcher.FetchAssets(ctx, g.assets, 10)
+		if err != nil {
+			status.Clear()
+			return nil, fmt.Errorf("failed to fetch assets: %w", err)
+		}
+		merged = append(merged, results...)
+	}
+
+	result := processDownloadResults(merged, styledOut)
+	status.Clear()
+
+	if len(result.Downloads) == 0 {
+		styledOut.Error("No assets downloaded successfully")
+		return nil, errors.New("no assets downloaded successfully")
+	}
+
+	return result, nil
+}

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"sync"
 
 	"github.com/sleuth-io/sx/internal/assets"
 	"github.com/sleuth-io/sx/internal/clients"
@@ -55,8 +56,11 @@ func loadActiveProfilesAndLockFiles(
 			return nil, nil, nil, nil, false, fmt.Errorf("invalid configuration for profile %s: %w", c.ProfileName, validateErr)
 		}
 	}
-	// Seed identity from the first active profile for the lock-fetch
-	// loop's initial pass; loadActiveLockFiles swaps it per-iteration.
+	// Seed the process-global identity from the first active profile so
+	// any code path that runs before the parallel fan-out completes (or
+	// that reads the override without a context) sees a sane value.
+	// loadActiveLockFiles passes per-profile identity via context so the
+	// global override is not touched mid-fetch.
 	mgmt.SetIdentityOverride(activeConfigs[0].Identity)
 
 	profileLocks = loadActiveLockFiles(ctx, activeConfigs, status)
@@ -99,36 +103,53 @@ func loadActiveProfilesAndLockFiles(
 	return profileLocks, mpc, primaryCfg, cfg, false, nil
 }
 
-// loadActiveLockFiles fetches lock files for every active profile,
-// honoring per-profile identity overrides so team/user scope resolution
-// happens against the right email. Individual fetch failures are
-// captured per-profile rather than failing the whole call so partial
-// installs can proceed.
+// loadActiveLockFiles fetches lock files for every active profile in
+// parallel, honoring per-profile identity overrides so team/user scope
+// resolution happens against the right email. Each goroutine carries
+// its profile's identity on its context (mgmt.ContextWithIdentity), so
+// the process-global override is not touched and concurrent fetches
+// cannot bleed identity into each other. Audit attribution doesn't
+// matter during fetch (no mutations), so the global audit tag is left
+// for the caller to set after the fan-out. Individual fetch failures
+// are captured per-profile rather than failing the whole call so
+// partial installs can proceed.
 func loadActiveLockFiles(ctx context.Context, configs []*config.Config, status *components.Status) []profileLockFile {
-	results := make([]profileLockFile, 0, len(configs))
-	for _, cfg := range configs {
-		entry := profileLockFile{ProfileName: cfg.ProfileName, Config: cfg}
-		// Validation already ran in loadActiveProfilesAndLockFiles; if
-		// callers stop pre-validating, restore the inline check here.
-		// Switch identity context to this profile before any vault op
-		// that resolves the caller's actor.
-		mgmt.SetIdentityOverride(cfg.Identity)
-		mgmt.SetAuditProfileTag(cfg.ProfileName)
-		vault, err := vaultpkg.NewFromConfig(cfg)
-		if err != nil {
-			entry.FetchErr = fmt.Errorf("failed to create vault for profile %s: %w", cfg.ProfileName, err)
-			results = append(results, entry)
-			continue
-		}
-		entry.Vault = vault
-		lf, err := fetchLockFileWithCache(ctx, vault, cfg, status)
-		if err != nil {
-			entry.FetchErr = err
-		} else {
-			entry.LockFile = lf
-		}
-		results = append(results, entry)
+	results := make([]profileLockFile, len(configs))
+	if len(configs) == 0 {
+		return results
 	}
+
+	if len(configs) == 1 {
+		status.Start("Fetching lock file")
+	} else {
+		status.Start(fmt.Sprintf("Fetching lock files for %d profiles", len(configs)))
+	}
+
+	var wg sync.WaitGroup
+	for i, cfg := range configs {
+		wg.Add(1)
+		go func(i int, cfg *config.Config) {
+			defer wg.Done()
+			entry := profileLockFile{ProfileName: cfg.ProfileName, Config: cfg}
+			fetchCtx := mgmt.ContextWithIdentity(ctx, cfg.Identity)
+			vault, err := vaultpkg.NewFromConfig(cfg)
+			if err != nil {
+				entry.FetchErr = fmt.Errorf("failed to create vault for profile %s: %w", cfg.ProfileName, err)
+				results[i] = entry
+				return
+			}
+			entry.Vault = vault
+			lf, err := fetchLockFile(fetchCtx, vault, cfg)
+			if err != nil {
+				entry.FetchErr = err
+			} else {
+				entry.LockFile = lf
+			}
+			results[i] = entry
+		}(i, cfg)
+	}
+	wg.Wait()
+	status.Clear()
 	return results
 }
 

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/sleuth-io/sx/internal/assets"
@@ -146,9 +147,9 @@ func mergeApplicableAssets(
 	profileLocks []profileLockFile,
 	targetClients []clients.Client,
 	matcherScope *scope.Matcher,
-) (sortedAssets []*lockfile.Asset, assetVault map[string]vaultpkg.Vault, conflicts []assetConflict, err error) {
+) (sortedAssets []*lockfile.Asset, assetVault map[string]vaultpkg.Vault, assetOrigin map[string]string, conflicts []assetConflict, err error) {
 	assetVault = make(map[string]vaultpkg.Vault)
-	assetOrigin := make(map[string]string)
+	assetOrigin = make(map[string]string)
 	conflictByName := make(map[string]*assetConflict)
 
 	for _, pl := range profileLocks {
@@ -158,7 +159,7 @@ func mergeApplicableAssets(
 		applicable := filterAssetsByScope(pl.LockFile, targetClients, matcherScope)
 		sorted, resolveErr := resolveAssetDependencies(pl.LockFile, applicable)
 		if resolveErr != nil {
-			return nil, nil, nil, fmt.Errorf("dependency resolution for profile %s: %w", pl.ProfileName, resolveErr)
+			return nil, nil, nil, nil, fmt.Errorf("dependency resolution for profile %s: %w", pl.ProfileName, resolveErr)
 		}
 		for _, asset := range sorted {
 			if existing, taken := assetOrigin[asset.Name]; taken {
@@ -186,7 +187,36 @@ func mergeApplicableAssets(
 			conflicts = append(conflicts, *conflictByName[n])
 		}
 	}
-	return sortedAssets, assetVault, conflicts, nil
+	return sortedAssets, assetVault, assetOrigin, conflicts, nil
+}
+
+// profileMetadata pairs identity + audit-tag context for the profiles
+// that own at least one downloaded asset. downloadAssetsMultiVault
+// consults this to swap the process-global identity/audit overrides
+// for each vault group's fetch.
+type profileMetadata struct {
+	Identity string
+	Profile  string
+	Vault    vaultpkg.Vault
+}
+
+// buildProfileMetadata derives the per-profile context from the slice
+// of profile lock files, indexed by ProfileName. Only profiles that
+// successfully fetched a lock file (and thus participated in the merge)
+// are included.
+func buildProfileMetadata(profileLocks []profileLockFile) map[string]profileMetadata {
+	out := make(map[string]profileMetadata, len(profileLocks))
+	for _, pl := range profileLocks {
+		if pl.LockFile == nil || pl.Config == nil {
+			continue
+		}
+		out[pl.ProfileName] = profileMetadata{
+			Identity: pl.Config.Identity,
+			Profile:  pl.ProfileName,
+			Vault:    pl.Vault,
+		}
+	}
+	return out
 }
 
 // reportFetchErrors surfaces per-profile lock file fetch failures as
@@ -227,13 +257,18 @@ func reportConflicts(conflicts []assetConflict, defaultProfile string, styledOut
 }
 
 // downloadAssetsMultiVault downloads each asset from the vault its
-// origin profile points at, then aggregates the results into the same
-// shape as the single-vault downloader so the rest of the install flow
-// is unchanged.
+// origin profile points at, swapping the process-global identity and
+// audit-profile-tag overrides per group so a profile's downloads run
+// under that profile's identity. Failures of one vault group are
+// reported as warnings; the call only errors out when no group produced
+// any successful downloads. Caller is responsible for restoring the
+// primary identity/audit-tag after the function returns.
 func downloadAssetsMultiVault(
 	ctx context.Context,
 	assetsToInstall []*lockfile.Asset,
-	assetVault map[string]vaultpkg.Vault,
+	assetOrigin map[string]string,
+	profileMeta map[string]profileMetadata,
+	profileOrder []string,
 	status *components.Status,
 	styledOut *ui.Output,
 ) (*downloadAssetsResult, error) {
@@ -241,43 +276,74 @@ func downloadAssetsMultiVault(
 		return &downloadAssetsResult{}, nil
 	}
 
-	// Group assets by their backing vault so we issue one batched fetch
-	// per vault (preserving the existing per-vault concurrency limit).
+	// Group assets by origin profile so we issue one batched fetch per
+	// profile (preserving the existing per-vault concurrency limit) and
+	// have a stable iteration order matching the input config.
 	type group struct {
-		vault  vaultpkg.Vault
-		assets []*lockfile.Asset
+		profile string
+		assets  []*lockfile.Asset
 	}
-	groups := make(map[vaultpkg.Vault]*group)
+	groupsByProfile := make(map[string]*group)
 	for _, asset := range assetsToInstall {
-		v, ok := assetVault[asset.Name]
-		if !ok || v == nil {
-			return nil, fmt.Errorf("no vault routing for asset %s", asset.Name)
+		origin, ok := assetOrigin[asset.Name]
+		if !ok {
+			return nil, fmt.Errorf("no origin profile recorded for asset %s", asset.Name)
 		}
-		g, exists := groups[v]
+		if _, hasMeta := profileMeta[origin]; !hasMeta {
+			return nil, fmt.Errorf("no profile metadata for origin %s of asset %s", origin, asset.Name)
+		}
+		g, exists := groupsByProfile[origin]
 		if !exists {
-			g = &group{vault: v}
-			groups[v] = g
+			g = &group{profile: origin}
+			groupsByProfile[origin] = g
 		}
 		g.assets = append(g.assets, asset)
+	}
+
+	// Build an ordered slice using profileOrder so output is stable.
+	orderedGroups := make([]*group, 0, len(groupsByProfile))
+	for _, name := range profileOrder {
+		if g, ok := groupsByProfile[name]; ok {
+			orderedGroups = append(orderedGroups, g)
+		}
+	}
+	// Defensive: include any group not in profileOrder (shouldn't happen
+	// but guards against silently dropping assets).
+	for name, g := range groupsByProfile {
+		if !slices.ContainsFunc(orderedGroups, func(o *group) bool { return o.profile == name }) {
+			orderedGroups = append(orderedGroups, g)
+		}
 	}
 
 	status.Start(fmt.Sprintf("Downloading %d assets", len(assetsToInstall)))
 
 	var merged []assets.DownloadResult
-	for _, g := range groups {
-		fetcher := assets.NewAssetFetcher(g.vault)
+	var groupErrs []error
+	for _, g := range orderedGroups {
+		meta := profileMeta[g.profile]
+		mgmt.SetIdentityOverride(meta.Identity)
+		mgmt.SetAuditProfileTag(meta.Profile)
+
+		fetcher := assets.NewAssetFetcher(meta.Vault)
 		results, err := fetcher.FetchAssets(ctx, g.assets, 10)
 		if err != nil {
-			status.Clear()
-			return nil, fmt.Errorf("failed to fetch assets: %w", err)
+			groupErrs = append(groupErrs, fmt.Errorf("profile %s: %w", g.profile, err))
+			continue
 		}
 		merged = append(merged, results...)
+	}
+
+	for _, err := range groupErrs {
+		styledOut.Warning(err.Error())
 	}
 
 	result := processDownloadResults(merged, styledOut)
 	status.Clear()
 
 	if len(result.Downloads) == 0 {
+		if len(groupErrs) > 0 {
+			return nil, errors.New("no assets downloaded successfully (every vault download failed; see warnings above)")
+		}
 		styledOut.Error("No assets downloaded successfully")
 		return nil, errors.New("no assets downloaded successfully")
 	}

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -208,6 +208,10 @@ type profileMetadata struct {
 	Identity string
 	Profile  string
 	Vault    vaultpkg.Vault
+	// VaultKey is the vault's repo URL (or server URL for Sleuth) used
+	// to partition the asset disk cache so two vaults publishing the
+	// same name@version don't collide.
+	VaultKey string
 }
 
 // buildProfileMetadata derives the per-profile context from the slice
@@ -224,6 +228,7 @@ func buildProfileMetadata(profileLocks []profileLockFile) map[string]profileMeta
 			Identity: pl.Config.Identity,
 			Profile:  pl.ProfileName,
 			Vault:    pl.Vault,
+			VaultKey: pl.Config.GetRepositoryURL(),
 		}
 	}
 	return out
@@ -353,7 +358,7 @@ func downloadAssetsMultiVault(
 		mgmt.SetIdentityOverride(meta.Identity)
 		mgmt.SetAuditProfileTag(meta.Profile)
 
-		fetcher := assets.NewAssetFetcher(meta.Vault)
+		fetcher := assets.NewAssetFetcher(meta.Vault, meta.VaultKey)
 		results, err := fetcher.FetchAssets(ctx, g.assets, 10)
 		if err != nil {
 			groupErrs = append(groupErrs, fmt.Errorf("profile %s: %w", g.profile, err))

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -392,12 +392,16 @@ func downloadAssetsMultiVault(
 		merged = append(merged, results...)
 	}
 
+	// Stop the spinner before printing any human-facing diagnostics so
+	// per-group warnings and per-asset error lines don't interleave
+	// with spinner redraws on a multi-vault failure.
+	status.Clear()
+
 	for _, err := range groupErrs {
 		styledOut.Warning(err.Error())
 	}
 
 	result := processDownloadResults(merged, styledOut)
-	status.Clear()
 
 	if len(result.Downloads) == 0 {
 		if len(groupErrs) > 0 {

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -225,7 +225,7 @@ func buildProfileMetadata(profileLocks []profileLockFile) map[string]profileMeta
 			Identity: pl.Config.Identity,
 			Profile:  pl.ProfileName,
 			Vault:    pl.Vault,
-			VaultKey: pl.Config.GetRepositoryURL(),
+			VaultKey: pl.Config.VaultIdentifier(),
 		}
 	}
 	return out

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -108,13 +108,10 @@ func loadActiveLockFiles(ctx context.Context, configs []*config.Config, status *
 	results := make([]profileLockFile, 0, len(configs))
 	for _, cfg := range configs {
 		entry := profileLockFile{ProfileName: cfg.ProfileName, Config: cfg}
-		if err := cfg.Validate(); err != nil {
-			entry.FetchErr = fmt.Errorf("invalid configuration for profile %s: %w", cfg.ProfileName, err)
-			results = append(results, entry)
-			continue
-		}
-		// Switch identity context to this profile before any vault op that
-		// resolves the caller's actor.
+		// Validation already ran in loadActiveProfilesAndLockFiles; if
+		// callers stop pre-validating, restore the inline check here.
+		// Switch identity context to this profile before any vault op
+		// that resolves the caller's actor.
 		mgmt.SetIdentityOverride(cfg.Identity)
 		mgmt.SetAuditProfileTag(cfg.ProfileName)
 		vault, err := vaultpkg.NewFromConfig(cfg)
@@ -341,12 +338,19 @@ func downloadAssetsMultiVault(
 			orderedGroups = append(orderedGroups, g)
 		}
 	}
-	// Defensive: include any group not in profileOrder (shouldn't happen
-	// but guards against silently dropping assets).
-	for name, g := range groupsByProfile {
+	// Defensive: include any group not in profileOrder (shouldn't
+	// happen, but guards against silently dropping assets). Sort the
+	// missing names so output stays deterministic on the safety path,
+	// matching the primary path's profileOrder iteration.
+	var missing []string
+	for name := range groupsByProfile {
 		if !slices.ContainsFunc(orderedGroups, func(o *group) bool { return o.profile == name }) {
-			orderedGroups = append(orderedGroups, g)
+			missing = append(missing, name)
 		}
+	}
+	sort.Strings(missing)
+	for _, name := range missing {
+		orderedGroups = append(orderedGroups, groupsByProfile[name])
 	}
 
 	status.Start(fmt.Sprintf("Downloading %d assets", len(assetsToInstall)))

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -48,20 +48,18 @@ func loadActiveProfilesAndLockFiles(
 	if len(activeConfigs) == 0 {
 		return nil, nil, nil, nil, false, errors.New("no active profiles configured — run 'sx profile activate <name>'")
 	}
-	primaryCfg = activeConfigs[0]
-	if validateErr := primaryCfg.Validate(); validateErr != nil {
-		return nil, nil, nil, nil, false, fmt.Errorf("invalid configuration for profile %s: %w", primaryCfg.ProfileName, validateErr)
+	// Validate every active config up front; an invalid entry is a
+	// configuration error the user should fix regardless of fetch order.
+	for _, c := range activeConfigs {
+		if validateErr := c.Validate(); validateErr != nil {
+			return nil, nil, nil, nil, false, fmt.Errorf("invalid configuration for profile %s: %w", c.ProfileName, validateErr)
+		}
 	}
-	mgmt.SetIdentityOverride(primaryCfg.Identity)
+	// Seed identity from the first active profile for the lock-fetch
+	// loop's initial pass; loadActiveLockFiles swaps it per-iteration.
+	mgmt.SetIdentityOverride(activeConfigs[0].Identity)
 
 	profileLocks = loadActiveLockFiles(ctx, activeConfigs, status)
-	// loadActiveLockFiles leaves the identity + audit-tag overrides set
-	// to whichever profile was last in its loop. Restore them to the
-	// primary now so any audit-emitting code between here and the
-	// per-vault download/bootstrap swaps attributes to the right
-	// profile.
-	mgmt.SetIdentityOverride(primaryCfg.Identity)
-	mgmt.SetAuditProfileTag(primaryCfg.ProfileName)
 	if !reportFetchErrors(profileLocks, styledOut) {
 		// All profiles failed. A pristine "no lock file yet" outcome is
 		// the new-user case (every profile reports ErrLockFileNotFound).
@@ -81,16 +79,23 @@ func loadActiveProfilesAndLockFiles(
 		return nil, nil, nil, nil, true, nil
 	}
 
-	// Primary config (used for downstream env detection) comes from the
-	// first profile that successfully fetched a lock file. Asset-level
-	// vault routing happens later via mergeApplicableAssets.
+	// Primary = first profile that actually contributed a lock file.
+	// This is the profile that owns audit attribution for any
+	// post-fetch single-vault work (env detection, hooks, ensure-asset-
+	// support) and is the fallback identity when no per-vault swap
+	// applies. Using the first *active* profile would misattribute when
+	// the default's fetch failed but a secondary succeeded.
+	primaryCfg = activeConfigs[0]
 	cfg = primaryCfg
 	for _, pl := range profileLocks {
 		if pl.LockFile != nil {
+			primaryCfg = pl.Config
 			cfg = pl.Config
 			break
 		}
 	}
+	mgmt.SetIdentityOverride(primaryCfg.Identity)
+	mgmt.SetAuditProfileTag(primaryCfg.ProfileName)
 	return profileLocks, mpc, primaryCfg, cfg, false, nil
 }
 

--- a/internal/commands/install_multi.go
+++ b/internal/commands/install_multi.go
@@ -55,6 +55,13 @@ func loadActiveProfilesAndLockFiles(
 	mgmt.SetIdentityOverride(primaryCfg.Identity)
 
 	profileLocks = loadActiveLockFiles(ctx, activeConfigs, status)
+	// loadActiveLockFiles leaves the identity + audit-tag overrides set
+	// to whichever profile was last in its loop. Restore them to the
+	// primary now so any audit-emitting code between here and the
+	// per-vault download/bootstrap swaps attributes to the right
+	// profile.
+	mgmt.SetIdentityOverride(primaryCfg.Identity)
+	mgmt.SetAuditProfileTag(primaryCfg.ProfileName)
 	if !reportFetchErrors(profileLocks, styledOut) {
 		// All profiles failed. A pristine "no lock file yet" outcome is
 		// the new-user case (every profile reports ErrLockFileNotFound).
@@ -147,8 +154,7 @@ func mergeApplicableAssets(
 	profileLocks []profileLockFile,
 	targetClients []clients.Client,
 	matcherScope *scope.Matcher,
-) (sortedAssets []*lockfile.Asset, assetVault map[string]vaultpkg.Vault, assetOrigin map[string]string, conflicts []assetConflict, err error) {
-	assetVault = make(map[string]vaultpkg.Vault)
+) (sortedAssets []*lockfile.Asset, assetOrigin map[string]string, conflicts []assetConflict, err error) {
 	assetOrigin = make(map[string]string)
 	conflictByName := make(map[string]*assetConflict)
 
@@ -159,7 +165,7 @@ func mergeApplicableAssets(
 		applicable := filterAssetsByScope(pl.LockFile, targetClients, matcherScope)
 		sorted, resolveErr := resolveAssetDependencies(pl.LockFile, applicable)
 		if resolveErr != nil {
-			return nil, nil, nil, nil, fmt.Errorf("dependency resolution for profile %s: %w", pl.ProfileName, resolveErr)
+			return nil, nil, nil, fmt.Errorf("dependency resolution for profile %s: %w", pl.ProfileName, resolveErr)
 		}
 		for _, asset := range sorted {
 			if existing, taken := assetOrigin[asset.Name]; taken {
@@ -172,7 +178,6 @@ func mergeApplicableAssets(
 				continue
 			}
 			sortedAssets = append(sortedAssets, asset)
-			assetVault[asset.Name] = pl.Vault
 			assetOrigin[asset.Name] = pl.ProfileName
 		}
 	}
@@ -187,7 +192,7 @@ func mergeApplicableAssets(
 			conflicts = append(conflicts, *conflictByName[n])
 		}
 	}
-	return sortedAssets, assetVault, assetOrigin, conflicts, nil
+	return sortedAssets, assetOrigin, conflicts, nil
 }
 
 // profileMetadata pairs identity + audit-tag context for the profiles
@@ -217,6 +222,25 @@ func buildProfileMetadata(profileLocks []profileLockFile) map[string]profileMeta
 		}
 	}
 	return out
+}
+
+// hadHardFetchFailure reports whether any active profile failed to
+// fetch its lock file with something other than ErrLockFileNotFound.
+// Used to gate removed-asset cleanup so a transient outage on one
+// profile doesn't cause sx to uninstall assets that belong to another
+// active profile (since cleanup compares against the merged-but-
+// partial sortedAssets set).
+func hadHardFetchFailure(profileLocks []profileLockFile) bool {
+	for _, pl := range profileLocks {
+		if pl.FetchErr == nil {
+			continue
+		}
+		if errors.Is(pl.FetchErr, vaultpkg.ErrLockFileNotFound) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // reportFetchErrors surfaces per-profile lock file fetch failures as

--- a/internal/commands/install_multi_test.go
+++ b/internal/commands/install_multi_test.go
@@ -1,0 +1,123 @@
+package commands
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/clients"
+	"github.com/sleuth-io/sx/internal/config"
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/scope"
+	"github.com/sleuth-io/sx/internal/ui"
+)
+
+// buildProfileLock constructs a profileLockFile suitable for merge
+// tests without touching the disk. Each asset is global-scoped so
+// scope.NewMatcher matches everything.
+func buildProfileLock(profile string, assetNames ...string) profileLockFile {
+	lf := &lockfile.LockFile{LockVersion: "1"}
+	for _, name := range assetNames {
+		lf.Assets = append(lf.Assets, lockfile.Asset{
+			Name:    name,
+			Version: "1.0.0",
+			Type:    asset.TypeSkill,
+		})
+	}
+	return profileLockFile{
+		ProfileName: profile,
+		Config:      &config.Config{ProfileName: profile},
+		LockFile:    lf,
+	}
+}
+
+func mergeAssetNames(assets []*lockfile.Asset) []string {
+	out := make([]string, 0, len(assets))
+	for _, a := range assets {
+		out = append(out, a.Name)
+	}
+	return out
+}
+
+func TestMergeApplicableAssets_DefaultFirstWins(t *testing.T) {
+	clientList := []clients.Client{&stubClient{id: "claude-code"}}
+	matcher := scope.NewMatcher(&scope.Scope{Type: lockfile.ScopeGlobal})
+
+	// "work" is default, listed first per GetActiveProfileNames bubbling.
+	locks := []profileLockFile{
+		buildProfileLock("work", "shared", "work-only"),
+		buildProfileLock("personal", "shared", "personal-only"),
+	}
+	sortedAssets, vaultMap, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
+	if err != nil {
+		t.Fatalf("mergeApplicableAssets: %v", err)
+	}
+	names := mergeAssetNames(sortedAssets)
+	slices.Sort(names)
+	wantNames := []string{"personal-only", "shared", "work-only"}
+	if !slices.Equal(names, wantNames) {
+		t.Fatalf("names=%v want %v", names, wantNames)
+	}
+	if len(conflicts) != 1 || conflicts[0].AssetName != "shared" {
+		t.Fatalf("expected one conflict for shared, got %v", conflicts)
+	}
+	if conflicts[0].Winner != "work" {
+		t.Fatalf("winner=%s want work", conflicts[0].Winner)
+	}
+	if !slices.Equal(conflicts[0].Shadowed, []string{"personal"}) {
+		t.Fatalf("shadowed=%v want [personal]", conflicts[0].Shadowed)
+	}
+	if vaultMap == nil {
+		t.Fatalf("vaultMap should be non-nil")
+	}
+}
+
+func TestMergeApplicableAssets_ThreeWayConflict(t *testing.T) {
+	clientList := []clients.Client{&stubClient{id: "claude-code"}}
+	matcher := scope.NewMatcher(&scope.Scope{Type: lockfile.ScopeGlobal})
+
+	locks := []profileLockFile{
+		buildProfileLock("a", "dup"),
+		buildProfileLock("b", "dup"),
+		buildProfileLock("c", "dup"),
+	}
+	_, _, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("expected single conflict record, got %d", len(conflicts))
+	}
+	if conflicts[0].Winner != "a" {
+		t.Fatalf("winner=%s want a", conflicts[0].Winner)
+	}
+	if !slices.Equal(conflicts[0].Shadowed, []string{"b", "c"}) {
+		t.Fatalf("shadowed=%v want [b c]", conflicts[0].Shadowed)
+	}
+}
+
+func TestReportConflicts_DefaultWinsIsMuted(t *testing.T) {
+	var buf bytes.Buffer
+	out := ui.NewOutput(&buf, &buf)
+	reportConflicts([]assetConflict{{AssetName: "shared", Winner: "work", Shadowed: []string{"personal"}}}, "work", out)
+	// Warning should NOT appear when default wins.
+	if strings.Contains(buf.String(), "Warning") {
+		t.Fatalf("expected muted output when default wins, got: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "shared") {
+		t.Fatalf("expected message to mention asset name, got: %s", buf.String())
+	}
+}
+
+func TestReportConflicts_NonDefaultWinsWarns(t *testing.T) {
+	var buf bytes.Buffer
+	out := ui.NewOutput(&buf, &buf)
+	// Default is "work" but winner is "personal" — should warn loudly.
+	reportConflicts([]assetConflict{{AssetName: "shared", Winner: "personal", Shadowed: []string{"work"}}}, "work", out)
+	got := buf.String()
+	if !strings.Contains(got, "shared") {
+		t.Fatalf("expected warning to name asset, got: %s", got)
+	}
+}

--- a/internal/commands/install_multi_test.go
+++ b/internal/commands/install_multi_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -50,7 +51,7 @@ func TestMergeApplicableAssets_DefaultFirstWins(t *testing.T) {
 		buildProfileLock("work", "shared", "work-only"),
 		buildProfileLock("personal", "shared", "personal-only"),
 	}
-	sortedAssets, vaultMap, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
+	sortedAssets, vaultMap, origin, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
 	if err != nil {
 		t.Fatalf("mergeApplicableAssets: %v", err)
 	}
@@ -72,6 +73,12 @@ func TestMergeApplicableAssets_DefaultFirstWins(t *testing.T) {
 	if vaultMap == nil {
 		t.Fatalf("vaultMap should be non-nil")
 	}
+	if origin["shared"] != "work" {
+		t.Fatalf("origin[shared]=%s want work", origin["shared"])
+	}
+	if origin["personal-only"] != "personal" {
+		t.Fatalf("origin[personal-only]=%s want personal", origin["personal-only"])
+	}
 }
 
 func TestMergeApplicableAssets_ThreeWayConflict(t *testing.T) {
@@ -83,7 +90,8 @@ func TestMergeApplicableAssets_ThreeWayConflict(t *testing.T) {
 		buildProfileLock("b", "dup"),
 		buildProfileLock("c", "dup"),
 	}
-	_, _, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
+	sorted, vaultMap, _, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
+	_, _ = sorted, vaultMap
 	if err != nil {
 		t.Fatalf("merge: %v", err)
 	}
@@ -119,5 +127,26 @@ func TestReportConflicts_NonDefaultWinsWarns(t *testing.T) {
 	got := buf.String()
 	if !strings.Contains(got, "shared") {
 		t.Fatalf("expected warning to name asset, got: %s", got)
+	}
+}
+
+func TestBuildProfileMetadataSkipsFailures(t *testing.T) {
+	locks := []profileLockFile{
+		{ProfileName: "good", Config: &config.Config{Identity: "good@x.com", ProfileName: "good"}, LockFile: &lockfile.LockFile{}},
+		{ProfileName: "fetch-failed", Config: &config.Config{Identity: "x@x.com"}, FetchErr: errors.New("boom")},
+		{ProfileName: "no-config", LockFile: &lockfile.LockFile{}},
+	}
+	meta := buildProfileMetadata(locks)
+	if _, ok := meta["good"]; !ok {
+		t.Fatalf("good should be in metadata")
+	}
+	if _, ok := meta["fetch-failed"]; ok {
+		t.Fatalf("fetch-failed should not be in metadata (no lockfile)")
+	}
+	if _, ok := meta["no-config"]; ok {
+		t.Fatalf("no-config should not be in metadata (nil config)")
+	}
+	if meta["good"].Identity != "good@x.com" {
+		t.Fatalf("identity carried wrong, got %q", meta["good"].Identity)
 	}
 }

--- a/internal/commands/install_multi_test.go
+++ b/internal/commands/install_multi_test.go
@@ -51,7 +51,7 @@ func TestMergeApplicableAssets_DefaultFirstWins(t *testing.T) {
 		buildProfileLock("work", "shared", "work-only"),
 		buildProfileLock("personal", "shared", "personal-only"),
 	}
-	sortedAssets, vaultMap, origin, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
+	sortedAssets, origin, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
 	if err != nil {
 		t.Fatalf("mergeApplicableAssets: %v", err)
 	}
@@ -70,9 +70,6 @@ func TestMergeApplicableAssets_DefaultFirstWins(t *testing.T) {
 	if !slices.Equal(conflicts[0].Shadowed, []string{"personal"}) {
 		t.Fatalf("shadowed=%v want [personal]", conflicts[0].Shadowed)
 	}
-	if vaultMap == nil {
-		t.Fatalf("vaultMap should be non-nil")
-	}
 	if origin["shared"] != "work" {
 		t.Fatalf("origin[shared]=%s want work", origin["shared"])
 	}
@@ -90,8 +87,7 @@ func TestMergeApplicableAssets_ThreeWayConflict(t *testing.T) {
 		buildProfileLock("b", "dup"),
 		buildProfileLock("c", "dup"),
 	}
-	sorted, vaultMap, _, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
-	_, _ = sorted, vaultMap
+	_, _, conflicts, err := mergeApplicableAssets(locks, clientList, matcher)
 	if err != nil {
 		t.Fatalf("merge: %v", err)
 	}

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -3,11 +3,14 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sleuth-io/sx/internal/config"
+	"github.com/sleuth-io/sx/internal/mgmt"
 	"github.com/sleuth-io/sx/internal/ui"
+	"github.com/sleuth-io/sx/internal/ui/components"
 )
 
 // NewProfileCommand creates the profile command with subcommands
@@ -15,7 +18,7 @@ func NewProfileCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "profile",
 		Short: "Manage configuration profiles",
-		Long:  "Manage multiple configuration profiles for switching between different servers.",
+		Long:  "Manage multiple configuration profiles for switching between different vaults. Multiple profiles can be active at the same time; sx install merges assets from every active profile.",
 	}
 
 	cmd.AddCommand(newProfileListCommand())
@@ -23,6 +26,10 @@ func NewProfileCommand() *cobra.Command {
 	cmd.AddCommand(newProfileUseCommand())
 	cmd.AddCommand(newProfileCurrentCommand())
 	cmd.AddCommand(newProfileRemoveCommand())
+	cmd.AddCommand(newProfileActivateCommand())
+	cmd.AddCommand(newProfileDeactivateCommand())
+	cmd.AddCommand(newProfileDefaultCommand())
+	cmd.AddCommand(newProfileEditCommand())
 
 	return cmd
 }
@@ -38,11 +45,12 @@ func newProfileListCommand() *cobra.Command {
 func newProfileAddCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add <profile-name>",
-		Short: "<name> Add a new profile ",
+		Short: "Add a new profile",
 		Long: `Add a new configuration profile with the specified name.
 
 Each profile can connect to a different vault (local path, Git repo, or Skills.new).
-After creating a profile, use 'sx profile use <name>' to switch to it.`,
+After creating a profile, use 'sx profile activate <name>' to add it to the active
+set, or 'sx profile use <name>' to make it the only active profile.`,
 		Example: `  sx profile add work
   sx profile add personal
   sx profile add local`,
@@ -72,13 +80,59 @@ func runProfileAdd(cmd *cobra.Command, args []string) error {
 
 	// Set the active profile and run init
 	config.SetActiveProfile(profileName)
-	return runInit(cmd, nil, "", "", "", "")
+	if err := runInit(cmd, nil, "", "", "", ""); err != nil {
+		return err
+	}
+
+	// Prompt for identity now that the profile is saved.
+	return promptProfileIdentity(cmd, profileName)
+}
+
+// promptProfileIdentity asks the user which email should be used for
+// team/user scope resolution in this profile and saves it. The default
+// is the profile's existing identity, falling back to git config
+// user.email.
+func promptProfileIdentity(cmd *cobra.Command, profileName string) error {
+	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		return err
+	}
+	profile, ok := mpc.GetProfile(profileName)
+	if !ok {
+		return fmt.Errorf("profile not found after init: %s", profileName)
+	}
+
+	defaultIdentity := profile.Identity
+	if defaultIdentity == "" {
+		actor, gitErr := mgmt.CurrentGitActor(cmd.Context(), "")
+		if gitErr == nil && !actor.Synthetic && !actor.IsBot() {
+			defaultIdentity = actor.Email
+		}
+	}
+
+	styledOut.Newline()
+	styledOut.Muted("Used to resolve team and user-scoped installs in this profile.")
+	identity, err := components.InputWithDefault("Identity email for profile "+profileName, defaultIdentity)
+	if err != nil {
+		// Non-interactive or cancelled — keep whatever was already there.
+		return nil //nolint:nilerr // identity is optional; fall back to git config at use time.
+	}
+	identity = strings.TrimSpace(identity)
+	if identity == "" || identity == profile.Identity {
+		return nil
+	}
+	profile.Identity = identity
+	mpc.SetProfile(profileName, profile)
+	return config.SaveMultiProfile(mpc)
 }
 
 func newProfileUseCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <profile-name>",
-		Short: "Switch to a profile",
+		Short: "Switch to a profile exclusively (deactivates all others)",
+		Long:  "Exclusive activation: makes the named profile the only active profile and sets it as the default. Use 'sx profile activate' to add to the active set without deactivating others.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runProfileUse,
 	}
@@ -87,7 +141,7 @@ func newProfileUseCommand() *cobra.Command {
 func newProfileCurrentCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "current",
-		Short: "Show the current active profile",
+		Short: "Show the active profiles",
 		RunE:  runProfileCurrent,
 	}
 }
@@ -101,6 +155,49 @@ func newProfileRemoveCommand() *cobra.Command {
 	}
 }
 
+func newProfileActivateCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "activate <profile-name>",
+		Short: "Add a profile to the active set",
+		Long:  "Adds the named profile to the active set without deactivating other profiles. sx install will then merge assets from every active profile.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runProfileActivate,
+	}
+}
+
+func newProfileDeactivateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deactivate <profile-name>",
+		Short: "Remove a profile from the active set",
+		Long:  "Removes the profile from the active set. Cannot deactivate the last active profile. Assets installed from the deactivated profile are removed on the next sx install.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runProfileDeactivate,
+	}
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	return cmd
+}
+
+func newProfileDefaultCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "default <profile-name>",
+		Short: "Set the default profile (target for writes and conflict tiebreaker)",
+		Long:  "The default profile owns mutations when no --profile flag is given and wins conflicts when multiple active profiles publish an asset with the same name. Activates the profile if it isn't already active.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runProfileDefault,
+	}
+}
+
+func newProfileEditCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit <profile-name>",
+		Short: "Edit profile fields (identity email)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runProfileEdit,
+	}
+	cmd.Flags().String("identity", "", "Identity email for team/user scope resolution")
+	return cmd
+}
+
 func runProfileList(cmd *cobra.Command, args []string) error {
 	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
 
@@ -109,7 +206,11 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	activeProfile := config.GetActiveProfileName(mpc)
+	defaultProfile := mpc.DefaultProfile
+	activeSet := make(map[string]bool, len(mpc.ActiveProfiles))
+	for _, n := range mpc.ActiveProfiles {
+		activeSet[n] = true
+	}
 	profiles := mpc.ListProfiles()
 
 	if len(profiles) == 0 {
@@ -120,19 +221,37 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 	for _, name := range profiles {
 		profile, _ := mpc.GetProfile(name)
 
-		// Build description based on profile type
 		desc := profile.RepositoryURL
 		if desc == "" {
 			desc = profile.ServerURL
 		}
+		if profile.Identity != "" {
+			desc += " (" + profile.Identity + ")"
+		}
 
-		if name == activeProfile {
-			styledOut.SuccessItem(styledOut.BoldText(name) + " " + styledOut.MutedText(desc))
+		marker := "  "
+		switch {
+		case activeSet[name] && name == defaultProfile:
+			marker = "✓★"
+		case activeSet[name]:
+			marker = "✓ "
+		case name == defaultProfile:
+			marker = " ★"
+		}
+
+		label := name
+		if name == defaultProfile {
+			label = styledOut.BoldText(name)
+		}
+		if activeSet[name] {
+			styledOut.SuccessItem(marker + " " + label + " " + styledOut.MutedText(desc))
 		} else {
-			styledOut.ListItem(" ", name+" "+styledOut.MutedText(desc))
+			styledOut.ListItem(marker, label+" "+styledOut.MutedText(desc))
 		}
 	}
 
+	styledOut.Newline()
+	styledOut.Muted("✓ = active   ★ = default")
 	return nil
 }
 
@@ -145,6 +264,12 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if _, ok := mpc.GetProfile(profileName); !ok {
+		return fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	// Exclusive activation: shrink ActiveProfiles to just this one.
+	mpc.ActiveProfiles = []string{profileName}
 	if err := mpc.SetDefaultProfile(profileName); err != nil {
 		return err
 	}
@@ -153,7 +278,7 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	styledOut.Success("Switched to profile: " + profileName)
+	styledOut.Success("Switched to profile: " + profileName + " (now the only active profile)")
 	return nil
 }
 
@@ -163,8 +288,14 @@ func runProfileCurrent(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	activeProfile := config.GetActiveProfileName(mpc)
-	fmt.Println(activeProfile)
+	names := config.GetActiveProfileNames(mpc)
+	for _, name := range names {
+		if name == mpc.DefaultProfile {
+			fmt.Println(name + " (default)")
+		} else {
+			fmt.Println(name)
+		}
+	}
 	return nil
 }
 
@@ -191,5 +322,117 @@ func runProfileRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	styledOut.Success("Removed profile: " + profileName)
+	return nil
+}
+
+func runProfileActivate(cmd *cobra.Command, args []string) error {
+	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	profileName := args[0]
+
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		return err
+	}
+
+	if err := mpc.Activate(profileName); err != nil {
+		return err
+	}
+	if err := config.SaveMultiProfile(mpc); err != nil {
+		return err
+	}
+
+	styledOut.Success("Activated profile: " + profileName)
+	active := strings.Join(mpc.ActiveProfiles, ", ")
+	styledOut.Muted("Active profiles: " + active)
+	return nil
+}
+
+func runProfileDeactivate(cmd *cobra.Command, args []string) error {
+	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	profileName := args[0]
+
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		return err
+	}
+
+	if !mpc.IsProfileActive(profileName) {
+		return fmt.Errorf("profile not active: %s", profileName)
+	}
+
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	if !skipConfirm {
+		styledOut.Warning("Deactivating " + profileName + " will remove its installed assets on the next sx install.")
+		confirmed, err := components.Confirm("Continue?", true)
+		if err != nil || !confirmed {
+			return errors.New("deactivation cancelled")
+		}
+	}
+
+	if err := mpc.Deactivate(profileName); err != nil {
+		return err
+	}
+	if err := config.SaveMultiProfile(mpc); err != nil {
+		return err
+	}
+
+	styledOut.Success("Deactivated profile: " + profileName)
+	styledOut.Muted("Run 'sx install' to remove its installed assets.")
+	return nil
+}
+
+func runProfileDefault(cmd *cobra.Command, args []string) error {
+	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	profileName := args[0]
+
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		return err
+	}
+
+	wasActive := mpc.IsProfileActive(profileName)
+	if err := mpc.SetDefaultProfile(profileName); err != nil {
+		return err
+	}
+	if err := config.SaveMultiProfile(mpc); err != nil {
+		return err
+	}
+
+	if !wasActive {
+		styledOut.Success("Activated " + profileName + " and set as default")
+	} else {
+		styledOut.Success("Default profile is now: " + profileName)
+	}
+	return nil
+}
+
+func runProfileEdit(cmd *cobra.Command, args []string) error {
+	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	profileName := args[0]
+
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		return err
+	}
+	profile, ok := mpc.GetProfile(profileName)
+	if !ok {
+		return fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	identityFlag, _ := cmd.Flags().GetString("identity")
+	if identityFlag != "" {
+		profile.Identity = strings.TrimSpace(identityFlag)
+		mpc.SetProfile(profileName, profile)
+		if err := config.SaveMultiProfile(mpc); err != nil {
+			return err
+		}
+		styledOut.Success("Updated identity for " + profileName + ": " + profile.Identity)
+		return nil
+	}
+
+	// Interactive fallback
+	if err := promptProfileIdentity(cmd, profileName); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -245,11 +245,7 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 		if name == defaultProfile {
 			label = styledOut.BoldText(name)
 		}
-		if activeSet[name] {
-			styledOut.SuccessItem(marker + " " + label + " " + styledOut.MutedText(desc))
-		} else {
-			styledOut.ListItem(marker, label+" "+styledOut.MutedText(desc))
-		}
+		styledOut.ListItem(marker, label+" "+styledOut.MutedText(desc))
 	}
 
 	styledOut.Newline()

--- a/internal/commands/profile.go
+++ b/internal/commands/profile.go
@@ -129,13 +129,15 @@ func promptProfileIdentity(cmd *cobra.Command, profileName string) error {
 }
 
 func newProfileUseCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "use <profile-name>",
 		Short: "Switch to a profile exclusively (deactivates all others)",
 		Long:  "Exclusive activation: makes the named profile the only active profile and sets it as the default. Use 'sx profile activate' to add to the active set without deactivating others.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runProfileUse,
 	}
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt when deactivating other active profiles")
+	return cmd
 }
 
 func newProfileCurrentCommand() *cobra.Command {
@@ -266,6 +268,27 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 
 	if _, ok := mpc.GetProfile(profileName); !ok {
 		return fmt.Errorf("profile not found: %s", profileName)
+	}
+
+	// If other profiles are currently active, warn before silently
+	// deactivating them — sx install would otherwise clean up their
+	// installed assets on the next run.
+	var toDeactivate []string
+	for _, n := range mpc.ActiveProfiles {
+		if n != profileName {
+			toDeactivate = append(toDeactivate, n)
+		}
+	}
+	if len(toDeactivate) > 0 {
+		skipConfirm, _ := cmd.Flags().GetBool("yes")
+		if !skipConfirm {
+			styledOut.Warning("This will deactivate: " + strings.Join(toDeactivate, ", "))
+			styledOut.Muted("Their installed assets will be removed on the next sx install.")
+			confirmed, err := components.Confirm("Continue?", true)
+			if err != nil || !confirmed {
+				return errors.New("profile use cancelled")
+			}
+		}
 	}
 
 	// Exclusive activation: shrink ActiveProfiles to just this one.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,14 @@ type Config struct {
 	// - For path: file:// URL pointing to local directory (file:///path/to/repo)
 	RepositoryURL string `json:"repositoryUrl,omitempty"`
 
+	// Identity is the email used to resolve team and user scopes when
+	// this Config is the active profile. Empty falls back to git config.
+	Identity string `json:"identity,omitempty"`
+
+	// ProfileName is the active profile name this Config was loaded from.
+	// Populated by Load(); not serialized.
+	ProfileName string `json:"-"`
+
 	// ForceEnabledClients is the list of client IDs that should always be enabled,
 	// even if not detected.
 	ForceEnabledClients []string `json:"forceEnabledClients,omitempty"`
@@ -63,7 +71,53 @@ func Load() (*Config, error) {
 		}
 	}
 
-	return profile.ToConfig(mpc.ForceEnabledClients, mpc.ForceDisabledClients), nil
+	cfg := profile.ToConfig(mpc.ForceEnabledClients, mpc.ForceDisabledClients)
+	cfg.ProfileName = profileName
+	return cfg, nil
+}
+
+// LoadActive returns one Config per active profile. The default profile
+// (if it is in the active set) is always first so callers can use slice
+// order as conflict precedence. Used by read-side commands that must
+// span every active profile (sx install, sx list).
+func LoadActive() ([]*Config, *MultiProfileConfig, error) {
+	mpc, err := LoadMultiProfile()
+	if err != nil {
+		return nil, nil, err
+	}
+	names := GetActiveProfileNames(mpc)
+	if len(names) == 0 {
+		return nil, nil, errors.New("no active profiles configured")
+	}
+	configs := make([]*Config, 0, len(names))
+	overrideHint := ""
+	switch {
+	case GetActiveProfileOverride() != "":
+		overrideHint = " (from --profile flag)"
+	case os.Getenv("SX_PROFILE") != "":
+		overrideHint = " (from SX_PROFILE env)"
+	}
+	for _, name := range names {
+		profile, ok := mpc.GetProfile(name)
+		if !ok {
+			return nil, nil, fmt.Errorf("active profile not found: %s%s", name, overrideHint)
+		}
+		cfg := profile.ToConfig(mpc.ForceEnabledClients, mpc.ForceDisabledClients)
+		cfg.ProfileName = name
+		configs = append(configs, cfg)
+	}
+	return configs, mpc, nil
+}
+
+// GetIdentity returns the configured identity email for this profile, or
+// empty when not set (callers fall back to git config user.email).
+func (c *Config) GetIdentity() string {
+	return c.Identity
+}
+
+// GetProfileName returns the profile name this Config was loaded from.
+func (c *Config) GetProfileName() string {
+	return c.ProfileName
 }
 
 // Save saves the configuration to the config file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,20 @@ func (c *Config) GetRepositoryURL() string {
 	return c.RepositoryURL
 }
 
+// VaultIdentifier returns a stable string that uniquely identifies the
+// vault this Config points at, suitable for use as a cache partition
+// key. Prefers RepositoryURL when set (the canonical field for git and
+// path vaults, and modern Sleuth configs) and falls back to ServerURL
+// for legacy Sleuth configs that predate the RepositoryURL field.
+// Returns empty only when both are missing — which Validate would have
+// already rejected.
+func (c *Config) VaultIdentifier() string {
+	if c.RepositoryURL != "" {
+		return c.RepositoryURL
+	}
+	return c.ServerURL
+}
+
 // IsSilent checks if silent mode is enabled via environment variable
 func IsSilent() bool {
 	return os.Getenv("SX_SYNC_SILENT") == "true" || os.Getenv("SKILLS_SYNC_SILENT") == "true"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -583,6 +583,34 @@ func TestProfileToConfig(t *testing.T) {
 	}
 }
 
+// TestVaultIdentifier_LegacySleuthFallsBackToServerURL covers the
+// cache-key invariant the lock-file/ETag cache relies on under the
+// parallel multi-profile fan-out: two legacy Sleuth profiles (with
+// only ServerURL set, no RepositoryURL) must produce distinct cache
+// keys via VaultIdentifier so they don't share an on-disk cache file
+// and race when fetched concurrently.
+func TestVaultIdentifier_LegacySleuthFallsBackToServerURL(t *testing.T) {
+	a := &Config{Type: RepositoryTypeSleuth, ServerURL: "https://a.sleuth.io"}
+	b := &Config{Type: RepositoryTypeSleuth, ServerURL: "https://b.sleuth.io"}
+
+	if got := a.VaultIdentifier(); got != "https://a.sleuth.io" {
+		t.Errorf("legacy Sleuth a: VaultIdentifier = %q, want https://a.sleuth.io", got)
+	}
+	if got := b.VaultIdentifier(); got != "https://b.sleuth.io" {
+		t.Errorf("legacy Sleuth b: VaultIdentifier = %q, want https://b.sleuth.io", got)
+	}
+	if a.VaultIdentifier() == b.VaultIdentifier() {
+		t.Fatal("two distinct legacy Sleuth profiles must not share a cache key")
+	}
+
+	// Modern config (RepositoryURL populated) must still prefer it
+	// even when ServerURL is also set.
+	c := &Config{Type: RepositoryTypeSleuth, RepositoryURL: "https://canonical.example", ServerURL: "https://legacy.example"}
+	if got := c.VaultIdentifier(); got != "https://canonical.example" {
+		t.Errorf("modern Sleuth: VaultIdentifier = %q, want canonical RepositoryURL", got)
+	}
+}
+
 // Test SaveMultiProfile persists client settings correctly
 func TestSaveMultiProfileWithClientSettings(t *testing.T) {
 	tmpHome := t.TempDir()

--- a/internal/config/multi_active_test.go
+++ b/internal/config/multi_active_test.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/utils"
+)
+
+// writeConfig persists a backwards-compatible config payload at the
+// canonical location for tests that exercise the multi-active resolver.
+func writeConfig(t *testing.T, payload map[string]any) {
+	t.Helper()
+	configFile, err := utils.GetConfigFile()
+	if err != nil {
+		t.Fatalf("config file path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configFile), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(configFile, data, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func newTestHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	SetActiveProfile("")
+	t.Setenv("SX_PROFILE", "")
+}
+
+func TestEnsureActiveProfilesBackfillsFromDefault(t *testing.T) {
+	newTestHome(t)
+	writeConfig(t, map[string]any{
+		"defaultProfile": "work",
+		"profiles": map[string]any{
+			"work":     map[string]any{"type": "git", "repositoryUrl": "g@x:work"},
+			"personal": map[string]any{"type": "git", "repositoryUrl": "g@x:personal"},
+		},
+	})
+
+	mpc, err := LoadMultiProfile()
+	if err != nil {
+		t.Fatalf("LoadMultiProfile: %v", err)
+	}
+	if got := mpc.ActiveProfiles; !slices.Equal(got, []string{"work"}) {
+		t.Fatalf("ActiveProfiles=%v, want [work]", got)
+	}
+}
+
+func TestGetActiveProfileNamesPlacesDefaultFirst(t *testing.T) {
+	mpc := &MultiProfileConfig{
+		DefaultProfile: "work",
+		ActiveProfiles: []string{"personal", "work"},
+		Profiles: map[string]*Profile{
+			"work":     {Type: RepositoryTypeGit, RepositoryURL: "g@x:w"},
+			"personal": {Type: RepositoryTypeGit, RepositoryURL: "g@x:p"},
+		},
+	}
+	got := GetActiveProfileNames(mpc)
+	want := []string{"work", "personal"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestGetActiveProfileNamesEnvOverride(t *testing.T) {
+	newTestHome(t)
+	mpc := &MultiProfileConfig{
+		DefaultProfile: "work",
+		ActiveProfiles: []string{"work"},
+		Profiles: map[string]*Profile{
+			"work":     {Type: RepositoryTypeGit, RepositoryURL: "g@x:w"},
+			"personal": {Type: RepositoryTypeGit, RepositoryURL: "g@x:p"},
+		},
+	}
+	t.Setenv("SX_PROFILE", "personal, work")
+	defer t.Setenv("SX_PROFILE", "")
+	got := GetActiveProfileNames(mpc)
+	want := []string{"personal", "work"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestActivateDeactivate(t *testing.T) {
+	mpc := &MultiProfileConfig{
+		DefaultProfile: "work",
+		ActiveProfiles: []string{"work"},
+		Profiles: map[string]*Profile{
+			"work":     {Type: RepositoryTypeGit, RepositoryURL: "g@x:w"},
+			"personal": {Type: RepositoryTypeGit, RepositoryURL: "g@x:p"},
+		},
+	}
+
+	if err := mpc.Activate("personal"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !mpc.IsProfileActive("personal") {
+		t.Fatalf("personal should be active after Activate")
+	}
+	if !slices.Equal(mpc.ActiveProfiles, []string{"work", "personal"}) {
+		t.Fatalf("ActiveProfiles=%v", mpc.ActiveProfiles)
+	}
+
+	if err := mpc.Deactivate("work"); err != nil {
+		t.Fatalf("Deactivate: %v", err)
+	}
+	if mpc.DefaultProfile != "personal" {
+		t.Fatalf("DefaultProfile should fall back to remaining active, got %s", mpc.DefaultProfile)
+	}
+
+	if err := mpc.Deactivate("personal"); err == nil {
+		t.Fatalf("Deactivate of last active should fail")
+	}
+}
+
+func TestSetDefaultProfileAutoActivates(t *testing.T) {
+	mpc := &MultiProfileConfig{
+		DefaultProfile: "work",
+		ActiveProfiles: []string{"work"},
+		Profiles: map[string]*Profile{
+			"work":     {Type: RepositoryTypeGit, RepositoryURL: "g@x:w"},
+			"personal": {Type: RepositoryTypeGit, RepositoryURL: "g@x:p"},
+		},
+	}
+	if err := mpc.SetDefaultProfile("personal"); err != nil {
+		t.Fatalf("SetDefaultProfile: %v", err)
+	}
+	if !mpc.IsProfileActive("personal") {
+		t.Fatalf("personal should be auto-activated when set as default")
+	}
+}
+
+func TestLoadActiveReturnsEveryActive(t *testing.T) {
+	newTestHome(t)
+	writeConfig(t, map[string]any{
+		"defaultProfile": "work",
+		"activeProfiles": []string{"work", "personal"},
+		"profiles": map[string]any{
+			"work":     map[string]any{"type": "git", "repositoryUrl": "g@x:w", "identity": "work@example.com"},
+			"personal": map[string]any{"type": "git", "repositoryUrl": "g@x:p", "identity": "me@personal.com"},
+		},
+	})
+
+	configs, mpc, err := LoadActive()
+	if err != nil {
+		t.Fatalf("LoadActive: %v", err)
+	}
+	if mpc.DefaultProfile != "work" {
+		t.Fatalf("DefaultProfile=%s", mpc.DefaultProfile)
+	}
+	if len(configs) != 2 {
+		t.Fatalf("got %d configs, want 2", len(configs))
+	}
+	if configs[0].ProfileName != "work" {
+		t.Fatalf("expected work first (default), got %s", configs[0].ProfileName)
+	}
+	identities := []string{configs[0].Identity, configs[1].Identity}
+	wantIdentities := []string{"work@example.com", "me@personal.com"}
+	if !reflect.DeepEqual(identities, wantIdentities) {
+		t.Fatalf("identities=%v want %v", identities, wantIdentities)
+	}
+}
+
+func TestDeleteProfileKeepsActiveSetNonEmpty(t *testing.T) {
+	mpc := &MultiProfileConfig{
+		DefaultProfile: "work",
+		ActiveProfiles: []string{"work", "personal"},
+		Profiles: map[string]*Profile{
+			"work":     {Type: RepositoryTypeGit, RepositoryURL: "g@x:w"},
+			"personal": {Type: RepositoryTypeGit, RepositoryURL: "g@x:p"},
+		},
+	}
+	if err := mpc.DeleteProfile("work"); err != nil {
+		t.Fatalf("DeleteProfile: %v", err)
+	}
+	if mpc.DefaultProfile != "personal" {
+		t.Fatalf("DefaultProfile should fall back, got %s", mpc.DefaultProfile)
+	}
+	if !slices.Equal(mpc.ActiveProfiles, []string{"personal"}) {
+		t.Fatalf("ActiveProfiles=%v", mpc.ActiveProfiles)
+	}
+}

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/sleuth-io/sx/internal/utils"
 )
@@ -29,12 +31,28 @@ type Profile struct {
 	// - For git: git repository URL (https://github.com/org/repo.git)
 	// - For path: file:// URL pointing to local directory (file:///path/to/repo)
 	RepositoryURL string `json:"repositoryUrl,omitempty"`
+
+	// Identity is the email used to resolve team and user scopes for this
+	// profile. When empty, sx falls back to `git config user.email`. Set
+	// per-profile so a single machine can use different identities for
+	// different vaults (e.g. work vs personal email).
+	Identity string `json:"identity,omitempty"`
 }
 
 // MultiProfileConfig represents the full configuration file with multiple profiles
 type MultiProfileConfig struct {
-	// DefaultProfile is the name of the currently active profile
+	// DefaultProfile is the profile that owns "write" actions when no
+	// --profile flag is given (sx add, sx role, sx team ...). It is also
+	// the conflict tiebreaker when multiple active profiles publish an
+	// asset with the same name. Always a member of ActiveProfiles.
 	DefaultProfile string `json:"defaultProfile"`
+
+	// ActiveProfiles is the set of profiles considered "on" for read
+	// operations (sx install, sx list). When more than one is active,
+	// install merges applicable assets from every active profile's vault.
+	// Order is precedence for conflict resolution when DefaultProfile
+	// isn't in the active set.
+	ActiveProfiles []string `json:"activeProfiles,omitempty"`
 
 	// Profiles is a map of profile name to profile configuration
 	Profiles map[string]*Profile `json:"profiles"`
@@ -112,7 +130,54 @@ func loadMultiProfileConfig(data []byte) (*MultiProfileConfig, error) {
 	}
 	// Migrate old bootstrap option keys to new consolidated keys
 	migrateBootstrapKeys(&mpc)
+	// Backfill ActiveProfiles from DefaultProfile for configs written by
+	// older sx versions that only tracked a single default.
+	ensureActiveProfiles(&mpc)
 	return &mpc, nil
+}
+
+// ensureActiveProfiles guarantees that ActiveProfiles is populated and
+// consistent with the available profiles. When upgrading from a config
+// written before ActiveProfiles existed, the default profile becomes the
+// sole active profile.
+func ensureActiveProfiles(mpc *MultiProfileConfig) {
+	// Drop stale entries that point at deleted profiles.
+	if len(mpc.ActiveProfiles) > 0 {
+		filtered := mpc.ActiveProfiles[:0]
+		seen := make(map[string]bool, len(mpc.ActiveProfiles))
+		for _, name := range mpc.ActiveProfiles {
+			if _, ok := mpc.Profiles[name]; !ok {
+				continue
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			filtered = append(filtered, name)
+		}
+		mpc.ActiveProfiles = filtered
+	}
+	// Legacy migration: no ActiveProfiles → default becomes the only active.
+	if len(mpc.ActiveProfiles) == 0 {
+		if mpc.DefaultProfile != "" {
+			if _, ok := mpc.Profiles[mpc.DefaultProfile]; ok {
+				mpc.ActiveProfiles = []string{mpc.DefaultProfile}
+				return
+			}
+		}
+		// Last resort: if DefaultProfile is missing, pick deterministic first.
+		names := make([]string, 0, len(mpc.Profiles))
+		for name := range mpc.Profiles {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		if len(names) > 0 {
+			mpc.ActiveProfiles = []string{names[0]}
+			if mpc.DefaultProfile == "" {
+				mpc.DefaultProfile = names[0]
+			}
+		}
+	}
 }
 
 // migrateBootstrapKeys migrates old client-specific bootstrap keys to the new shared keys.
@@ -156,6 +221,7 @@ func migrateOldConfig(data []byte) (*MultiProfileConfig, error) {
 	// Create multi-profile config with the old config as "default" profile
 	mpc := &MultiProfileConfig{
 		DefaultProfile: DefaultProfileName,
+		ActiveProfiles: []string{DefaultProfileName},
 		Profiles: map[string]*Profile{
 			DefaultProfileName: {
 				Type:          oldCfg.Type,
@@ -207,6 +273,7 @@ type backwardsCompatibleConfig struct {
 
 	// New multi-profile fields
 	DefaultProfile string              `json:"defaultProfile"`
+	ActiveProfiles []string            `json:"activeProfiles,omitempty"`
 	Profiles       map[string]*Profile `json:"profiles"`
 
 	// Client enable/disable settings (global across profiles)
@@ -233,6 +300,7 @@ func SaveMultiProfile(mpc *MultiProfileConfig) error {
 	// Build backwards-compatible config with active profile at top level
 	compat := backwardsCompatibleConfig{
 		DefaultProfile:       mpc.DefaultProfile,
+		ActiveProfiles:       mpc.ActiveProfiles,
 		Profiles:             mpc.Profiles,
 		ForceEnabledClients:  mpc.ForceEnabledClients,
 		ForceDisabledClients: mpc.ForceDisabledClients,
@@ -263,19 +331,132 @@ func SaveMultiProfile(mpc *MultiProfileConfig) error {
 	return nil
 }
 
-// GetActiveProfileName returns the name of the profile that should be used
+// GetActiveProfileName returns the name of the profile that owns single-
+// profile actions (mutations, --profile flag overrides, --profile=NAME).
+// For the read-side set used by sx install, see GetActiveProfileNames.
 func GetActiveProfileName(mpc *MultiProfileConfig) string {
 	// Priority: override > env var > default profile
 	if activeProfileOverride != "" {
-		return activeProfileOverride
+		return firstName(activeProfileOverride)
 	}
 	if envProfile := os.Getenv("SX_PROFILE"); envProfile != "" {
-		return envProfile
+		return firstName(envProfile)
 	}
 	if mpc.DefaultProfile != "" {
 		return mpc.DefaultProfile
 	}
 	return DefaultProfileName
+}
+
+// GetActiveProfileNames returns every profile that should be loaded by
+// read-side commands (sx install, sx list). When --profile or SX_PROFILE
+// is set, the override list wins and its order is preserved (treating
+// the user's explicit input as authoritative precedence). Otherwise
+// ActiveProfiles is returned, with the default profile bubbled to the
+// front so conflict resolution favors it.
+func GetActiveProfileNames(mpc *MultiProfileConfig) []string {
+	var raw []string
+	explicitOverride := false
+	switch {
+	case activeProfileOverride != "":
+		raw = splitNames(activeProfileOverride)
+		explicitOverride = true
+	case os.Getenv("SX_PROFILE") != "":
+		raw = splitNames(os.Getenv("SX_PROFILE"))
+		explicitOverride = true
+	case len(mpc.ActiveProfiles) > 0:
+		raw = append(raw, mpc.ActiveProfiles...)
+	case mpc.DefaultProfile != "":
+		raw = []string{mpc.DefaultProfile}
+	default:
+		raw = []string{DefaultProfileName}
+	}
+
+	seen := make(map[string]bool, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, name := range raw {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	// Bubble the default profile to the front for the persisted active
+	// set; explicit user overrides keep their input order.
+	if !explicitOverride && mpc.DefaultProfile != "" && seen[mpc.DefaultProfile] && len(out) > 1 && out[0] != mpc.DefaultProfile {
+		ordered := make([]string, 0, len(out))
+		ordered = append(ordered, mpc.DefaultProfile)
+		for _, name := range out {
+			if name != mpc.DefaultProfile {
+				ordered = append(ordered, name)
+			}
+		}
+		out = ordered
+	}
+	return out
+}
+
+// firstName returns the first comma-separated entry, trimmed.
+func firstName(s string) string {
+	parts := splitNames(s)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
+// splitNames parses a comma-separated profile list, trimming whitespace
+// and skipping empties.
+func splitNames(s string) []string {
+	parts := make([]string, 0)
+	for raw := range strings.SplitSeq(s, ",") {
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return parts
+}
+
+// IsProfileActive reports whether the named profile is in ActiveProfiles.
+func (mpc *MultiProfileConfig) IsProfileActive(name string) bool {
+	return slices.Contains(mpc.ActiveProfiles, name)
+}
+
+// Activate adds name to ActiveProfiles. Returns an error if the profile
+// does not exist. A no-op when already active.
+func (mpc *MultiProfileConfig) Activate(name string) error {
+	if _, ok := mpc.Profiles[name]; !ok {
+		return fmt.Errorf("profile not found: %s", name)
+	}
+	if mpc.IsProfileActive(name) {
+		return nil
+	}
+	mpc.ActiveProfiles = append(mpc.ActiveProfiles, name)
+	return nil
+}
+
+// Deactivate removes name from ActiveProfiles. Refuses to remove the
+// last active profile. If the deactivated profile was also the default,
+// the first remaining active profile takes over as the new default so
+// the invariant "DefaultProfile is always active" still holds.
+func (mpc *MultiProfileConfig) Deactivate(name string) error {
+	if !mpc.IsProfileActive(name) {
+		return fmt.Errorf("profile not active: %s", name)
+	}
+	if len(mpc.ActiveProfiles) <= 1 {
+		return errors.New("cannot deactivate the last active profile")
+	}
+	filtered := mpc.ActiveProfiles[:0]
+	for _, n := range mpc.ActiveProfiles {
+		if n != name {
+			filtered = append(filtered, n)
+		}
+	}
+	mpc.ActiveProfiles = filtered
+	if mpc.DefaultProfile == name {
+		mpc.DefaultProfile = mpc.ActiveProfiles[0]
+	}
+	return nil
 }
 
 // ListProfiles returns a sorted list of profile names
@@ -309,7 +490,16 @@ func (mpc *MultiProfileConfig) DeleteProfile(name string) error {
 	}
 	delete(mpc.Profiles, name)
 
-	// If we deleted the default profile, set a new default
+	// Drop from active set, refusing to leave the set empty.
+	filtered := mpc.ActiveProfiles[:0]
+	for _, n := range mpc.ActiveProfiles {
+		if n != name {
+			filtered = append(filtered, n)
+		}
+	}
+	mpc.ActiveProfiles = filtered
+
+	// If we deleted the default profile, pick a new default.
 	if mpc.DefaultProfile == name {
 		names := mpc.ListProfiles()
 		if len(names) > 0 {
@@ -318,15 +508,23 @@ func (mpc *MultiProfileConfig) DeleteProfile(name string) error {
 			mpc.DefaultProfile = ""
 		}
 	}
+
+	// Ensure ActiveProfiles is non-empty when profiles remain.
+	if len(mpc.ActiveProfiles) == 0 && mpc.DefaultProfile != "" {
+		mpc.ActiveProfiles = []string{mpc.DefaultProfile}
+	}
 	return nil
 }
 
-// SetDefaultProfile sets the default profile
+// SetDefaultProfile sets the default profile, activating it if needed.
 func (mpc *MultiProfileConfig) SetDefaultProfile(name string) error {
 	if _, ok := mpc.Profiles[name]; !ok {
 		return fmt.Errorf("profile not found: %s", name)
 	}
 	mpc.DefaultProfile = name
+	if !mpc.IsProfileActive(name) {
+		mpc.ActiveProfiles = append(mpc.ActiveProfiles, name)
+	}
 	return nil
 }
 
@@ -337,6 +535,7 @@ func (p *Profile) ToConfig(forceEnabled, forceDisabled []string) *Config {
 		ServerURL:            p.ServerURL,
 		AuthToken:            p.AuthToken,
 		RepositoryURL:        p.RepositoryURL,
+		Identity:             p.Identity,
 		ForceEnabledClients:  forceEnabled,
 		ForceDisabledClients: forceDisabled,
 	}
@@ -349,6 +548,7 @@ func ProfileFromConfig(cfg *Config) *Profile {
 		ServerURL:     cfg.ServerURL,
 		AuthToken:     cfg.AuthToken,
 		RepositoryURL: cfg.RepositoryURL,
+		Identity:      cfg.Identity,
 	}
 }
 

--- a/internal/mgmt/audit.go
+++ b/internal/mgmt/audit.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -54,12 +55,17 @@ const (
 
 // AuditEvent is a single row in .sx/audit/YYYY-MM.jsonl.
 type AuditEvent struct {
-	Timestamp  time.Time      `json:"ts"`
-	Actor      string         `json:"actor"`
-	Event      string         `json:"event"`
-	TargetType string         `json:"target_type"`
-	Target     string         `json:"target"`
-	Data       map[string]any `json:"data,omitempty"`
+	Timestamp  time.Time `json:"ts"`
+	Actor      string    `json:"actor"`
+	Event      string    `json:"event"`
+	TargetType string    `json:"target_type"`
+	Target     string    `json:"target"`
+	// Profile records which sx profile produced the event. Optional —
+	// older sx versions did not populate it. Useful for cross-vault
+	// correlation when a user runs multiple profiles against the same
+	// audit stream.
+	Profile string         `json:"profile,omitempty"`
+	Data    map[string]any `json:"data,omitempty"`
 }
 
 // AuditFilter narrows an audit query. Zero values mean "don't filter on
@@ -74,13 +80,43 @@ type AuditFilter struct {
 	Limit       int
 }
 
+// auditProfileTag is the active profile name reported on every emitted
+// audit event. Populated by SetAuditProfileTag at command boot so call
+// sites don't have to thread the profile through every AuditEvent
+// literal. Guarded by auditProfileTagMu — vault mutation paths may emit
+// events from background goroutines.
+var (
+	auditProfileTagMu sync.RWMutex
+	auditProfileTag   string
+)
+
+// SetAuditProfileTag records the profile name to stamp onto subsequent
+// AppendAuditEvent calls. Empty disables tagging.
+func SetAuditProfileTag(name string) {
+	auditProfileTagMu.Lock()
+	auditProfileTag = strings.TrimSpace(name)
+	auditProfileTagMu.Unlock()
+}
+
+// getAuditProfileTag reads the tag under the package mutex.
+func getAuditProfileTag() string {
+	auditProfileTagMu.RLock()
+	defer auditProfileTagMu.RUnlock()
+	return auditProfileTag
+}
+
 // AppendAuditEvent appends an event to the monthly audit file for the
-// event's timestamp. The parent directory is created if needed.
+// event's timestamp. The parent directory is created if needed. Stamps
+// the active profile (when set via SetAuditProfileTag) so consumers can
+// correlate cross-profile activity.
 func AppendAuditEvent(vaultRoot string, event AuditEvent) error {
 	if event.Timestamp.IsZero() {
 		event.Timestamp = time.Now().UTC()
 	} else {
 		event.Timestamp = event.Timestamp.UTC()
+	}
+	if event.Profile == "" {
+		event.Profile = getAuditProfileTag()
 	}
 
 	dir := filepath.Join(vaultRoot, AuditDirName)

--- a/internal/mgmt/identity.go
+++ b/internal/mgmt/identity.go
@@ -123,19 +123,52 @@ func getIdentityOverrideLocked() string {
 	return identityOverride
 }
 
+// identityContextKey scopes a per-call identity override carried in
+// context. Used by the multi-profile install fan-out so concurrent lock
+// file fetches can each resolve actor against their own profile email
+// without racing the process-global override.
+type identityContextKey struct{}
+
+// ContextWithIdentity returns a derived context that carries the given
+// email as the per-call identity override. CurrentGitActor consults
+// this in preference to the process-global override, so concurrent
+// fetches can scope identity independently. Empty email returns ctx
+// unchanged.
+func ContextWithIdentity(ctx context.Context, email string) context.Context {
+	trimmed := strings.TrimSpace(email)
+	if trimmed == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, identityContextKey{}, trimmed)
+}
+
+// identityFromContext extracts the per-call identity override, returning
+// "" when ctx is nil or no identity was set.
+func identityFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	v, _ := ctx.Value(identityContextKey{}).(string)
+	return v
+}
+
 // CurrentGitActor resolves the caller's identity. SX_BOT short-circuits
 // the resolution: if set, the actor is a bot identity, with Email
 // "bot:<name>" so audit log entries are attributed unambiguously and
-// never collide with a human email. Otherwise, a profile-provided
-// identity (via SetIdentityOverride) wins next so per-profile email
-// overrides take effect. Failing that, resolution proceeds via `git
-// config user.email` (scoped to the given repoPath if non-empty,
-// falling back to global git config), with a $USER@host fallback for
-// unconfigured workstations. Returns ErrIdentityNotSet only when every
-// source fails.
+// never collide with a human email. Otherwise resolution prefers a
+// per-call identity carried on ctx (see ContextWithIdentity) so
+// concurrent multi-profile work can scope identity per goroutine;
+// falling back to the process-global override (SetIdentityOverride),
+// then to `git config user.email` (scoped to the given repoPath if
+// non-empty, falling back to global git config), with a $USER@host
+// fallback for unconfigured workstations. Returns ErrIdentityNotSet
+// only when every source fails.
 func CurrentGitActor(ctx context.Context, repoPath string) (Actor, error) {
 	botName := strings.TrimSpace(os.Getenv(SXBotEnv))
-	override := getIdentityOverrideLocked()
+	override := identityFromContext(ctx)
+	if override == "" {
+		override = getIdentityOverrideLocked()
+	}
 	cacheKey := actorCacheKey{repoPath: repoPath, bot: botName, identity: override}
 
 	actorCacheMu.Lock()

--- a/internal/mgmt/identity.go
+++ b/internal/mgmt/identity.go
@@ -87,6 +87,7 @@ func (a Actor) RequireRealIdentity() error {
 type actorCacheKey struct {
 	repoPath string
 	bot      string
+	identity string
 }
 
 // actorCache caches the result of CurrentGitActor per (repoPath, SX_BOT)
@@ -97,17 +98,45 @@ var (
 	actorCache   = make(map[actorCacheKey]Actor)
 )
 
+// identityOverride is a process-wide email override set from the active
+// profile's Identity field. When non-empty, CurrentGitActor uses it
+// instead of consulting `git config user.email`. Guarded by
+// identityOverrideMu so concurrent vault HTTP/git work (or background
+// audit writes) reads a stable value.
+var (
+	identityOverrideMu sync.RWMutex
+	identityOverride   string
+)
+
+// SetIdentityOverride sets the process-wide email override consulted by
+// CurrentGitActor. Pass empty to clear. Trims whitespace.
+func SetIdentityOverride(email string) {
+	identityOverrideMu.Lock()
+	identityOverride = strings.TrimSpace(email)
+	identityOverrideMu.Unlock()
+}
+
+// getIdentityOverrideLocked reads the override under the package mutex.
+func getIdentityOverrideLocked() string {
+	identityOverrideMu.RLock()
+	defer identityOverrideMu.RUnlock()
+	return identityOverride
+}
+
 // CurrentGitActor resolves the caller's identity. SX_BOT short-circuits
 // the resolution: if set, the actor is a bot identity, with Email
 // "bot:<name>" so audit log entries are attributed unambiguously and
-// never collide with a human email. Otherwise resolution proceeds via
-// `git config user.email` (scoped to the given repoPath if non-empty,
+// never collide with a human email. Otherwise, a profile-provided
+// identity (via SetIdentityOverride) wins next so per-profile email
+// overrides take effect. Failing that, resolution proceeds via `git
+// config user.email` (scoped to the given repoPath if non-empty,
 // falling back to global git config), with a $USER@host fallback for
 // unconfigured workstations. Returns ErrIdentityNotSet only when every
 // source fails.
 func CurrentGitActor(ctx context.Context, repoPath string) (Actor, error) {
 	botName := strings.TrimSpace(os.Getenv(SXBotEnv))
-	cacheKey := actorCacheKey{repoPath: repoPath, bot: botName}
+	override := getIdentityOverrideLocked()
+	cacheKey := actorCacheKey{repoPath: repoPath, bot: botName, identity: override}
 
 	actorCacheMu.Lock()
 	if cached, ok := actorCache[cacheKey]; ok {
@@ -121,6 +150,20 @@ func CurrentGitActor(ctx context.Context, repoPath string) (Actor, error) {
 			Email: "bot:" + botName,
 			Name:  botName,
 			Bot:   botName,
+		}
+		actorCacheMu.Lock()
+		actorCache[cacheKey] = actor
+		actorCacheMu.Unlock()
+		return actor, nil
+	}
+
+	if override != "" {
+		// Use git config user.name when available for a nicer display;
+		// the email is authoritative from the profile override.
+		name := readGitConfig(ctx, repoPath, "user.name")
+		actor := Actor{
+			Email: NormalizeEmail(override),
+			Name:  strings.TrimSpace(name),
 		}
 		actorCacheMu.Lock()
 		actorCache[cacheKey] = actor

--- a/internal/mgmt/identity.go
+++ b/internal/mgmt/identity.go
@@ -129,27 +129,41 @@ func getIdentityOverrideLocked() string {
 // without racing the process-global override.
 type identityContextKey struct{}
 
-// ContextWithIdentity returns a derived context that carries the given
-// email as the per-call identity override. CurrentGitActor consults
-// this in preference to the process-global override, so concurrent
-// fetches can scope identity independently. Empty email returns ctx
-// unchanged.
-func ContextWithIdentity(ctx context.Context, email string) context.Context {
-	trimmed := strings.TrimSpace(email)
-	if trimmed == "" {
-		return ctx
-	}
-	return context.WithValue(ctx, identityContextKey{}, trimmed)
+// identityContextValue carries an explicit per-call identity. Stored as
+// a pointer so absent vs. present-but-empty are distinguishable: absent
+// means "no per-call override; consult the process-global override",
+// while present-but-empty means "this caller explicitly has no
+// identity — skip both overrides and resolve via git config". The
+// fan-out in loadActiveLockFiles relies on the latter so a profile
+// with empty Identity falls back to git config even when an earlier
+// profile in the active set seeded a non-empty global override.
+type identityContextValue struct {
+	Email string
 }
 
-// identityFromContext extracts the per-call identity override, returning
-// "" when ctx is nil or no identity was set.
-func identityFromContext(ctx context.Context) string {
+// ContextWithIdentity returns a derived context that carries the given
+// email as the per-call identity override. CurrentGitActor consults
+// this in preference to the process-global override. An empty email
+// is recorded as an *explicit* opt-out (skip both overrides, resolve
+// via git config) rather than as a no-op — see identityContextValue.
+func ContextWithIdentity(ctx context.Context, email string) context.Context {
+	v := &identityContextValue{Email: strings.TrimSpace(email)}
+	return context.WithValue(ctx, identityContextKey{}, v)
+}
+
+// identityFromContext extracts the per-call identity override. The
+// second return is true when ctx carries an explicit value (including
+// the explicit-empty opt-out); false means no per-call override was
+// set and callers should consult the global override.
+func identityFromContext(ctx context.Context) (string, bool) {
 	if ctx == nil {
-		return ""
+		return "", false
 	}
-	v, _ := ctx.Value(identityContextKey{}).(string)
-	return v
+	v, ok := ctx.Value(identityContextKey{}).(*identityContextValue)
+	if !ok || v == nil {
+		return "", false
+	}
+	return v.Email, true
 }
 
 // CurrentGitActor resolves the caller's identity. SX_BOT short-circuits
@@ -165,8 +179,8 @@ func identityFromContext(ctx context.Context) string {
 // only when every source fails.
 func CurrentGitActor(ctx context.Context, repoPath string) (Actor, error) {
 	botName := strings.TrimSpace(os.Getenv(SXBotEnv))
-	override := identityFromContext(ctx)
-	if override == "" {
+	override, fromCtx := identityFromContext(ctx)
+	if !fromCtx {
 		override = getIdentityOverrideLocked()
 	}
 	cacheKey := actorCacheKey{repoPath: repoPath, bot: botName, identity: override}

--- a/internal/mgmt/identity_test.go
+++ b/internal/mgmt/identity_test.go
@@ -8,6 +8,26 @@ import (
 	"testing"
 )
 
+func TestCurrentGitActorRespectsIdentityOverride(t *testing.T) {
+	ResetActorCache()
+	t.Cleanup(func() {
+		SetIdentityOverride("")
+		ResetActorCache()
+	})
+	SetIdentityOverride("profile-user@example.com")
+
+	actor, err := CurrentGitActor(context.Background(), "")
+	if err != nil {
+		t.Fatalf("CurrentGitActor: %v", err)
+	}
+	if actor.Email != "profile-user@example.com" {
+		t.Fatalf("got %s, want profile-user@example.com", actor.Email)
+	}
+	if actor.Synthetic {
+		t.Fatalf("override should not be synthetic")
+	}
+}
+
 func TestCurrentGitActorWithConfiguredRepo(t *testing.T) {
 	ResetActorCache()
 	dir := t.TempDir()

--- a/internal/mgmt/identity_test.go
+++ b/internal/mgmt/identity_test.go
@@ -3,8 +3,10 @@ package mgmt
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -188,6 +190,96 @@ func TestFallbackEmail_UsesLocalPrefix(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, "local:") {
 		t.Errorf("fallback email must carry the local: prefix to prevent admin-list collisions, got %q", got)
+	}
+}
+
+// TestContextWithIdentity_PrefersContextOverGlobal verifies that an
+// identity carried on the context wins over the process-global override.
+// This is the foundation for parallel multi-profile lock fetches where
+// each goroutine resolves identity against its own profile without
+// touching the shared override.
+func TestContextWithIdentity_PrefersContextOverGlobal(t *testing.T) {
+	ResetActorCache()
+	t.Cleanup(func() {
+		SetIdentityOverride("")
+		ResetActorCache()
+	})
+	SetIdentityOverride("global@example.com")
+
+	ctx := ContextWithIdentity(context.Background(), "ctx@example.com")
+	actor, err := CurrentGitActor(ctx, "")
+	if err != nil {
+		t.Fatalf("CurrentGitActor: %v", err)
+	}
+	if actor.Email != "ctx@example.com" {
+		t.Errorf("expected ctx@example.com to win, got %s", actor.Email)
+	}
+
+	// Same call without the context wrapping should fall back to the
+	// global override.
+	actor, err = CurrentGitActor(context.Background(), "")
+	if err != nil {
+		t.Fatalf("CurrentGitActor (no ctx identity): %v", err)
+	}
+	if actor.Email != "global@example.com" {
+		t.Errorf("expected global@example.com fallback, got %s", actor.Email)
+	}
+}
+
+// TestContextWithIdentity_EmptyIsNoop verifies that an empty email
+// leaves ctx untouched so callers don't accidentally clear a parent
+// identity by passing through.
+func TestContextWithIdentity_EmptyIsNoop(t *testing.T) {
+	parent := ContextWithIdentity(context.Background(), "parent@example.com")
+	child := ContextWithIdentity(parent, "")
+	if got := identityFromContext(child); got != "parent@example.com" {
+		t.Errorf("empty email must not clear parent identity, got %q", got)
+	}
+}
+
+// TestCurrentGitActor_ConcurrentContextIdentitiesDontBleed exercises the
+// multi-profile fan-out invariant: N goroutines each carrying a
+// different ContextWithIdentity must each see their own identity, with
+// no cross-bleed even if they execute simultaneously.
+func TestCurrentGitActor_ConcurrentContextIdentitiesDontBleed(t *testing.T) {
+	ResetActorCache()
+	t.Cleanup(func() {
+		SetIdentityOverride("")
+		ResetActorCache()
+	})
+	// Set a global override that none of the goroutines should ever
+	// resolve to (they all carry context identities).
+	SetIdentityOverride("global@example.com")
+
+	const goroutines = 16
+	emails := make([]string, goroutines)
+	for i := range emails {
+		emails[i] = fmt.Sprintf("profile-%d@example.com", i)
+	}
+
+	got := make([]string, goroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i, email := range emails {
+		wg.Add(1)
+		go func(i int, email string) {
+			defer wg.Done()
+			<-start
+			actor, err := CurrentGitActor(ContextWithIdentity(context.Background(), email), "")
+			if err != nil {
+				t.Errorf("goroutine %d: %v", i, err)
+				return
+			}
+			got[i] = actor.Email
+		}(i, email)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, want := range emails {
+		if got[i] != want {
+			t.Errorf("goroutine %d resolved %q, want %q", i, got[i], want)
+		}
 	}
 }
 

--- a/internal/mgmt/identity_test.go
+++ b/internal/mgmt/identity_test.go
@@ -226,14 +226,88 @@ func TestContextWithIdentity_PrefersContextOverGlobal(t *testing.T) {
 	}
 }
 
-// TestContextWithIdentity_EmptyIsNoop verifies that an empty email
-// leaves ctx untouched so callers don't accidentally clear a parent
-// identity by passing through.
-func TestContextWithIdentity_EmptyIsNoop(t *testing.T) {
-	parent := ContextWithIdentity(context.Background(), "parent@example.com")
-	child := ContextWithIdentity(parent, "")
-	if got := identityFromContext(child); got != "parent@example.com" {
-		t.Errorf("empty email must not clear parent identity, got %q", got)
+// TestContextWithIdentity_EmptyIsExplicitOptOut verifies that an empty
+// email is recorded as an explicit "no identity for this call" — not a
+// no-op pass-through. The multi-profile fan-out relies on this so a
+// profile with empty Identity falls back to git config rather than
+// inheriting the seeded global override (which carries the first
+// profile's email).
+func TestContextWithIdentity_EmptyIsExplicitOptOut(t *testing.T) {
+	ResetActorCache()
+	t.Cleanup(func() {
+		SetIdentityOverride("")
+		ResetActorCache()
+	})
+	SetIdentityOverride("global@example.com")
+
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	cmd = exec.Command("git", "config", "user.email", "git-config@example.com")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config: %v (%s)", err, out)
+	}
+
+	// ContextWithIdentity("") must skip both the per-call and global
+	// overrides and fall through to git config.
+	actor, err := CurrentGitActor(ContextWithIdentity(context.Background(), ""), dir)
+	if err != nil {
+		t.Fatalf("CurrentGitActor: %v", err)
+	}
+	if actor.Email != "git-config@example.com" {
+		t.Errorf("explicit-empty ctx must skip global override; got %s, want git-config@example.com", actor.Email)
+	}
+}
+
+// TestCurrentGitActor_MixedActiveSetFallsBackToGitConfig is the
+// regression for the fan-out hazard: when the active set mixes a
+// profile with an explicit Identity and one without, the
+// no-Identity profile must resolve against git config — not against
+// the seeded global override (which carries the first profile's
+// email). Simulates loadActiveLockFiles by setting the global
+// override and then resolving from a goroutine carrying
+// ContextWithIdentity("").
+func TestCurrentGitActor_MixedActiveSetFallsBackToGitConfig(t *testing.T) {
+	ResetActorCache()
+	t.Cleanup(func() {
+		SetIdentityOverride("")
+		ResetActorCache()
+	})
+	SetIdentityOverride("alice@work.com")
+
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "bob@personal.com"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	// Profile A: explicit Identity — should resolve to alice@work.com
+	actorA, err := CurrentGitActor(ContextWithIdentity(context.Background(), "alice@work.com"), dir)
+	if err != nil {
+		t.Fatalf("profile A: %v", err)
+	}
+	if actorA.Email != "alice@work.com" {
+		t.Errorf("profile A: got %s, want alice@work.com", actorA.Email)
+	}
+
+	// Profile B: empty Identity — must NOT inherit alice@work.com from
+	// the seeded global override; must fall through to git config.
+	actorB, err := CurrentGitActor(ContextWithIdentity(context.Background(), ""), dir)
+	if err != nil {
+		t.Fatalf("profile B: %v", err)
+	}
+	if actorB.Email != "bob@personal.com" {
+		t.Errorf("profile B: expected git-config fallback bob@personal.com, got %s", actorB.Email)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Active set replaces single active profile so `sx install` can pull from work + personal vaults at the same time
- Each profile carries its own identity email used for team/user scope resolution (defaults to `git config user.email`)
- Conflict policy: default profile wins silently; otherwise the first-active wins with a warning
- New subcommands `sx profile activate / deactivate / default / edit`; `sx profile use` keeps the exclusive-switch semantics

## Behavior

| Command | Behavior |
|---------|----------|
| `sx profile activate <name>` | adds to active set (additive) |
| `sx profile deactivate <name>` | removes from active set; cleanup happens on next `sx install` |
| `sx profile default <name>` | sets default; auto-activates if needed |
| `sx profile use <name>` | exclusive: makes `<name>` the only active profile (back-compat) |
| `sx install` | fetches every active profile's lock file in parallel, merges with conflict resolution, downloads per origin vault |
| `sx install --profile work,personal` | one-shot override of the active set for this run |

## Notes

- Process-global identity + audit profile tags are now mutex-guarded so concurrent vault HTTP/git work + background audit writes are race-free.
- Cross-profile dependency resolution is **not** supported in this PR (documented in `docs/profiles.md`); an asset in profile A cannot declare a dep on an asset only present in profile B.
- Legacy single-profile configs migrate automatically: `defaultProfile` becomes the sole entry in `activeProfiles`, and existing profiles fall back to `git config user.email` until the user sets `Identity` explicitly.

## Test plan

- [x] `make prepush` (format + lint + test + build)
- [x] `go test -race ./internal/mgmt/... ./internal/commands/...`
- [x] Conflict-policy unit tests (`TestMergeApplicableAssets_*`, `TestReportConflicts_*`)
- [x] Identity override unit test (`TestCurrentGitActorRespectsIdentityOverride`)
- [x] Multi-active config migration + helper tests (`internal/config/multi_active_test.go`)
- [x] Smoke test: `sx profile --help` lists the new subcommands and the binary builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)