### PR TITLE
SD-10156: Migrate more mutations

### DIFF
--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -547,33 +547,11 @@ var AllBotsBotStatusChoices = []BotsBotStatusChoices{
 
 // CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation includes the requested fields of the GraphQL type CreateBotApiKeyMutation.
 type CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation struct {
-	BotKey *string                                                                `json:"botKey"`
-	Errors []CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType `json:"errors"`
+	BotKey string `json:"botKey"`
 }
 
 // GetBotKey returns CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation.BotKey, and is useful for accessing the field via an interface.
-func (v *CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation) GetBotKey() *string { return v.BotKey }
-
-// GetErrors returns CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation.Errors, and is useful for accessing the field via an interface.
-func (v *CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation) GetErrors() []CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType {
-	return v.Errors
-}
-
-// CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType includes the requested fields of the GraphQL type ErrorType.
-type CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType struct {
-	Field    string   `json:"field"`
-	Messages []string `json:"messages"`
-}
-
-// GetField returns CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType.Field, and is useful for accessing the field via an interface.
-func (v *CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType) GetField() string {
-	return v.Field
-}
-
-// GetMessages returns CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType.Messages, and is useful for accessing the field via an interface.
-func (v *CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutationErrorsErrorType) GetMessages() []string {
-	return v.Messages
-}
+func (v *CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation) GetBotKey() string { return v.BotKey }
 
 // CreateBotApiKeyResponse is returned by CreateBotApiKey on success.
 type CreateBotApiKeyResponse struct {
@@ -587,9 +565,8 @@ func (v *CreateBotApiKeyResponse) GetCreateBotApiKey() *CreateBotApiKeyCreateBot
 
 // CreateBotCreateBotCreateBotMutation includes the requested fields of the GraphQL type CreateBotMutation.
 type CreateBotCreateBotCreateBotMutation struct {
-	Bot    *CreateBotCreateBotCreateBotMutationBotManagedBot    `json:"bot"`
-	BotKey *string                                              `json:"botKey"`
-	Errors []CreateBotCreateBotCreateBotMutationErrorsErrorType `json:"errors"`
+	Bot    *CreateBotCreateBotCreateBotMutationBotManagedBot `json:"bot"`
+	BotKey string                                            `json:"botKey"`
 }
 
 // GetBot returns CreateBotCreateBotCreateBotMutation.Bot, and is useful for accessing the field via an interface.
@@ -598,12 +575,7 @@ func (v *CreateBotCreateBotCreateBotMutation) GetBot() *CreateBotCreateBotCreate
 }
 
 // GetBotKey returns CreateBotCreateBotCreateBotMutation.BotKey, and is useful for accessing the field via an interface.
-func (v *CreateBotCreateBotCreateBotMutation) GetBotKey() *string { return v.BotKey }
-
-// GetErrors returns CreateBotCreateBotCreateBotMutation.Errors, and is useful for accessing the field via an interface.
-func (v *CreateBotCreateBotCreateBotMutation) GetErrors() []CreateBotCreateBotCreateBotMutationErrorsErrorType {
-	return v.Errors
-}
+func (v *CreateBotCreateBotCreateBotMutation) GetBotKey() string { return v.BotKey }
 
 // CreateBotCreateBotCreateBotMutationBotManagedBot includes the requested fields of the GraphQL type ManagedBot.
 type CreateBotCreateBotCreateBotMutationBotManagedBot struct {
@@ -620,20 +592,6 @@ func (v *CreateBotCreateBotCreateBotMutationBotManagedBot) GetName() string { re
 
 // GetSlug returns CreateBotCreateBotCreateBotMutationBotManagedBot.Slug, and is useful for accessing the field via an interface.
 func (v *CreateBotCreateBotCreateBotMutationBotManagedBot) GetSlug() string { return v.Slug }
-
-// CreateBotCreateBotCreateBotMutationErrorsErrorType includes the requested fields of the GraphQL type ErrorType.
-type CreateBotCreateBotCreateBotMutationErrorsErrorType struct {
-	Field    string   `json:"field"`
-	Messages []string `json:"messages"`
-}
-
-// GetField returns CreateBotCreateBotCreateBotMutationErrorsErrorType.Field, and is useful for accessing the field via an interface.
-func (v *CreateBotCreateBotCreateBotMutationErrorsErrorType) GetField() string { return v.Field }
-
-// GetMessages returns CreateBotCreateBotCreateBotMutationErrorsErrorType.Messages, and is useful for accessing the field via an interface.
-func (v *CreateBotCreateBotCreateBotMutationErrorsErrorType) GetMessages() []string {
-	return v.Messages
-}
 
 type CreateBotInput struct {
 	Name        string   `json:"name"`
@@ -2041,10 +1999,6 @@ mutation CreateBot ($input: CreateBotInput!) {
 			slug
 		}
 		botKey
-		errors {
-			field
-			messages
-		}
 	}
 }
 `
@@ -2079,10 +2033,6 @@ const CreateBotApiKey_Operation = `
 mutation CreateBotApiKey ($botId: ID!, $label: String) {
 	createBotApiKey(botId: $botId, label: $label) {
 		botKey
-		errors {
-			field
-			messages
-		}
 	}
 }
 `

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -533,18 +533,6 @@ type BotInstalledResponse struct {
 // GetBot returns BotInstalledResponse.Bot, and is useful for accessing the field via an interface.
 func (v *BotInstalledResponse) GetBot() BotInstalledBotManagedBot { return v.Bot }
 
-// An enumeration.
-type BotsBotStatusChoices string
-
-const (
-	// Active
-	BotsBotStatusChoicesActive BotsBotStatusChoices = "ACTIVE"
-)
-
-var AllBotsBotStatusChoices = []BotsBotStatusChoices{
-	BotsBotStatusChoicesActive,
-}
-
 // CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation includes the requested fields of the GraphQL type CreateBotApiKeyMutation.
 type CreateBotApiKeyCreateBotApiKeyCreateBotApiKeyMutation struct {
 	BotKey string `json:"botKey"`
@@ -876,7 +864,6 @@ type ListBotsBotsManagedBot struct {
 	Name        string                            `json:"name"`
 	Slug        string                            `json:"slug"`
 	Description string                            `json:"description"`
-	Status      BotsBotStatusChoices              `json:"status"`
 	Teams       []ListBotsBotsManagedBotTeamsTeam `json:"teams"`
 }
 
@@ -891,9 +878,6 @@ func (v *ListBotsBotsManagedBot) GetSlug() string { return v.Slug }
 
 // GetDescription returns ListBotsBotsManagedBot.Description, and is useful for accessing the field via an interface.
 func (v *ListBotsBotsManagedBot) GetDescription() string { return v.Description }
-
-// GetStatus returns ListBotsBotsManagedBot.Status, and is useful for accessing the field via an interface.
-func (v *ListBotsBotsManagedBot) GetStatus() BotsBotStatusChoices { return v.Status }
 
 // GetTeams returns ListBotsBotsManagedBot.Teams, and is useful for accessing the field via an interface.
 func (v *ListBotsBotsManagedBot) GetTeams() []ListBotsBotsManagedBotTeamsTeam { return v.Teams }
@@ -2299,7 +2283,6 @@ query ListBots {
 		name
 		slug
 		description
-		status
 		teams {
 			id
 			name

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -1709,15 +1709,15 @@ func (v *__BotInstalledInput) GetSlug() string { return v.Slug }
 
 // __CreateBotApiKeyInput is used internally by genqlient
 type __CreateBotApiKeyInput struct {
-	BotId string  `json:"botId"`
-	Label *string `json:"label"`
+	BotId string `json:"botId"`
+	Label string `json:"label"`
 }
 
 // GetBotId returns __CreateBotApiKeyInput.BotId, and is useful for accessing the field via an interface.
 func (v *__CreateBotApiKeyInput) GetBotId() string { return v.BotId }
 
 // GetLabel returns __CreateBotApiKeyInput.Label, and is useful for accessing the field via an interface.
-func (v *__CreateBotApiKeyInput) GetLabel() *string { return v.Label }
+func (v *__CreateBotApiKeyInput) GetLabel() string { return v.Label }
 
 // __CreateBotInput is used internally by genqlient
 type __CreateBotInput struct {
@@ -2030,7 +2030,7 @@ func CreateBot(
 
 // The mutation executed by CreateBotApiKey.
 const CreateBotApiKey_Operation = `
-mutation CreateBotApiKey ($botId: ID!, $label: String) {
+mutation CreateBotApiKey ($botId: ID!, $label: String!) {
 	createBotApiKey(botId: $botId, label: $label) {
 		botKey
 	}
@@ -2041,7 +2041,7 @@ func CreateBotApiKey(
 	ctx_ context.Context,
 	client_ graphql.Client,
 	botId string,
-	label *string,
+	label string,
 ) (data_ *CreateBotApiKeyResponse, err_ error) {
 	req_ := &graphql.Request{
 		OpName: "CreateBotApiKey",

--- a/internal/vault/graphql/genqlient.yaml
+++ b/internal/vault/graphql/genqlient.yaml
@@ -1,6 +1,6 @@
 # For full documentation see:
 # https://github.com/Khan/genqlient/blob/main/docs/genqlient.yaml
-schema: schema_2026_05_22.graphql
+schema: schema.graphql
 operations:
   - "operations/*.graphql"
 generated: generated.go

--- a/internal/vault/graphql/operations/create_bot.graphql
+++ b/internal/vault/graphql/operations/create_bot.graphql
@@ -6,9 +6,5 @@ mutation CreateBot($input: CreateBotInput!) {
       slug
     }
     botKey
-    errors {
-      field
-      messages
-    }
   }
 }

--- a/internal/vault/graphql/operations/create_bot_api_key.graphql
+++ b/internal/vault/graphql/operations/create_bot_api_key.graphql
@@ -1,9 +1,5 @@
 mutation CreateBotApiKey($botId: ID!, $label: String) {
   createBotApiKey(botId: $botId, label: $label) {
     botKey
-    errors {
-      field
-      messages
-    }
   }
 }

--- a/internal/vault/graphql/operations/create_bot_api_key.graphql
+++ b/internal/vault/graphql/operations/create_bot_api_key.graphql
@@ -1,4 +1,4 @@
-mutation CreateBotApiKey($botId: ID!, $label: String) {
+mutation CreateBotApiKey($botId: ID!, $label: String!) {
   createBotApiKey(botId: $botId, label: $label) {
     botKey
   }

--- a/internal/vault/graphql/operations/list_bots.graphql
+++ b/internal/vault/graphql/operations/list_bots.graphql
@@ -4,7 +4,6 @@ query ListBots {
     name
     slug
     description
-    status
     teams {
       id
       name

--- a/internal/vault/graphql/schema.graphql
+++ b/internal/vault/graphql/schema.graphql
@@ -5197,13 +5197,7 @@ type Mutation {
 
 type CreateBotMutation {
   bot: ManagedBot
-  botKey: String
-  errors: [ErrorType!]!
-}
-
-type ErrorType {
-  field: String!
-  messages: [String!]!
+  botKey: String!
 }
 
 input CreateBotInput {
@@ -5215,6 +5209,11 @@ input CreateBotInput {
 type UpdateBotMutation {
   bot: ManagedBot
   errors: [ErrorType!]!
+}
+
+type ErrorType {
+  field: String!
+  messages: [String!]!
 }
 
 input UpdateBotInput {
@@ -5230,8 +5229,7 @@ type DeleteBotMutation {
 }
 
 type CreateBotApiKeyMutation {
-  botKey: String
-  errors: [ErrorType!]!
+  botKey: String!
 }
 
 type DeleteBotApiKeyMutation {

--- a/internal/vault/graphql/schema.graphql
+++ b/internal/vault/graphql/schema.graphql
@@ -5,10 +5,10 @@ type ManagedBot {
   description: String!
   status: BotsBotStatusChoices!
   id: ID!
-  teams: [Team!]
-  teamMemberships: [BotTeamMembership!]
-  installedSkills: [BotInstalledSkill!]
-  apiKeys: [BotApiKey!]
+  teams: [Team!]!
+  teamMemberships: [BotTeamMembership!]!
+  installedSkills: [BotInstalledSkill!]!
+  apiKeys: [BotApiKey!]!
 }
 
 """
@@ -275,7 +275,7 @@ type OrganizationType implements TeamOrUsersScoped {
 
   """EXPERIMENTAL FIELD, can change at any time."""
   workingHours: WorkingHoursType
-  bots: [ManagedBot!]
+  bots: [ManagedBot!]!
   llmFeaturesEnabled: Boolean!
   repositories(provider: IntegrationProvider, term: String, alwaysIncludeIds: [ID!], before: String, after: String, first: Int, last: Int): RepositoryConnection!
   developerSalaries: [DeveloperSalaryType!]!
@@ -4223,7 +4223,7 @@ enum ChangeRequestStatusEnum {
 }
 
 type Query {
-  bots: [ManagedBot!]
+  bots: [ManagedBot!]!
   bot(slug: String, id: ID): ManagedBot!
   managementSession: ManagementSession!
   myAssetCapabilities: MyAssetCapabilities!

--- a/internal/vault/graphql/schema.graphql
+++ b/internal/vault/graphql/schema.graphql
@@ -4901,7 +4901,7 @@ type Mutation {
   createBot(input: CreateBotInput!): CreateBotMutation
   updateBot(input: UpdateBotInput!): UpdateBotMutation
   deleteBot(id: ID!): DeleteBotMutation
-  createBotApiKey(botId: ID!, label: String): CreateBotApiKeyMutation
+  createBotApiKey(botId: ID!, label: String!): CreateBotApiKeyMutation
   deleteBotApiKey(keyId: ID!): DeleteBotApiKeyMutation
   installSkillToBot(botId: ID!, skillId: ID!): InstallSkillToBotMutation
   uninstallSkillFromBot(botId: ID!, skillId: ID!): UninstallSkillFromBotMutation

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -435,47 +435,27 @@ func (s *SleuthVault) CreateBot(ctx context.Context, bot mgmt.Bot) (string, erro
 	if err != nil {
 		return "", err
 	}
-	mutation := `mutation CreateBot($input: CreateBotInput!) {
-		createBot(input: $input) {
-			bot { id name slug }
-			botKey
-			errors { field messages }
-		}
-	}`
-	input := map[string]any{"name": bot.Name}
+	input := vaultgql.CreateBotInput{Name: bot.Name}
 	if bot.Description != "" {
-		input["description"] = bot.Description
+		input.Description = &bot.Description
 	}
 	if len(teamIDs) > 0 {
-		input["teamIds"] = teamIDs
+		input.TeamIds = teamIDs
 	}
-	vars := map[string]any{"input": input}
 	// createBot auto-issues a default API key on the server and returns
 	// the raw token under `botKey` (only available on this single
 	// response — there is no follow-up API to fetch it again). Capture
 	// it so the CLI can print it once; otherwise the auto-issued key
 	// would be wasted and the user would have to immediately call
 	// `sx bot key create` to get a usable token.
-	var resp struct {
-		Data struct {
-			CreateBot struct {
-				Bot    *sleuthBotNode        `json:"bot"`
-				BotKey string                `json:"botKey"`
-				Errors []sleuthMutationError `json:"errors"`
-			} `json:"createBot"`
-		} `json:"data"`
-		Errors []sleuthGraphQLError `json:"errors"`
-	}
-	if err := s.executeGraphQLQuery(ctx, mutation, vars, &resp); err != nil {
+	resp, err := vaultgql.CreateBot(ctx, s.gqlClient(), input)
+	if err != nil {
 		return "", err
 	}
-	if err := sleuthErrorsToErr(resp.Errors); err != nil {
-		return "", err
+	if resp.CreateBot == nil {
+		return "", errors.New("missing createBot payload in response")
 	}
-	if err := sleuthMutationErrorsToErr(resp.Data.CreateBot.Errors); err != nil {
-		return "", err
-	}
-	return resp.Data.CreateBot.BotKey, nil
+	return resp.CreateBot.BotKey, nil
 }
 
 func (s *SleuthVault) UpdateBot(ctx context.Context, bot mgmt.Bot) error {

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -568,32 +568,16 @@ func (s *SleuthVault) resolveTeamGIDs(ctx context.Context, names []string) ([]st
 // assets search. Used for installSkillToBot/uninstallSkillFromBot, which
 // take skill GIDs rather than slugs.
 func (s *SleuthVault) assetGIDByName(ctx context.Context, name string) (string, error) {
-	query := `query AssetGID($search: String!) {
-		vault { assets(search: $search, first: 25) { nodes { id name } } }
-	}`
-	vars := map[string]any{"search": name}
-	var resp struct {
-		Data struct {
-			Vault struct {
-				Assets struct {
-					Nodes []struct {
-						ID   string `json:"id"`
-						Name string `json:"name"`
-					} `json:"nodes"`
-				} `json:"assets"`
-			} `json:"vault"`
-		} `json:"data"`
-		Errors []sleuthGraphQLError `json:"errors"`
-	}
-	if err := s.executeGraphQLQuery(ctx, query, vars, &resp); err != nil {
+	resp, err := vaultgql.AssetGID(ctx, s.gqlClient(), name)
+	if err != nil {
 		return "", err
 	}
-	if err := sleuthErrorsToErr(resp.Errors); err != nil {
-		return "", err
-	}
-	for _, n := range resp.Data.Vault.Assets.Nodes {
-		if n.Name == name {
-			return n.ID, nil
+	// VaultAsset is a GraphQL interface with concrete subtypes
+	// (Skill, MCP, Agent, ClaudeCodePlugin, ...). Use the interface
+	// getters to avoid switching on every variant.
+	for _, n := range resp.Vault.Assets.Nodes {
+		if n.GetName() == name {
+			return n.GetId(), nil
 		}
 	}
 	return "", fmt.Errorf("asset %q not found", name)

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -763,36 +763,18 @@ func (s *SleuthVault) CreateBotApiKey(ctx context.Context, botName, label string
 	if err != nil {
 		return "", mgmt.BotApiKey{}, err
 	}
-	mutation := `mutation CreateBotApiKey($botId: ID!, $label: String) {
-		createBotApiKey(botId: $botId, label: $label) {
-			botKey
-			errors { field messages }
-		}
-	}`
-	vars := map[string]any{"botId": gid, "label": label}
-	var resp struct {
-		Data struct {
-			CreateBotApiKey struct {
-				BotKey string                `json:"botKey"`
-				Errors []sleuthMutationError `json:"errors"`
-			} `json:"createBotApiKey"`
-		} `json:"data"`
-		Errors []sleuthGraphQLError `json:"errors"`
-	}
-	if err := s.executeGraphQLQuery(ctx, mutation, vars, &resp); err != nil {
+	resp, err := vaultgql.CreateBotApiKey(ctx, s.gqlClient(), gid, label)
+	if err != nil {
 		return "", mgmt.BotApiKey{}, err
 	}
-	if err := sleuthErrorsToErr(resp.Errors); err != nil {
-		return "", mgmt.BotApiKey{}, err
-	}
-	if err := sleuthMutationErrorsToErr(resp.Data.CreateBotApiKey.Errors); err != nil {
-		return "", mgmt.BotApiKey{}, err
+	if resp.CreateBotApiKey == nil {
+		return "", mgmt.BotApiKey{}, errors.New("missing createBotApiKey payload in response")
 	}
 	// The GraphQL response omits the per-key metadata (id/maskedToken/
 	// createdAt) since the raw token is the only useful payload at
 	// creation time. Callers that need to display the masked form should
 	// follow up with ListBotApiKeys.
-	return resp.Data.CreateBotApiKey.BotKey, mgmt.BotApiKey{Label: label}, nil
+	return resp.CreateBotApiKey.BotKey, mgmt.BotApiKey{Label: label}, nil
 }
 
 func (s *SleuthVault) ListBotApiKeys(ctx context.Context, botName string) ([]mgmt.BotApiKey, error) {

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -297,33 +297,25 @@ func (s *SleuthVault) SetAssetInstallation(ctx context.Context, assetName string
 
 // ---- Bot management (via the existing skills.new GraphQL surface) ----
 
+// sleuthBotNode is the in-memory shape used by listBotNodes consumers
+// (ListBots, GetBot, botGIDByName, botSlugByName, botsWithAssetInstalled).
+// Populated from the generated ListBots response — see listBotNodes for
+// the conversion. Only the fields actually read by callers are kept;
+// status and apiKeys were dead fields under the old hand-rolled struct.
 type sleuthBotNode struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Slug        string `json:"slug"`
-	Description string `json:"description"`
-	Status      string `json:"status"`
-	Teams       []struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	} `json:"teams"`
-	APIKeys []struct {
-		ID          string    `json:"id"`
-		Label       string    `json:"label"`
-		MaskedToken string    `json:"maskedToken"`
-		CreatedAt   time.Time `json:"createdAt"`
-	} `json:"apiKeys"`
+	ID          string
+	Name        string
+	Slug        string
+	Description string
+	Teams       []string // team names
 }
 
 func sleuthBotToMgmt(node sleuthBotNode) mgmt.Bot {
-	bot := mgmt.Bot{
+	return mgmt.Bot{
 		Name:        node.Name,
 		Description: node.Description,
+		Teams:       node.Teams,
 	}
-	for _, t := range node.Teams {
-		bot.Teams = append(bot.Teams, t.Name)
-	}
-	return bot
 }
 
 // sleuthBotListSoftCap is the count at which we warn about possible
@@ -339,34 +331,30 @@ const sleuthBotListSoftCap = 1000
 // projects these to mgmt.Bot; helpers like botGIDByName scan for a
 // single row.
 func (s *SleuthVault) listBotNodes(ctx context.Context) ([]sleuthBotNode, error) {
-	query := `query ListBots {
-		bots {
-			id
-			name
-			slug
-			description
-			status
-			teams { id name }
+	resp, err := vaultgql.ListBots(ctx, s.gqlClient())
+	if err != nil {
+		return nil, err
+	}
+	nodes := make([]sleuthBotNode, len(resp.Bots))
+	for i, b := range resp.Bots {
+		teams := make([]string, len(b.Teams))
+		for j, t := range b.Teams {
+			teams[j] = t.Name
 		}
-	}`
-	var resp struct {
-		Data struct {
-			Bots []sleuthBotNode `json:"bots"`
-		} `json:"data"`
-		Errors []sleuthGraphQLError `json:"errors"`
+		nodes[i] = sleuthBotNode{
+			ID:          b.Id,
+			Name:        b.Name,
+			Slug:        b.Slug,
+			Description: b.Description,
+			Teams:       teams,
+		}
 	}
-	if err := s.executeGraphQLQuery(ctx, query, nil, &resp); err != nil {
-		return nil, err
-	}
-	if err := sleuthErrorsToErr(resp.Errors); err != nil {
-		return nil, err
-	}
-	if len(resp.Data.Bots) >= sleuthBotListSoftCap {
+	if len(nodes) >= sleuthBotListSoftCap {
 		logger.Get().Warn("ListBots result reached the soft cap; some bots may be truncated by an undeclared server-side limit",
 			"soft_cap", sleuthBotListSoftCap,
-			"returned", len(resp.Data.Bots))
+			"returned", len(nodes))
 	}
-	return resp.Data.Bots, nil
+	return nodes, nil
 }
 
 func (s *SleuthVault) ListBots(ctx context.Context) ([]mgmt.Bot, error) {


### PR DESCRIPTION
Copy of #137 because that PR didn't get its target branch changed to `main`. This should have happened automatically, when its original branch got merged into `main`, but it didn't happen... so when I clicked merge, this PR went into the old, dead branch.