### PR TITLE
SD-10168: Improve `sx team`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build-darwin-amd64: ## Build for macOS (amd64/Intel)
 	@GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 $(MAIN_PATH)
 	@echo "Built: $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64"
 
-install: build ## Install binary to ~/.local/bin
+install: gql-generate build ## Install binary to ~/.local/bin
 	@echo "Installing $(BINARY_NAME)..."
 	@mkdir -p $(HOME)/.local/bin
 	@rm -f $(HOME)/.local/bin/$(BINARY_NAME) && cp $(BUILD_DIR)/$(BINARY_NAME) $(HOME)/.local/bin/

--- a/internal/commands/stats.go
+++ b/internal/commands/stats.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sleuth-io/sx/internal/mgmt"
 	"github.com/sleuth-io/sx/internal/ui"
+	"github.com/sleuth-io/sx/internal/vault"
 )
 
 // NewStatsCommand creates the `sx stats` command.
@@ -61,12 +62,12 @@ Time range is controlled with --since (7d, 30d, 90d, or all). Default is 30d.`,
 				summary = &mgmt.UsageSummary{}
 			}
 
-			teams, err := v.ListTeams(ctx)
+			teamResult, err := v.ListTeams(ctx, vault.ListTeamsOptions{Limit: 300})
 			if err != nil {
 				return err
 			}
 
-			report := buildStatsReport(summary, teams, since, limit)
+			report := buildStatsReport(summary, teamResult.Teams, since, limit)
 
 			if jsonOutput {
 				return emitStatsJSON(cmd, report, assetsOnly, teamsOnly)

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -85,7 +85,12 @@ func newTeamCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a new team",
-		Args:  cobra.ExactArgs(1),
+		Long: `Create a new team in the active profile's vault.
+
+Every team must have at least one admin to manage it, so the caller is
+automatically added as both a member and an admin. Use --member / --admin
+to add others alongside yourself.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
@@ -109,7 +114,8 @@ func newTeamCreateCommand() *cobra.Command {
 			// vaults, the server enforces org-admin. We resolve the
 			// actor up-front to surface "set git user.email" errors
 			// early rather than deep inside the transaction.
-			if _, err := v.CurrentActor(ctx); err != nil {
+			actor, err := v.CurrentActor(ctx)
+			if err != nil {
 				return err
 			}
 
@@ -128,6 +134,12 @@ func newTeamCreateCommand() *cobra.Command {
 				return err
 			}
 			status.Done("Created team " + team.Name)
+
+			// CreateTeam always adds the caller as member+admin so every
+			// team has at least one admin. Surface this so the user isn't
+			// surprised by a roster they didn't explicitly request.
+			out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			out.Info(fmt.Sprintf("You (%s) were added as a member and admin — every team needs at least one admin.", actor.Email))
 			return nil
 		},
 	}

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -118,15 +119,21 @@ are added — you are not added automatically.`,
 			// vaults, the server enforces org-admin. We resolve the
 			// actor up-front to surface "set git user.email" errors
 			// early rather than deep inside the transaction.
-			actor, err := v.CurrentActor(ctx)
-			if err != nil {
+			if _, err := v.CurrentActor(ctx); err != nil {
 				return err
+			}
+
+			allMembers := append([]string(nil), members...)
+			for _, a := range admins {
+				if !slices.Contains(allMembers, a) {
+					allMembers = append(allMembers, a)
+				}
 			}
 
 			team := mgmt.Team{
 				Name:         args[0],
 				Description:  description,
-				Members:      members,
+				Members:      allMembers,
 				Admins:       admins,
 				Repositories: repos,
 			}
@@ -138,16 +145,6 @@ are added — you are not added automatically.`,
 				return err
 			}
 			status.Done("Created team " + team.Name)
-
-			// CreateTeam adds the caller as member+admin only when no other
-			// admin was supplied (every team needs ≥1 admin). When the
-			// caller named an admin we trust the delegation and stay out
-			// of the roster. Surface whichever branch ran so the user
-			// isn't guessing at the resulting roster.
-			out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
-			if len(admins) == 0 {
-				out.Info(fmt.Sprintf("You (%s) were added as a member and admin — every team needs at least one admin.", actor.Email))
-			}
 			return nil
 		},
 	}
@@ -395,7 +392,7 @@ func printTeamList(cmd *cobra.Command, result *vault.ListTeamsResult, filter str
 			} else if len(t.Admins) == 2 {
 				adminSummary = strings.Join(t.Admins[:2], ", ")
 			}
-			out.Muted(fmt.Sprintf("    admins: %s", adminSummary))
+			out.Muted("    admins: " + adminSummary)
 		}
 		if t.Description != "" {
 			out.Muted("    " + t.Description)

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -73,7 +74,10 @@ func newTeamShowCommand() *cobra.Command {
 			}
 			team, err := v.GetTeam(ctx, args[0])
 			if err != nil {
-				return fmt.Errorf("team %q not found", args[0])
+				if errors.Is(err, mgmt.ErrTeamNotFound) {
+					return fmt.Errorf("team %q not found", args[0])
+				}
+				return err
 			}
 			return printTeamDetails(cmd, team)
 		},
@@ -346,7 +350,10 @@ func requireTeamAdmin(ctx context.Context, v vault.Vault, teamName string) error
 	}
 	team, err := v.GetTeam(ctx, teamName)
 	if err != nil {
-		return fmt.Errorf("team %q not found", teamName)
+		if errors.Is(err, mgmt.ErrTeamNotFound) {
+			return fmt.Errorf("team %q not found", teamName)
+		}
+		return err
 	}
 	if !team.IsAdmin(actor.Email) {
 		return fmt.Errorf("you (%s) are not an admin of team %s — only admins can modify a team", actor.Email, teamName)

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -123,12 +123,17 @@ are added — you are not added automatically.`,
 			// vaults, the server enforces org-admin. We resolve the
 			// actor up-front to surface "set git user.email" errors
 			// early rather than deep inside the transaction.
-			if _, err := v.CurrentActor(ctx); err != nil {
+			actor, err := v.CurrentActor(ctx)
+			if err != nil {
 				return err
 			}
 
+			effectiveAdmins := admins
+			if len(effectiveAdmins) == 0 {
+				effectiveAdmins = []string{actor.Email}
+			}
 			allMembers := append([]string(nil), members...)
-			for _, a := range admins {
+			for _, a := range effectiveAdmins {
 				if !slices.Contains(allMembers, a) {
 					allMembers = append(allMembers, a)
 				}
@@ -138,7 +143,7 @@ are added — you are not added automatically.`,
 				Name:         args[0],
 				Description:  description,
 				Members:      allMembers,
-				Admins:       admins,
+				Admins:       effectiveAdmins,
 				Repositories: repos,
 			}
 

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -34,7 +34,8 @@ func NewTeamCommand() *cobra.Command {
 }
 
 func newTeamListCommand() *cobra.Command {
-	return &cobra.Command{
+	var filter string
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List teams",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -45,13 +46,15 @@ func newTeamListCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			teams, err := v.ListTeams(ctx)
+			result, err := v.ListTeams(ctx, vault.ListTeamsOptions{Filter: filter})
 			if err != nil {
 				return err
 			}
-			return printTeamList(cmd, teams)
+			return printTeamList(cmd, result, filter)
 		},
 	}
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter teams by name")
+	return cmd
 }
 
 func newTeamShowCommand() *cobra.Command {
@@ -69,7 +72,7 @@ func newTeamShowCommand() *cobra.Command {
 			}
 			team, err := v.GetTeam(ctx, args[0])
 			if err != nil {
-				return err
+				return fmt.Errorf("team %q not found", args[0])
 			}
 			return printTeamDetails(cmd, team)
 		},
@@ -87,9 +90,10 @@ func newTeamCreateCommand() *cobra.Command {
 		Short: "Create a new team",
 		Long: `Create a new team in the active profile's vault.
 
-Every team must have at least one admin to manage it, so the caller is
-automatically added as both a member and an admin. Use --member / --admin
-to add others alongside yourself.`,
+Every team must have at least one admin to manage it. If you do not name
+an admin via --admin, you are added as a member and admin so the team
+isn't born orphaned. If you do supply --admin, only your named admins
+are added — you are not added automatically.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -135,11 +139,15 @@ to add others alongside yourself.`,
 			}
 			status.Done("Created team " + team.Name)
 
-			// CreateTeam always adds the caller as member+admin so every
-			// team has at least one admin. Surface this so the user isn't
-			// surprised by a roster they didn't explicitly request.
+			// CreateTeam adds the caller as member+admin only when no other
+			// admin was supplied (every team needs ≥1 admin). When the
+			// caller named an admin we trust the delegation and stay out
+			// of the roster. Surface whichever branch ran so the user
+			// isn't guessing at the resulting roster.
 			out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
-			out.Info(fmt.Sprintf("You (%s) were added as a member and admin — every team needs at least one admin.", actor.Email))
+			if len(admins) == 0 {
+				out.Info(fmt.Sprintf("You (%s) were added as a member and admin — every team needs at least one admin.", actor.Email))
+			}
 			return nil
 		},
 	}
@@ -341,10 +349,10 @@ func requireTeamAdmin(ctx context.Context, v vault.Vault, teamName string) error
 	}
 	team, err := v.GetTeam(ctx, teamName)
 	if err != nil {
-		return err
+		return fmt.Errorf("team %q not found", teamName)
 	}
 	if !team.IsAdmin(actor.Email) {
-		return fmt.Errorf("%s is not an admin of team %s", actor.Email, teamName)
+		return fmt.Errorf("you (%s) are not an admin of team %s — only admins can modify a team", actor.Email, teamName)
 	}
 	return nil
 }
@@ -357,24 +365,48 @@ func loadVault() (vault.Vault, error) {
 	return v, err
 }
 
-func printTeamList(cmd *cobra.Command, teams []mgmt.Team) error {
+func printTeamList(cmd *cobra.Command, result *vault.ListTeamsResult, filter string) error {
 	out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
-	if len(teams) == 0 {
-		out.Muted("No teams defined yet. Create one with 'sx team create <name>'.")
+	if len(result.Teams) == 0 {
+		if filter != "" {
+			out.Muted(fmt.Sprintf("No teams matching %q.", filter))
+		} else {
+			out.Muted("No teams found. Create one with 'sx team create <name>'.")
+		}
 		return nil
 	}
 	out.Header("Teams")
 	out.Newline()
-	for _, t := range teams {
+	for _, t := range result.Teams {
+		memberCount := t.MemberCount
+		if memberCount == 0 {
+			memberCount = len(t.Members)
+		}
 		line := fmt.Sprintf("  %s %s",
 			out.BoldText(t.Name),
 			out.MutedText(fmt.Sprintf("%d members, %d repos",
-				len(t.Members), len(t.Repositories))),
+				memberCount, len(t.Repositories))),
 		)
 		out.Println(line)
+		if len(t.Admins) > 0 {
+			adminSummary := t.Admins[0]
+			if len(t.Admins) > 2 {
+				adminSummary = strings.Join(t.Admins[:2], ", ") + fmt.Sprintf(" +%d more", len(t.Admins)-2)
+			} else if len(t.Admins) == 2 {
+				adminSummary = strings.Join(t.Admins[:2], ", ")
+			}
+			out.Muted(fmt.Sprintf("    admins: %s", adminSummary))
+		}
 		if t.Description != "" {
 			out.Muted("    " + t.Description)
 		}
+	}
+	out.Newline()
+	if result.HasMore {
+		out.Muted(fmt.Sprintf("Showing %d of %d teams. Use --filter to narrow results.",
+			len(result.Teams), result.TotalCount))
+	} else {
+		out.Muted(fmt.Sprintf("%d teams total.", result.TotalCount))
 	}
 	out.Newline()
 	return nil
@@ -382,23 +414,25 @@ func printTeamList(cmd *cobra.Command, teams []mgmt.Team) error {
 
 func printTeamDetails(cmd *cobra.Command, team *mgmt.Team) error {
 	out := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
-	out.Newline()
-	out.Header(team.Name)
+	out.Bold("Team: " + team.Name)
 	if team.Description != "" {
 		out.Println(team.Description)
 	}
-	out.Newline()
 
-	if len(team.Members) > 0 {
-		out.Bold("Members")
-		for _, m := range team.Members {
-			marker := " "
-			if team.IsAdmin(m) {
-				marker = "*"
-			}
-			out.Println(fmt.Sprintf("  %s %s", marker, m))
+	memberCount := team.MemberCount
+	if memberCount == 0 {
+		memberCount = len(team.Members)
+	}
+	out.Bold(fmt.Sprintf("Members (%d)", memberCount))
+	for _, m := range team.Members {
+		marker := " "
+		if team.IsAdmin(m) {
+			marker = "*"
 		}
-		out.Newline()
+		out.Println(fmt.Sprintf("  %s %s", marker, m))
+	}
+	if memberCount > len(team.Members) {
+		out.Muted(fmt.Sprintf("  … and %d more", memberCount-len(team.Members)))
 	}
 
 	if len(team.Repositories) > 0 {
@@ -406,7 +440,6 @@ func printTeamDetails(cmd *cobra.Command, team *mgmt.Team) error {
 		for _, r := range team.Repositories {
 			out.ListItem("•", r)
 		}
-		out.Newline()
 	}
 
 	return nil

--- a/internal/mgmt/teams.go
+++ b/internal/mgmt/teams.go
@@ -35,6 +35,7 @@ type Team struct {
 	Members      []string `toml:"members,omitempty"`
 	Admins       []string `toml:"admins,omitempty"`
 	Repositories []string `toml:"repositories,omitempty"`
+	MemberCount  int      `toml:"-"` // total members (may exceed len(Members) when paginated)
 }
 
 // IsMember returns true if the given email is in the team's member list.

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -129,11 +129,11 @@ func (g *GitVault) CurrentActor(ctx context.Context) (mgmt.Actor, error) {
 	return mgmt.CurrentGitActor(ctx, g.repoPath)
 }
 
-func (g *GitVault) ListTeams(ctx context.Context) ([]mgmt.Team, error) {
+func (g *GitVault) ListTeams(ctx context.Context, opts ListTeamsOptions) (*ListTeamsResult, error) {
 	if err := g.cloneOrUpdate(ctx); err != nil {
 		return nil, err
 	}
-	return commonListTeams(g.repoPath)
+	return commonListTeams(g.repoPath, opts)
 }
 
 func (g *GitVault) GetTeam(ctx context.Context, name string) (*mgmt.Team, error) {

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -989,7 +989,21 @@ func (v *ListTeamsOrganizationOrganizationType) GetTeams() ListTeamsOrganization
 
 // ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection includes the requested fields of the GraphQL type TeamsConnection.
 type ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection struct {
-	Nodes []ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam `json:"nodes"`
+	// Total count of edges.
+	TotalCount int `json:"totalCount"`
+	// Pagination data for this connection.
+	PageInfo ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo    `json:"pageInfo"`
+	Nodes    []ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam `json:"nodes"`
+}
+
+// GetTotalCount returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection.TotalCount, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection) GetTotalCount() int {
+	return v.TotalCount
+}
+
+// GetPageInfo returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection) GetPageInfo() ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo {
+	return v.PageInfo
 }
 
 // GetNodes returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection.Nodes, and is useful for accessing the field via an interface.
@@ -1001,7 +1015,7 @@ func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnection) GetNodes() [
 type ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam struct {
 	Id                 string                                                                                                     `json:"id"`
 	Name               string                                                                                                     `json:"name"`
-	AdminMemberIds     []string                                                                                                   `json:"adminMemberIds"`
+	AdminMembers       []ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType             `json:"adminMembers"`
 	Members            ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnection                    `json:"members"`
 	SkillsRepositories []ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType `json:"skillsRepositories"`
 }
@@ -1016,9 +1030,9 @@ func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) Get
 	return v.Name
 }
 
-// GetAdminMemberIds returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam.AdminMemberIds, and is useful for accessing the field via an interface.
-func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) GetAdminMemberIds() []string {
-	return v.AdminMemberIds
+// GetAdminMembers returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam.AdminMembers, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) GetAdminMembers() []ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType {
+	return v.AdminMembers
 }
 
 // GetMembers returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam.Members, and is useful for accessing the field via an interface.
@@ -1031,9 +1045,32 @@ func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) Get
 	return v.SkillsRepositories
 }
 
+// ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType includes the requested fields of the GraphQL type SimpleUserType.
+type ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType struct {
+	Id    string `json:"id"`
+	Email string `json:"email"`
+}
+
+// GetId returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType.Id, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType) GetId() string {
+	return v.Id
+}
+
+// GetEmail returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType.Email, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamAdminMembersSimpleUserType) GetEmail() string {
+	return v.Email
+}
+
 // ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnection includes the requested fields of the GraphQL type UserConnection.
 type ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnection struct {
-	Nodes []ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnectionNodesUser `json:"nodes"`
+	// Total count of edges.
+	TotalCount int                                                                                                `json:"totalCount"`
+	Nodes      []ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnectionNodesUser `json:"nodes"`
+}
+
+// GetTotalCount returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnection.TotalCount, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnection) GetTotalCount() int {
+	return v.TotalCount
 }
 
 // GetNodes returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembersUserConnection.Nodes, and is useful for accessing the field via an interface.
@@ -1063,11 +1100,44 @@ func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamMembe
 // GraphQL type for team-repository configuration with optional mono_repo_config
 type ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType struct {
 	RepositoryId string `json:"repositoryId"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
 }
 
 // GetRepositoryId returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType.RepositoryId, and is useful for accessing the field via an interface.
 func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType) GetRepositoryId() string {
 	return v.RepositoryId
+}
+
+// GetOwner returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType.Owner, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType) GetOwner() string {
+	return v.Owner
+}
+
+// GetName returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType.Name, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeamSkillsRepositoriesSkillsRepositoryType) GetName() string {
+	return v.Name
+}
+
+// ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+type ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor *string `json:"endCursor"`
+}
+
+// GetHasNextPage returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// GetEndCursor returns ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionPageInfo) GetEndCursor() *string {
+	return v.EndCursor
 }
 
 // ListTeamsResponse is returned by ListTeams on success.
@@ -3213,11 +3283,19 @@ func (v *__InstallSkillToBotInput) GetSkillId() string { return v.SkillId }
 
 // __ListTeamsInput is used internally by genqlient
 type __ListTeamsInput struct {
-	First int `json:"first"`
+	First       int     `json:"first"`
+	Term        *string `json:"term"`
+	MemberFirst int     `json:"memberFirst"`
 }
 
 // GetFirst returns __ListTeamsInput.First, and is useful for accessing the field via an interface.
 func (v *__ListTeamsInput) GetFirst() int { return v.First }
+
+// GetTerm returns __ListTeamsInput.Term, and is useful for accessing the field via an interface.
+func (v *__ListTeamsInput) GetTerm() *string { return v.Term }
+
+// GetMemberFirst returns __ListTeamsInput.MemberFirst, and is useful for accessing the field via an interface.
+func (v *__ListTeamsInput) GetMemberFirst() int { return v.MemberFirst }
 
 // __RemoveAssetInstallationsInput is used internally by genqlient
 type __RemoveAssetInstallationsInput struct {
@@ -3849,14 +3927,23 @@ func ListBots(
 
 // The query executed by ListTeams.
 const ListTeams_Operation = `
-query ListTeams ($first: Int!) {
+query ListTeams ($first: Int!, $term: String, $memberFirst: Int!) {
 	organization {
-		teams(first: $first) {
+		teams(first: $first, term: $term, parent: {any:true}) {
+			totalCount
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
 			nodes {
 				id
 				name
-				adminMemberIds
-				members(first: $first) {
+				adminMembers {
+					id
+					email
+				}
+				members(first: $memberFirst) {
+					totalCount
 					nodes {
 						id
 						email
@@ -3864,6 +3951,8 @@ query ListTeams ($first: Int!) {
 				}
 				skillsRepositories {
 					repositoryId
+					owner
+					name
 				}
 			}
 		}
@@ -3875,12 +3964,16 @@ func ListTeams(
 	ctx_ context.Context,
 	client_ graphql.Client,
 	first int,
+	term *string,
+	memberFirst int,
 ) (data_ *ListTeamsResponse, err_ error) {
 	req_ := &graphql.Request{
 		OpName: "ListTeams",
 		Query:  ListTeams_Operation,
 		Variables: &__ListTeamsInput{
-			First: first,
+			First:       first,
+			Term:        term,
+			MemberFirst: memberFirst,
 		},
 	}
 

--- a/internal/vault/graphql/operations/list_teams.graphql
+++ b/internal/vault/graphql/operations/list_teams.graphql
@@ -1,11 +1,20 @@
-query ListTeams($first: Int!) {
+query ListTeams($first: Int!, $term: String, $memberFirst: Int!) {
   organization {
-    teams(first: $first) {
+    teams(first: $first, term: $term, parent: {any: true}) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
       nodes {
         id
         name
-        adminMemberIds
-        members(first: $first) {
+        adminMembers{
+          id
+          email
+        }
+        members(first: $memberFirst) {
+          totalCount
           nodes {
             id
             email
@@ -13,6 +22,8 @@ query ListTeams($first: Int!) {
         }
         skillsRepositories {
           repositoryId
+          owner
+          name
         }
       }
     }

--- a/internal/vault/graphql/schema.graphql
+++ b/internal/vault/graphql/schema.graphql
@@ -39,7 +39,7 @@ type Team {
     before: String
     after: String
   ): UserConnection!
-  adminMemberIds: [ID!]
+  adminMembers: [SimpleUserType!]
   integrationDescription: String
   hasSubteams: Boolean!
   skillsRepositories: [SkillsRepositoryType!]
@@ -2709,6 +2709,13 @@ enum NotificationProviderType {
 
   """Slack"""
   SLACK
+}
+
+type SimpleUserType {
+  id: ID!
+  email: String!
+  display: String!
+  gravatar: String!
 }
 
 """

--- a/internal/vault/graphql/schema.graphql
+++ b/internal/vault/graphql/schema.graphql
@@ -2716,6 +2716,8 @@ GraphQL type for team-repository configuration with optional mono_repo_config
 """
 type SkillsRepositoryType {
   repositoryId: String!
+  owner: String!
+  name: String!
   monoRepoConfigId: ID
 }
 
@@ -3305,6 +3307,10 @@ enum WSEventType {
   error
   discovery_asset_found
   discovery_completed
+  managed_import_candidate_found
+  managed_import_scan_completed
+  managed_import_item_completed
+  managed_import_run_completed
   asset_loading_status
 }
 
@@ -3546,6 +3552,46 @@ type AssetDiscoveryEntry {
   repoName: String!
   isNew: Boolean!
   sourceClient: String!
+}
+
+type ManagedImportScanStatus {
+  isRunning: Boolean!
+  isComplete: Boolean!
+  candidates: [ManagedImportCandidate!]!
+}
+
+type ManagedImportCandidate {
+  assetName: String!
+  assetType: String!
+  sourceClient: String!
+  repoId: ID!
+  repoName: String!
+  path: String!
+  content: String!
+  contentHash: String!
+  files: [ManagedImportCandidateFile!]!
+}
+
+type ManagedImportCandidateFile {
+  name: String!
+  path: String
+  content: String!
+}
+
+type ManagedImportRunStatus {
+  isRunning: Boolean!
+  isComplete: Boolean!
+  items: [ManagedImportRunItem!]!
+}
+
+type ManagedImportRunItem {
+  assetName: String!
+  assetType: String!
+
+  """pending | done | error"""
+  status: String!
+  assetGid: ID
+  error: String
 }
 
 """A tool available from an MCP integration."""
@@ -4046,7 +4092,7 @@ type InstalledAssetInstallStatus {
 
 """Installation location for an installed asset."""
 type InstalledAssetInstallation {
-  entityType: String!
+  entityType: VaultAssetInstallationEntityType!
   entityId: String
   entityName: String!
   entityProvider: String
@@ -4661,6 +4707,9 @@ type Query {
   ): SkillPullRequestConnection!
   skillDiscoveryStatus(repositoryGid: ID!): SkillDiscoveryStatus!
   assetDiscoveryStatus: AssetDiscoveryStatus!
+  managedImportScanStatus: ManagedImportScanStatus!
+  managedImportRunStatus: ManagedImportRunStatus!
+  aiAssetCleanupRoots: [String!]!
   skillVersionDiff(
     """Skill GID"""
     skillId: ID!
@@ -5530,6 +5579,26 @@ type Mutation {
 
   """Trigger a re-scan of all repositories for AI assets."""
   triggerAssetDiscovery: TriggerAssetDiscoveryMutation
+
+  """
+  Start a managed-import scan over the user-selected repositories.
+  
+  Resets prior scan state, queues one celery task per repo, and returns
+  immediately. Frontend reads progress from ``managedImportScanStatus`` and
+  listens to ``MANAGED_IMPORT_CANDIDATE_FOUND`` / ``MANAGED_IMPORT_SCAN_COMPLETED``
+  websocket events.
+  """
+  triggerManagedImportScan(repositoryIds: [ID!]!): TriggerManagedImportScanMutation
+
+  """
+  Kick off background import of confirmed candidates.
+  
+  Returns immediately. Frontend watches ``managedImportRunStatus`` (polling)
+  and ``MANAGED_IMPORT_ITEM_COMPLETED`` / ``MANAGED_IMPORT_RUN_COMPLETED``
+  WebSocket events for progress. The scan status in Redis is cleared so a
+  subsequent re-scan starts fresh.
+  """
+  confirmManagedImport(items: [ManagedImportItemInput!]!): ConfirmManagedImportMutation
   createMonoRepoConfig(input: CreateMonoRepoConfigInput!): CreateMonoRepoConfigMutation
   updateMonoRepoConfig(input: UpdateMonoRepoConfigInput!): UpdateMonoRepoConfigMutation
   deleteMonoRepoConfig(id: ID!): DeleteMonoRepoConfigMutation
@@ -6192,8 +6261,7 @@ input CreateAssetInput {
 }
 
 input AssetInstallationInput {
-  """organization, repository, team, user, or bot"""
-  entityType: String!
+  entityType: VaultAssetInstallationEntityType!
 
   """GID of the entity (null for organization-wide)"""
   entityId: ID
@@ -6289,9 +6357,7 @@ type UninstallAssetMutation {
 input UninstallAssetInput {
   """GID of the asset to uninstall from a target"""
   id: ID!
-
-  """Installation entity type (organization, repository, team, user, bot)"""
-  entityType: String!
+  entityType: VaultAssetInstallationEntityType!
 
   """GID of the entity (null for organization-wide installs)"""
   entityId: ID
@@ -6326,6 +6392,45 @@ type UpdateSuggestedSkillStatusMutation {
 type TriggerAssetDiscoveryMutation {
   success: Boolean!
   errors: [ErrorType!]!
+}
+
+"""
+Start a managed-import scan over the user-selected repositories.
+
+Resets prior scan state, queues one celery task per repo, and returns
+immediately. Frontend reads progress from ``managedImportScanStatus`` and
+listens to ``MANAGED_IMPORT_CANDIDATE_FOUND`` / ``MANAGED_IMPORT_SCAN_COMPLETED``
+websocket events.
+"""
+type TriggerManagedImportScanMutation {
+  success: Boolean!
+  errors: [ErrorType!]!
+}
+
+"""
+Kick off background import of confirmed candidates.
+
+Returns immediately. Frontend watches ``managedImportRunStatus`` (polling)
+and ``MANAGED_IMPORT_ITEM_COMPLETED`` / ``MANAGED_IMPORT_RUN_COMPLETED``
+WebSocket events for progress. The scan status in Redis is cleared so a
+subsequent re-scan starts fresh.
+"""
+type ConfirmManagedImportMutation {
+  success: Boolean!
+  errors: [ErrorType!]!
+}
+
+input ManagedImportItemInput {
+  name: String!
+  assetType: AssetType!
+  repositoryIds: [ID!]!
+  files: [ManagedImportFileInput!]!
+}
+
+input ManagedImportFileInput {
+  name: String!
+  path: String
+  content: String!
 }
 
 type CreateMonoRepoConfigMutation {

--- a/internal/vault/mgmt_e2e_test.go
+++ b/internal/vault/mgmt_e2e_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -69,15 +70,15 @@ func TestPathVault_TeamUserLifecycleE2E(t *testing.T) {
 	}
 
 	// 2. List teams and verify.
-	teams, err := v.ListTeams(ctx)
+	teamResult, err := v.ListTeams(ctx, ListTeamsOptions{})
 	if err != nil {
 		t.Fatalf("ListTeams failed: %v", err)
 	}
-	if len(teams) != 1 || teams[0].Name != "platform" {
-		t.Fatalf("expected 1 team 'platform', got %+v", teams)
+	if len(teamResult.Teams) != 1 || teamResult.Teams[0].Name != "platform" {
+		t.Fatalf("expected 1 team 'platform', got %+v", teamResult.Teams)
 	}
-	if len(teams[0].Members) != 2 {
-		t.Errorf("expected 2 members, got %d", len(teams[0].Members))
+	if len(teamResult.Teams[0].Members) != 2 {
+		t.Errorf("expected 2 members, got %d", len(teamResult.Teams[0].Members))
 	}
 
 	// 3. Add a second repository via AddTeamRepository.
@@ -194,12 +195,12 @@ func TestPathVault_TeamUserLifecycleE2E(t *testing.T) {
 	if err := v.DeleteTeam(ctx, "platform"); err != nil {
 		t.Fatalf("DeleteTeam failed: %v", err)
 	}
-	teams, err = v.ListTeams(ctx)
+	teamResult, err = v.ListTeams(ctx, ListTeamsOptions{})
 	if err != nil {
 		t.Fatalf("ListTeams after delete failed: %v", err)
 	}
-	if len(teams) != 0 {
-		t.Errorf("expected no teams, got %d", len(teams))
+	if len(teamResult.Teams) != 0 {
+		t.Errorf("expected no teams, got %d", len(teamResult.Teams))
 	}
 
 	m, _, err = manifest.LoadOrMigrate(dir)
@@ -604,7 +605,7 @@ type = "skill"
 	}
 
 	// Any read-side call triggers LoadOrMigrate.
-	if _, err := v.ListTeams(context.Background()); err != nil {
+	if _, err := v.ListTeams(context.Background(), ListTeamsOptions{}); err != nil {
 		t.Fatalf("ListTeams (triggers migration) failed: %v", err)
 	}
 
@@ -664,5 +665,99 @@ func runGit(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func newPathVaultWithTeams(t *testing.T, count int) (Vault, string) {
+	t.Helper()
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "alice@example.com")
+	runGit(t, dir, "config", "user.name", "Alice")
+
+	if err := manifest.Save(dir, &manifest.Manifest{SchemaVersion: manifest.CurrentSchemaVersion}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	ctx := context.Background()
+	for i := range count {
+		name := fmt.Sprintf("team-%d", i)
+		if err := v.CreateTeam(ctx, mgmt.Team{
+			Name:    name,
+			Members: []string{"alice@example.com"},
+			Admins:  []string{"alice@example.com"},
+		}); err != nil {
+			t.Fatalf("CreateTeam %s: %v", name, err)
+		}
+	}
+	return v, dir
+}
+
+func TestPathVault_ListTeams_DefaultLimit(t *testing.T) {
+	v, _ := newPathVaultWithTeams(t, 25)
+	ctx := context.Background()
+
+	result, err := v.ListTeams(ctx, ListTeamsOptions{})
+	if err != nil {
+		t.Fatalf("ListTeams: %v", err)
+	}
+	if len(result.Teams) != 20 {
+		t.Errorf("expected 20 teams, got %d", len(result.Teams))
+	}
+	if result.TotalCount != 25 {
+		t.Errorf("expected TotalCount=25, got %d", result.TotalCount)
+	}
+	if !result.HasMore {
+		t.Error("expected HasMore=true")
+	}
+}
+
+func TestPathVault_ListTeams_FilterClientSide(t *testing.T) {
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "alice@example.com")
+	runGit(t, dir, "config", "user.name", "Alice")
+
+	if err := manifest.Save(dir, &manifest.Manifest{SchemaVersion: manifest.CurrentSchemaVersion}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	ctx := context.Background()
+
+	for _, name := range []string{"platform-api", "platform-web", "infra", "data-eng"} {
+		if err := v.CreateTeam(ctx, mgmt.Team{
+			Name:    name,
+			Members: []string{"alice@example.com"},
+			Admins:  []string{"alice@example.com"},
+		}); err != nil {
+			t.Fatalf("CreateTeam %s: %v", name, err)
+		}
+	}
+
+	result, err := v.ListTeams(ctx, ListTeamsOptions{Filter: "platform"})
+	if err != nil {
+		t.Fatalf("ListTeams: %v", err)
+	}
+	if len(result.Teams) != 2 {
+		t.Errorf("expected 2 teams matching 'platform', got %d: %+v", len(result.Teams), result.Teams)
+	}
+	if result.TotalCount != 2 {
+		t.Errorf("expected TotalCount=2, got %d", result.TotalCount)
+	}
+	if result.HasMore {
+		t.Error("expected HasMore=false")
+	}
+	for _, team := range result.Teams {
+		if !strings.Contains(team.Name, "platform") {
+			t.Errorf("team %q does not match filter 'platform'", team.Name)
+		}
 	}
 }

--- a/internal/vault/mgmt_e2e_test.go
+++ b/internal/vault/mgmt_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -759,5 +760,77 @@ func TestPathVault_ListTeams_FilterClientSide(t *testing.T) {
 		if !strings.Contains(team.Name, "platform") {
 			t.Errorf("team %q does not match filter 'platform'", team.Name)
 		}
+	}
+}
+
+func TestPathVault_CreateTeam_NoAdminsDefaultsToCaller(t *testing.T) {
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "alice@example.com")
+	runGit(t, dir, "config", "user.name", "Alice")
+
+	if err := manifest.Save(dir, &manifest.Manifest{SchemaVersion: manifest.CurrentSchemaVersion}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := v.CreateTeam(ctx, mgmt.Team{
+		Name: "no-admins",
+	}); err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+
+	team, err := v.GetTeam(ctx, "no-admins")
+	if err != nil {
+		t.Fatalf("GetTeam: %v", err)
+	}
+	if !slices.Contains(team.Admins, "alice@example.com") {
+		t.Errorf("caller should be auto-added as admin, got admins=%v", team.Admins)
+	}
+	if !slices.Contains(team.Members, "alice@example.com") {
+		t.Errorf("caller should be auto-added as member, got members=%v", team.Members)
+	}
+}
+
+func TestPathVault_CreateTeam_ExplicitAdminNotCaller(t *testing.T) {
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "alice@example.com")
+	runGit(t, dir, "config", "user.name", "Alice")
+
+	if err := manifest.Save(dir, &manifest.Manifest{SchemaVersion: manifest.CurrentSchemaVersion}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := v.CreateTeam(ctx, mgmt.Team{
+		Name:   "explicit-admin",
+		Admins: []string{"bob@example.com"},
+	}); err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+
+	team, err := v.GetTeam(ctx, "explicit-admin")
+	if err != nil {
+		t.Fatalf("GetTeam: %v", err)
+	}
+	if !slices.Contains(team.Admins, "bob@example.com") {
+		t.Errorf("explicit admin should be set, got admins=%v", team.Admins)
+	}
+	if slices.Contains(team.Admins, "alice@example.com") {
+		t.Errorf("caller should not be auto-added as admin when explicit admins given, got admins=%v", team.Admins)
+	}
+	if !slices.Contains(team.Members, "bob@example.com") {
+		t.Errorf("admin should be auto-added as member, got members=%v", team.Members)
 	}
 }

--- a/internal/vault/mgmt_e2e_test.go
+++ b/internal/vault/mgmt_e2e_test.go
@@ -556,7 +556,7 @@ func TestPathVault_TeamMutationsRequireAdmin(t *testing.T) {
 			t.Errorf("%s: expected admin check to reject, got nil", label)
 			return
 		}
-		if !strings.Contains(err.Error(), "is not an admin of team") {
+		if !strings.Contains(err.Error(), "are not an admin of team") {
 			t.Errorf("%s: unexpected error: %v", label, err)
 		}
 	}

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -72,22 +72,40 @@ func requireTeamAdminInTx(m *manifest.Manifest, teamName string, actor mgmt.Acto
 		return nil, err
 	}
 	if !team.IsAdmin(actor.Email) {
-		return nil, fmt.Errorf("%s is not an admin of team %s", actor.Email, teamName)
+		return nil, fmt.Errorf("you (%s) are not an admin of team %s — only admins can modify a team", actor.Email, teamName)
 	}
 	return team, nil
 }
 
-// commonListTeams returns a copy of every team in the vault's manifest.
-func commonListTeams(vaultRoot string) ([]mgmt.Team, error) {
+const defaultListTeamsLimit = 20
+
+func commonListTeams(vaultRoot string, opts ListTeamsOptions) (*ListTeamsResult, error) {
 	m, err := loadManifest(vaultRoot)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]mgmt.Team, len(m.Teams))
-	for i, t := range m.Teams {
-		out[i] = manifestTeamToMgmt(t)
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultListTeamsLimit
 	}
-	return out, nil
+	var matched []mgmt.Team
+	for _, t := range m.Teams {
+		team := manifestTeamToMgmt(t)
+		if opts.Filter != "" && !strings.Contains(strings.ToLower(team.Name), strings.ToLower(opts.Filter)) {
+			continue
+		}
+		matched = append(matched, team)
+	}
+	total := len(matched)
+	hasMore := total > limit
+	if hasMore {
+		matched = matched[:limit]
+	}
+	return &ListTeamsResult{
+		Teams:      matched,
+		TotalCount: total,
+		HasMore:    hasMore,
+	}, nil
 }
 
 // commonGetTeam returns a single team by name.
@@ -104,20 +122,28 @@ func commonGetTeam(vaultRoot, name string) (*mgmt.Team, error) {
 	return &out, nil
 }
 
-// commonCreateTeam adds a new team. The caller is always added to both
-// Members and Admins so every team has at least one admin — prevents the
-// "delete all admins then take over" attack.
+// commonCreateTeam adds a new team. If the caller did not specify any
+// admins, they are added as both a member and an admin so the team isn't
+// born orphaned — the same "≥1 admin" invariant we enforce on member
+// removal. When the caller explicitly names another admin, we trust that
+// delegation and don't force the caller into the roster: they can always
+// remove themselves anyway via team member remove, so the auto-add was
+// just an extra step.
 func commonCreateTeam(vaultRoot string, actor mgmt.Actor, team mgmt.Team) error {
 	return withManifest(vaultRoot, actor, func(m *manifest.Manifest) (*mgmt.AuditEvent, error) {
 		if _, err := m.FindTeam(team.Name); err == nil {
 			return nil, fmt.Errorf("%w: %s", manifest.ErrTeamExists, team.Name)
 		}
 		mt := mgmtTeamToManifest(team)
-		if !slices.Contains(mt.Members, actor.Email) {
-			mt.Members = append(mt.Members, actor.Email)
-		}
-		if !slices.Contains(mt.Admins, actor.Email) {
+		if len(mt.Admins) == 0 {
 			mt.Admins = append(mt.Admins, actor.Email)
+		}
+		// Admins must be members — being admin of a team you don't belong
+		// to is nonsensical and breaks team member listings.
+		for _, a := range mt.Admins {
+			if !slices.Contains(mt.Members, a) {
+				mt.Members = append(mt.Members, a)
+			}
 		}
 		if _, err := m.UpsertTeam(mt); err != nil {
 			return nil, err
@@ -805,6 +831,7 @@ func manifestTeamToMgmt(t manifest.Team) mgmt.Team {
 		Name:         t.Name,
 		Description:  t.Description,
 		Members:      append([]string(nil), t.Members...),
+		MemberCount:  len(t.Members),
 		Admins:       append([]string(nil), t.Admins...),
 		Repositories: append([]string(nil), t.Repositories...),
 	}

--- a/internal/vault/pathrepo_mgmt.go
+++ b/internal/vault/pathrepo_mgmt.go
@@ -68,14 +68,14 @@ func (p *PathVault) CurrentActor(ctx context.Context) (mgmt.Actor, error) {
 	return mgmt.CurrentGitActor(ctx, p.repoPath)
 }
 
-func (p *PathVault) ListTeams(ctx context.Context) ([]mgmt.Team, error) {
-	var out []mgmt.Team
+func (p *PathVault) ListTeams(ctx context.Context, opts ListTeamsOptions) (*ListTeamsResult, error) {
+	var out *ListTeamsResult
 	err := p.withReadLock(ctx, func() error {
-		teams, err := commonListTeams(p.repoPath)
+		result, err := commonListTeams(p.repoPath, opts)
 		if err != nil {
 			return err
 		}
-		out = teams
+		out = result
 		return nil
 	})
 	return out, err

--- a/internal/vault/repository.go
+++ b/internal/vault/repository.go
@@ -117,7 +117,7 @@ type Vault interface {
 	CurrentActor(ctx context.Context) (mgmt.Actor, error)
 
 	// Team management
-	ListTeams(ctx context.Context) ([]mgmt.Team, error)
+	ListTeams(ctx context.Context, opts ListTeamsOptions) (*ListTeamsResult, error)
 	GetTeam(ctx context.Context, name string) (*mgmt.Team, error)
 	CreateTeam(ctx context.Context, team mgmt.Team) error
 	UpdateTeam(ctx context.Context, team mgmt.Team) error
@@ -263,6 +263,19 @@ type SourceHandler interface {
 }
 
 // ListAssetsOptions contains options for listing vault assets
+// ListTeamsOptions controls the ListTeams query.
+type ListTeamsOptions struct {
+	Filter string // Server-side term search (substring match on team name)
+	Limit  int    // Max teams to return (default 20)
+}
+
+// ListTeamsResult holds the paginated team list and total count.
+type ListTeamsResult struct {
+	Teams      []mgmt.Team
+	TotalCount int  // Total teams matching the filter (-1 if unknown)
+	HasMore    bool // True when more teams exist beyond Limit
+}
+
 type ListAssetsOptions struct {
 	Type   string // Filter by asset type (skill, mcp, etc.)
 	Search string // Search query for filtering assets

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -135,10 +135,17 @@ func (s *SleuthVault) CreateTeam(ctx context.Context, team mgmt.Team) error {
 	if err != nil {
 		return err
 	}
-	if resp.CreateTeam == nil {
-		return nil
+	if resp.CreateTeam != nil {
+		if err := gqlMutationErrors(resp.CreateTeam.Errors); err != nil {
+			return err
+		}
 	}
-	return gqlMutationErrors(resp.CreateTeam.Errors)
+	for _, admin := range team.Admins {
+		if err := s.SetTeamAdmin(ctx, team.Name, admin, true); err != nil {
+			return fmt.Errorf("failed to set admin %s: %w", admin, err)
+		}
+	}
+	return nil
 }
 
 func (s *SleuthVault) UpdateTeam(ctx context.Context, team mgmt.Team) error {

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -555,7 +555,7 @@ func (s *SleuthVault) resolveTeamGIDs(ctx context.Context, names []string) ([]st
 	for _, name := range names {
 		gid, ok := idsByName[name]
 		if !ok {
-			return nil, mgmt.ErrTeamNotFound
+			return nil, fmt.Errorf("%w: %s", mgmt.ErrTeamNotFound, name)
 		}
 		out = append(out, gid)
 	}

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -37,78 +37,86 @@ func (s *SleuthVault) CurrentActor(ctx context.Context) (mgmt.Actor, error) {
 	return mgmt.Actor{Email: mgmt.NormalizeEmail(resp.User.Email), Name: name}, nil
 }
 
-func (s *SleuthVault) ListTeams(ctx context.Context) ([]mgmt.Team, error) {
-	nodes, err := s.listTeamNodes(ctx)
+func (s *SleuthVault) ListTeams(ctx context.Context, opts ListTeamsOptions) (*ListTeamsResult, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultListTeamsLimit
+	}
+	var term *string
+	if opts.Filter != "" {
+		term = &opts.Filter
+	}
+	resp, err := vaultgql.ListTeams(ctx, s.gqlClient(), limit, term, sleuthMemberPageSize)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]mgmt.Team, 0, len(nodes))
-	for _, node := range nodes {
-		out = append(out, sleuthTeamToMgmt(node))
+	conn := resp.Organization.Teams
+	teams := make([]mgmt.Team, 0, len(conn.Nodes))
+	for _, n := range conn.Nodes {
+		teams = append(teams, sleuthTeamToMgmt(gqlTeamNodeToSleuthNode(n)))
 	}
-	return out, nil
+	return &ListTeamsResult{
+		Teams:      teams,
+		TotalCount: conn.TotalCount,
+		HasMore:    conn.PageInfo.HasNextPage,
+	}, nil
 }
 
-// sleuthTeamListPageSize caps the per-page team and per-team-member fetch
-// counts. Set high enough to cover every realistic org in a single call
-// (the Sleuth API's internal default is ~200, and the largest observed
-// deployments have well under 1000 teams). If a response saturates the
-// cap we emit a warning so we notice truncation before users do; we do
-// not silently paginate via cursor because the GraphQL schema does not
-// currently expose pageInfo for these connections and blindly paging
-// could infinite-loop against older server versions.
-const sleuthTeamListPageSize = 1000
+const sleuthMemberPageSize = 50
 
-// listTeamNodes fetches the raw team nodes (including GIDs) from the
-// server. ListTeams projects these to mgmt.Team; teamGIDByName scans for
-// a single row — keeping a single query text in one place.
+// listTeamNodes fetches raw team nodes for internal lookups (teamGIDByName,
+// resolveTeamGIDs). Uses a high limit since these need to search the full list.
 func (s *SleuthVault) listTeamNodes(ctx context.Context) ([]sleuthTeamNode, error) {
-	resp, err := vaultgql.ListTeams(ctx, s.gqlClient(), sleuthTeamListPageSize)
+	return s.listTeamNodesFiltered(ctx, nil, sleuthTeamLookupPageSize)
+}
+
+const sleuthTeamLookupPageSize = 300
+
+func (s *SleuthVault) listTeamNodesFiltered(ctx context.Context, term *string, first int) ([]sleuthTeamNode, error) {
+	resp, err := vaultgql.ListTeams(ctx, s.gqlClient(), first, term, sleuthMemberPageSize)
 	if err != nil {
 		return nil, err
 	}
 	gqlNodes := resp.Organization.Teams.Nodes
 	nodes := make([]sleuthTeamNode, len(gqlNodes))
 	for i, n := range gqlNodes {
-		node := sleuthTeamNode{
-			ID:             n.Id,
-			Name:           n.Name,
-			AdminMemberIDs: n.AdminMemberIds,
-		}
-		for _, m := range n.Members.Nodes {
-			node.Members = append(node.Members, sleuthTeamMember{ID: m.Id, Email: m.Email})
-		}
-		for _, r := range n.SkillsRepositories {
-			node.SkillsRepositories = append(node.SkillsRepositories, sleuthSkillsRepoRef{RepositoryID: r.RepositoryId})
-		}
-		nodes[i] = node
+		nodes[i] = gqlTeamNodeToSleuthNode(n)
 	}
-	if len(nodes) >= sleuthTeamListPageSize {
-		logger.Get().Warn("ListTeams result saturated page size; some teams may be truncated",
-			"page_size", sleuthTeamListPageSize,
-			"returned", len(nodes))
-	}
-	for _, node := range nodes {
-		if len(node.Members) >= sleuthTeamListPageSize {
-			logger.Get().Warn("team member list saturated page size; some members may be truncated",
-				"team", node.Name,
-				"page_size", sleuthTeamListPageSize,
-				"returned", len(node.Members))
-		}
+	if resp.Organization.Teams.PageInfo.HasNextPage {
+		logger.Get().Warn("ListTeams result has more pages; some teams may be missing",
+			"first", first,
+			"returned", len(nodes),
+			"totalCount", resp.Organization.Teams.TotalCount)
 	}
 	return nodes, nil
 }
 
+func gqlTeamNodeToSleuthNode(n vaultgql.ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) sleuthTeamNode {
+	node := sleuthTeamNode{
+		ID:          n.Id,
+		Name:        n.Name,
+		MemberCount: n.Members.TotalCount,
+	}
+	for _, a := range n.AdminMembers {
+		node.Admins = append(node.Admins, a.Email)
+	}
+	for _, m := range n.Members.Nodes {
+		node.Members = append(node.Members, sleuthTeamMember{ID: m.Id, Email: m.Email})
+	}
+	for _, r := range n.SkillsRepositories {
+		node.Repositories = append(node.Repositories, r.Owner+"/"+r.Name)
+	}
+	return node
+}
+
 func (s *SleuthVault) GetTeam(ctx context.Context, name string) (*mgmt.Team, error) {
-	// GraphQL's team() takes an ID, not a name, so we fetch the full list
-	// and filter. This is fine for typical orgs (tens of teams).
-	teams, err := s.ListTeams(ctx)
+	result, err := s.ListTeams(ctx, ListTeamsOptions{Filter: name, Limit: 300})
 	if err != nil {
 		return nil, err
 	}
-	for i := range teams {
-		if teams[i].Name == name {
-			t := teams[i]
+	for i := range result.Teams {
+		if result.Teams[i].Name == name {
+			t := result.Teams[i]
 			return &t, nil
 		}
 	}
@@ -540,7 +548,7 @@ func (s *SleuthVault) resolveTeamGIDs(ctx context.Context, names []string) ([]st
 	for _, name := range names {
 		gid, ok := idsByName[name]
 		if !ok {
-			return nil, fmt.Errorf("%w: %s", mgmt.ErrTeamNotFound, name)
+			return nil, mgmt.ErrTeamNotFound
 		}
 		out = append(out, gid)
 	}
@@ -969,21 +977,16 @@ type sleuthTeamMember struct {
 	Email string
 }
 
-type sleuthSkillsRepoRef struct {
-	RepositoryID string
-}
-
 // sleuthTeamNode is the in-memory shape used by listTeamNodes consumers
 // (ListTeams, GetTeam, teamGIDByName, etc.). Populated from the generated
-// ListTeams response — see listTeamNodes for the conversion. Field shape
-// no longer needs to mirror the GraphQL wire format since genqlient
-// handles unmarshaling.
+// ListTeams response — see listTeamNodes for the conversion.
 type sleuthTeamNode struct {
-	ID                 string
-	Name               string
-	AdminMemberIDs     []string
-	Members            []sleuthTeamMember
-	SkillsRepositories []sleuthSkillsRepoRef
+	ID           string
+	Name         string
+	Admins       []string // emails from adminMembers
+	Members      []sleuthTeamMember
+	MemberCount  int
+	Repositories []string // owner/name slugs
 }
 
 type sleuthMutationError struct {
@@ -992,22 +995,14 @@ type sleuthMutationError struct {
 }
 
 func sleuthTeamToMgmt(node sleuthTeamNode) mgmt.Team {
-	team := mgmt.Team{Name: node.Name}
+	team := mgmt.Team{Name: node.Name, MemberCount: node.MemberCount}
 	for _, m := range node.Members {
 		team.Members = append(team.Members, mgmt.NormalizeEmail(m.Email))
 	}
-	adminIDs := make(map[string]struct{}, len(node.AdminMemberIDs))
-	for _, id := range node.AdminMemberIDs {
-		adminIDs[id] = struct{}{}
+	for _, email := range node.Admins {
+		team.Admins = append(team.Admins, mgmt.NormalizeEmail(email))
 	}
-	for _, m := range node.Members {
-		if _, ok := adminIDs[m.ID]; ok {
-			team.Admins = append(team.Admins, mgmt.NormalizeEmail(m.Email))
-		}
-	}
-	for _, r := range node.SkillsRepositories {
-		team.Repositories = append(team.Repositories, r.RepositoryID)
-	}
+	team.Repositories = append(team.Repositories, node.Repositories...)
 	return team
 }
 

--- a/internal/vault/sleuth_test.go
+++ b/internal/vault/sleuth_test.go
@@ -74,8 +74,8 @@ func TestSleuthVault_ListTeams_QueryShape(t *testing.T) {
 					"teams": map[string]any{
 						"nodes": []any{
 							map[string]any{
-								"id":             "team-1",
-								"name":           "platform",
+								"id":   "team-1",
+								"name": "platform",
 								"adminMembers": []any{
 									map[string]any{"id": "u1", "email": "a@example.com"},
 								},
@@ -224,8 +224,8 @@ func makeTeamNodes(count int, prefix string) []any {
 	nodes := make([]any, count)
 	for i := range count {
 		nodes[i] = map[string]any{
-			"id":             fmt.Sprintf("team-%d", i),
-			"name":           fmt.Sprintf("%s-%d", prefix, i),
+			"id":                 fmt.Sprintf("team-%d", i),
+			"name":               fmt.Sprintf("%s-%d", prefix, i),
 			"adminMembers":       []any{},
 			"members":            map[string]any{"totalCount": 0, "nodes": []any{}},
 			"skillsRepositories": []any{},

--- a/internal/vault/sleuth_test.go
+++ b/internal/vault/sleuth_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -87,6 +88,11 @@ func TestSleuthVault_ListTeams_QueryShape(t *testing.T) {
 								},
 							},
 						},
+						"totalCount": 1,
+						"pageInfo": map[string]any{
+							"hasNextPage": false,
+							"endCursor":   nil,
+						},
 					},
 				},
 			}
@@ -94,12 +100,12 @@ func TestSleuthVault_ListTeams_QueryShape(t *testing.T) {
 	})
 
 	v := NewSleuthVault(srv.URL, "test-token")
-	teams, err := v.ListTeams(context.Background())
+	result, err := v.ListTeams(context.Background(), ListTeamsOptions{Limit: 100})
 	if err != nil {
 		t.Fatalf("ListTeams failed: %v", err)
 	}
-	if len(teams) != 1 || teams[0].Name != "platform" {
-		t.Fatalf("unexpected teams: %+v", teams)
+	if len(result.Teams) != 1 || result.Teams[0].Name != "platform" {
+		t.Fatalf("unexpected teams: %+v", result.Teams)
 	}
 	if len(*records) != 1 || (*records)[0].OperationName != "ListTeams" {
 		t.Fatalf("expected single ListTeams request, got: %+v", *records)
@@ -208,5 +214,99 @@ func TestSleuthVault_SetInstallations_OmitsEmptyVersion(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func makeTeamNodes(count int, prefix string) []any {
+	nodes := make([]any, count)
+	for i := range count {
+		nodes[i] = map[string]any{
+			"id":             fmt.Sprintf("team-%d", i),
+			"name":           fmt.Sprintf("%s-%d", prefix, i),
+			"adminMemberIds": []any{},
+			"members":        map[string]any{"nodes": []any{}},
+			"skillsRepositories": []any{},
+		}
+	}
+	return nodes
+}
+
+func TestSleuthVault_ListTeams_DefaultLimitAndTotalCount(t *testing.T) {
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"ListTeams": func(vars map[string]any) any {
+			first, _ := vars["first"].(float64)
+			if int(first) > 30 {
+				t.Errorf("expected first <= 30, got %v", first)
+			}
+			return map[string]any{
+				"organization": map[string]any{
+					"teams": map[string]any{
+						"nodes":      makeTeamNodes(20, "team"),
+						"totalCount": 55,
+						"pageInfo": map[string]any{
+							"hasNextPage": true,
+							"endCursor":   "cursor-20",
+						},
+					},
+				},
+			}
+		},
+	})
+
+	v := NewSleuthVault(srv.URL, "test-token")
+	result, err := v.ListTeams(context.Background(), ListTeamsOptions{})
+	if err != nil {
+		t.Fatalf("ListTeams failed: %v", err)
+	}
+	if len(result.Teams) != 20 {
+		t.Errorf("expected 20 teams, got %d", len(result.Teams))
+	}
+	if result.TotalCount != 55 {
+		t.Errorf("expected TotalCount=55, got %d", result.TotalCount)
+	}
+	if !result.HasMore {
+		t.Error("expected HasMore=true")
+	}
+}
+
+func TestSleuthVault_ListTeams_FilterPassesTerm(t *testing.T) {
+	srv, records := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"ListTeams": func(vars map[string]any) any {
+			term, _ := vars["term"].(string)
+			if term != "platform" {
+				t.Errorf("expected term=platform, got %q", term)
+			}
+			return map[string]any{
+				"organization": map[string]any{
+					"teams": map[string]any{
+						"nodes":      makeTeamNodes(2, "platform"),
+						"totalCount": 2,
+						"pageInfo": map[string]any{
+							"hasNextPage": false,
+							"endCursor":   nil,
+						},
+					},
+				},
+			}
+		},
+	})
+
+	v := NewSleuthVault(srv.URL, "test-token")
+	result, err := v.ListTeams(context.Background(), ListTeamsOptions{Filter: "platform"})
+	if err != nil {
+		t.Fatalf("ListTeams failed: %v", err)
+	}
+	if len(result.Teams) != 2 {
+		t.Errorf("expected 2 teams, got %d", len(result.Teams))
+	}
+	if result.TotalCount != 2 {
+		t.Errorf("expected TotalCount=2, got %d", result.TotalCount)
+	}
+	if result.HasMore {
+		t.Error("expected HasMore=false")
+	}
+	rec := (*records)[0]
+	if _, ok := rec.Variables["term"]; !ok {
+		t.Error("expected $term variable in request")
 	}
 }

--- a/internal/vault/sleuth_test.go
+++ b/internal/vault/sleuth_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/mgmt"
 )
 
 // mockSleuthGraphQL spins up a test server that dispatches on the
@@ -311,5 +312,132 @@ func TestSleuthVault_ListTeams_FilterPassesTerm(t *testing.T) {
 	rec := (*records)[0]
 	if _, ok := rec.Variables["term"]; !ok {
 		t.Error("expected $term variable in request")
+	}
+}
+
+func TestSleuthVault_CreateTeam_SetsAdminsAfterCreation(t *testing.T) {
+	srv, records := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"FindUser": func(vars map[string]any) any {
+			term := vars["term"].(string)
+			return map[string]any{
+				"organization": map[string]any{
+					"users": map[string]any{
+						"nodes": []any{
+							map[string]any{"id": "u-" + term, "email": term},
+						},
+					},
+				},
+			}
+		},
+		"CreateTeam": func(vars map[string]any) any {
+			return map[string]any{
+				"createTeam": map[string]any{
+					"team":   map[string]any{"id": "team-new", "name": "platform"},
+					"errors": []any{},
+				},
+			}
+		},
+		"ListTeams": func(vars map[string]any) any {
+			return map[string]any{
+				"organization": map[string]any{
+					"teams": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"id":                 "team-new",
+								"name":               "platform",
+								"adminMembers":       []any{},
+								"members":            map[string]any{"totalCount": 0, "nodes": []any{}},
+								"skillsRepositories": []any{},
+							},
+						},
+						"totalCount": 1,
+						"pageInfo":   map[string]any{"hasNextPage": false, "endCursor": nil},
+					},
+				},
+			}
+		},
+		"SetTeamAdmin": func(vars map[string]any) any {
+			return map[string]any{
+				"setTeamAdmin": map[string]any{
+					"team":   map[string]any{"id": "team-new"},
+					"errors": []any{},
+				},
+			}
+		},
+	})
+
+	v := NewSleuthVault(srv.URL, "test-token")
+	err := v.CreateTeam(context.Background(), mgmt.Team{
+		Name:    "platform",
+		Members: []string{"alice@example.com", "bob@example.com"},
+		Admins:  []string{"alice@example.com", "bob@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTeam failed: %v", err)
+	}
+
+	var ops []string
+	for _, r := range *records {
+		ops = append(ops, r.OperationName)
+	}
+	// Expect: FindUser(alice), FindUser(bob), CreateTeam, ListTeams(for teamGID), SetTeamAdmin(alice), ListTeams, SetTeamAdmin(bob)
+	createIdx := -1
+	setAdminCount := 0
+	for i, op := range ops {
+		if op == "CreateTeam" {
+			createIdx = i
+		}
+		if op == "SetTeamAdmin" {
+			setAdminCount++
+			if createIdx < 0 {
+				t.Fatal("SetTeamAdmin called before CreateTeam")
+			}
+		}
+	}
+	if createIdx < 0 {
+		t.Fatal("CreateTeam was never called")
+	}
+	if setAdminCount != 2 {
+		t.Errorf("expected 2 SetTeamAdmin calls, got %d; ops=%v", setAdminCount, ops)
+	}
+}
+
+func TestSleuthVault_CreateTeam_NoAdminsSkipsSetTeamAdmin(t *testing.T) {
+	srv, records := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"FindUser": func(vars map[string]any) any {
+			term := vars["term"].(string)
+			return map[string]any{
+				"organization": map[string]any{
+					"users": map[string]any{
+						"nodes": []any{
+							map[string]any{"id": "u-" + term, "email": term},
+						},
+					},
+				},
+			}
+		},
+		"CreateTeam": func(vars map[string]any) any {
+			return map[string]any{
+				"createTeam": map[string]any{
+					"team":   map[string]any{"id": "team-new", "name": "solo"},
+					"errors": []any{},
+				},
+			}
+		},
+	})
+
+	v := NewSleuthVault(srv.URL, "test-token")
+	err := v.CreateTeam(context.Background(), mgmt.Team{
+		Name:    "solo",
+		Members: []string{"alice@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTeam failed: %v", err)
+	}
+
+	for _, r := range *records {
+		if r.OperationName == "SetTeamAdmin" {
+			t.Fatal("SetTeamAdmin should not be called when no admins specified")
+		}
 	}
 }

--- a/internal/vault/sleuth_test.go
+++ b/internal/vault/sleuth_test.go
@@ -76,15 +76,18 @@ func TestSleuthVault_ListTeams_QueryShape(t *testing.T) {
 							map[string]any{
 								"id":             "team-1",
 								"name":           "platform",
-								"adminMemberIds": []any{"u1"},
+								"adminMembers": []any{
+									map[string]any{"id": "u1", "email": "a@example.com"},
+								},
 								"members": map[string]any{
+									"totalCount": 2,
 									"nodes": []any{
 										map[string]any{"id": "u1", "email": "a@example.com"},
 										map[string]any{"id": "u2", "email": "b@example.com"},
 									},
 								},
 								"skillsRepositories": []any{
-									map[string]any{"repositoryId": "repo-9"},
+									map[string]any{"repositoryId": "repo-9", "owner": "org", "name": "repo-9"},
 								},
 							},
 						},
@@ -223,8 +226,8 @@ func makeTeamNodes(count int, prefix string) []any {
 		nodes[i] = map[string]any{
 			"id":             fmt.Sprintf("team-%d", i),
 			"name":           fmt.Sprintf("%s-%d", prefix, i),
-			"adminMemberIds": []any{},
-			"members":        map[string]any{"nodes": []any{}},
+			"adminMembers":       []any{},
+			"members":            map[string]any{"totalCount": 0, "nodes": []any{}},
 			"skillsRepositories": []any{},
 		}
 	}


### PR DESCRIPTION
- [x] Merge GQL schema changes in Pulse


Explain the current author becomes team admin by default
<img width="1378" height="465" alt="Screenshot from 2026-05-21 15-49-10" src="https://github.com/user-attachments/assets/4a67398f-fc7f-45f5-89e1-2594996b4ddd" />

Teams list
<img width="474" height="396" alt="image" src="https://github.com/user-attachments/assets/c4fe654e-8d36-4de8-9cf8-10c5a77a5de5" />
<img width="444" height="206" alt="image" src="https://github.com/user-attachments/assets/bd88e5cd-9633-42e8-85db-59818f4e08f8" />
<img width="587" height="480" alt="image" src="https://github.com/user-attachments/assets/e601b2ea-9454-490b-a9a9-80f2646a6493" />

<img width="693" height="567" alt="image" src="https://github.com/user-attachments/assets/6e30a4cc-2f88-4414-90dc-05cb2778fe87" />


```
sx $ sx team list --profile dev
Teams

  A 5 members, 3 repos
    admins: mmm@sleuth.io, zzzz@sleuth.io +2 more
  B 0 members, 0 repos
  Backend 1 members, 0 repos
  C 0 members, 0 repos
  D 0 members, 0 repos
  E 0 members, 0 repos
  Engineering 0 members, 0 repos
  F 0 members, 0 repos
  Frontend 2 members, 0 repos
  G 0 members, 0 repos
  H 0 members, 0 repos
  I 0 members, 0 repos
  J 0 members, 0 repos
  K 0 members, 0 repos
  L 0 members, 0 repos
  M 0 members, 0 repos
  N 0 members, 0 repos
  new 0 members, 0 repos
  O 0 members, 0 repos
  P 0 members, 0 repos

Showing 20 of 32 teams. Use --filter to narrow results.

sx $ sx team show A --profile dev
Team: A
Members (5)
  * aaa@gmail.com
  * bbb@gmail.com
  * ....
Repositories
  • sleuth-io/as-oct
  • sleuth-ip/bitbucket-pr-reminder
  • sleuth-io/sx
```


<img width="436" height="83" alt="image" src="https://github.com/user-attachments/assets/6672acb7-778e-47b5-9688-440d818c9861" />

```
sx $ sx team member add frontend mmmmmm@sleuth.io --profile gh
✗ you (iiiiii@gmail.com) are not an admin of team frontend — only admins can modify a team
```

