### PR TITLE
SD-10171: Track install profile per asset

### DIFF
--- a/internal/assets/tracker.go
+++ b/internal/assets/tracker.go
@@ -29,6 +29,7 @@ type InstalledAsset struct {
 	Type       string            `json:"type,omitempty"`       // Asset type (skill, agent, mcp, etc) - added in v3
 	Repository string            `json:"repository,omitempty"` // Empty for global scope
 	Path       string            `json:"path,omitempty"`       // Path within repo (if path-scoped)
+	Profile    string            `json:"profile,omitempty"`    // Profile that installed it; empty means default
 	Clients    []string          `json:"clients"`
 	Config     map[string]string `json:"config,omitempty"` // Type-specific config (e.g., marketplace for plugins)
 }

--- a/internal/assets/tracker_profile_test.go
+++ b/internal/assets/tracker_profile_test.go
@@ -1,0 +1,72 @@
+package assets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// An installed asset must remember which profile installed it, so
+// `vault list --installed --profile X` can show only X's assets.
+// Empty profile means the default profile.
+
+func TestInstalledAsset_ProfileRoundTrips(t *testing.T) {
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	tracker := &Tracker{
+		Version: TrackerFormatVersion,
+		Assets: []InstalledAsset{
+			{Name: "chat", Version: "1.0", Type: "skill", Clients: []string{"claude-code"}, Profile: "gh"},
+			{Name: "coding-standards", Version: "2.0", Type: "skill", Clients: []string{"claude-code"}}, // default profile
+		},
+	}
+
+	if err := SaveTracker(tracker); err != nil {
+		t.Fatalf("SaveTracker() error = %v", err)
+	}
+
+	loaded, err := LoadTracker()
+	if err != nil {
+		t.Fatalf("LoadTracker() error = %v", err)
+	}
+
+	got := map[string]string{}
+	for _, a := range loaded.Assets {
+		got[a.Name] = a.Profile
+	}
+
+	if got["chat"] != "gh" {
+		t.Errorf("chat profile = %q, want %q", got["chat"], "gh")
+	}
+	if got["coding-standards"] != "" {
+		t.Errorf("coding-standards profile = %q, want empty (default)", got["coding-standards"])
+	}
+}
+
+// Trackers written before this field existed have no "profile" key. They
+// must load with an empty profile (meaning default), not fail.
+func TestInstalledAsset_OldTrackerLoadsWithEmptyProfile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SX_CACHE_DIR", dir)
+
+	old := `{
+  "version": "3",
+  "assets": [
+    {"name": "frontend-design", "version": "1.0", "type": "skill", "clients": ["claude-code"]}
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(dir, "installed.json"), []byte(old), 0644); err != nil {
+		t.Fatalf("write old tracker: %v", err)
+	}
+
+	loaded, err := LoadTracker()
+	if err != nil {
+		t.Fatalf("LoadTracker() error = %v", err)
+	}
+	if len(loaded.Assets) != 1 {
+		t.Fatalf("loaded %d assets, want 1", len(loaded.Assets))
+	}
+	if loaded.Assets[0].Profile != "" {
+		t.Errorf("old asset profile = %q, want empty", loaded.Assets[0].Profile)
+	}
+}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -484,7 +484,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 
 	// Early exit if nothing to install
 	if len(assetsToInstall) == 0 {
-		return handleNothingToInstall(ctx, hookMode, tracker, sortedAssets, env, targetClientIDs, profileMeta, profileOrder, primaryCfg.ProfileName, styledOut, out)
+		return handleNothingToInstall(ctx, hookMode, tracker, sortedAssets, env, targetClientIDs, profileMeta, profileOrder, primaryCfg.ProfileName, assetOrigin, styledOut, out)
 	}
 
 	// Download assets, routing each to its origin profile's vault and
@@ -503,7 +503,7 @@ func runInstall(cmd *cobra.Command, args []string, hookMode bool, hookClientID s
 	installResult := installAssets(ctx, downloadResult.Downloads, env.GitContext, env.CurrentScope, env.Clients, styledOut, strict)
 
 	// Save new installation state (only for successfully installed assets)
-	saveInstallationState(tracker, sortedAssets, assetsToInstall, downloadResult.Downloads, installResult, env.CurrentScope, targetClientIDs, out)
+	saveInstallationState(tracker, sortedAssets, assetsToInstall, downloadResult.Downloads, installResult, env.CurrentScope, targetClientIDs, assetOrigin, out)
 
 	// Ensure skills support is configured for all clients (creates local rules files, etc.)
 	ensureAssetSupport(ctx, env.Clients, buildInstallScope(env.CurrentScope, env.GitContext), out)
@@ -1046,7 +1046,7 @@ func ensureAssetSupport(ctx context.Context, targetClients []clients.Client, sco
 // saveInstallationState saves the current installation state to tracker file.
 // Assets that failed to download or install are skipped so they will be retried
 // on the next install run.
-func saveInstallationState(tracker *assets.Tracker, sortedAssets []*lockfile.Asset, assetsToInstall []*lockfile.Asset, downloads []*assets.AssetWithMetadata, installResult *assets.InstallResult, currentScope *scope.Scope, targetClientIDs []string, out *outputHelper) {
+func saveInstallationState(tracker *assets.Tracker, sortedAssets []*lockfile.Asset, assetsToInstall []*lockfile.Asset, downloads []*assets.AssetWithMetadata, installResult *assets.InstallResult, currentScope *scope.Scope, targetClientIDs []string, assetOrigin map[string]string, out *outputHelper) {
 	// Build metadata lookup map from downloads
 	metadataByName := make(map[string]*assets.AssetWithMetadata)
 	for _, d := range downloads {
@@ -1076,12 +1076,24 @@ func saveInstallationState(tracker *assets.Tracker, sortedAssets []*lockfile.Ass
 		}
 
 		key := assetKeyForInstall(art, currentScope)
+
+		// Stamp the profile that installed this asset, taken from assetOrigin
+		// (the merge winner). On a repair run assetOrigin is nil, so keep the
+		// profile already recorded rather than blanking it.
+		profile := assetOrigin[art.Name]
+		if profile == "" {
+			if existing := tracker.FindAsset(key); existing != nil {
+				profile = existing.Profile
+			}
+		}
+
 		installed := assets.InstalledAsset{
 			Name:       art.Name,
 			Version:    art.Version,
 			Type:       art.Type.Key,
 			Repository: key.Repository,
 			Path:       key.Path,
+			Profile:    profile,
 			Clients:    targetClientIDs,
 		}
 

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -1078,8 +1078,9 @@ func saveInstallationState(tracker *assets.Tracker, sortedAssets []*lockfile.Ass
 		key := assetKeyForInstall(art, currentScope)
 
 		// Stamp the profile that installed this asset, taken from assetOrigin
-		// (the merge winner). On a repair run assetOrigin is nil, so keep the
-		// profile already recorded rather than blanking it.
+		// (the merge winner). The lookup is "" when the winner is the default
+		// (unnamed) profile or the asset isn't in the merge map; in that case
+		// keep the profile already recorded rather than blanking it.
 		profile := assetOrigin[art.Name]
 		if profile == "" {
 			if existing := tracker.FindAsset(key); existing != nil {

--- a/internal/commands/install_context.go
+++ b/internal/commands/install_context.go
@@ -260,11 +260,13 @@ func handleNothingToInstall(
 	profileMeta map[string]profileMetadata,
 	profileOrder []string,
 	primaryProfile string,
+	assetOrigin map[string]string,
 	styledOut *ui.Output,
 	out *outputHelper,
 ) error {
-	// Save state even if nothing changed (no assets attempted, no downloads)
-	saveInstallationState(tracker, sortedAssets, nil, nil, nil, env.CurrentScope, targetClientIDs, out)
+	// Save state even if nothing changed: this is where already-installed
+	// assets get their profile stamped/backfilled on a repair or up-to-date run.
+	saveInstallationState(tracker, sortedAssets, nil, nil, nil, env.CurrentScope, targetClientIDs, assetOrigin, out)
 
 	// Install client-specific hooks
 	// env.Clients is already filtered by --client/--clients flag

--- a/internal/commands/install_profile_test.go
+++ b/internal/commands/install_profile_test.go
@@ -1,0 +1,163 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/assets"
+	"github.com/sleuth-io/sx/internal/config"
+)
+
+// setupTwoProfiles writes a multi-profile config with two path vaults,
+// "default" (active) and "gh", and seeds one skill into each. Returns the two
+// vault dirs.
+func setupTwoProfiles(t *testing.T, env *TestEnv) (defaultVault, ghVault string) {
+	t.Helper()
+
+	defaultVault = env.MkdirAll(filepath.Join(env.TempDir, "vault-default"))
+	ghVault = env.MkdirAll(filepath.Join(env.TempDir, "vault-gh"))
+
+	env.AddSkillToVault(defaultVault, "default-skill", "1.0.0")
+	env.WriteLockFile(defaultVault, `
+[[assets]]
+name = "default-skill"
+version = "1.0.0"
+type = "skill"
+
+[assets.source-path]
+path = "assets/default-skill/1.0.0"
+`)
+
+	env.AddSkillToVault(ghVault, "gh-skill", "1.0.0")
+	env.WriteLockFile(ghVault, `
+[[assets]]
+name = "gh-skill"
+version = "1.0.0"
+type = "skill"
+
+[assets.source-path]
+path = "assets/gh-skill/1.0.0"
+`)
+
+	configDir := env.MkdirAll(filepath.Join(env.HomeDir, ".config", "sx"))
+	cfg := fmt.Sprintf(`{
+  "defaultProfile": "default",
+  "activeProfiles": ["default"],
+  "profiles": {
+    "default": {"type": "path", "repositoryUrl": "file://%s"},
+    "gh": {"type": "path", "repositoryUrl": "file://%s"}
+  }
+}`, defaultVault, ghVault)
+	env.WriteFile(filepath.Join(configDir, "config.json"), cfg)
+
+	return defaultVault, ghVault
+}
+
+//  1. A plain `sx install` stamps each installed asset with the current
+//     (default) profile.
+func TestInstall_StampsCurrentProfile(t *testing.T) {
+	env := NewTestEnv(t)
+	setupTwoProfiles(t, env)
+	env.Chdir(env.MkdirAll(filepath.Join(env.TempDir, "work")))
+
+	cmd := NewInstallCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	tracker, err := assets.LoadTracker()
+	if err != nil {
+		t.Fatalf("LoadTracker: %v", err)
+	}
+	got := profileByName(tracker.Assets)
+	if got["default-skill"] != "default" {
+		t.Errorf("default-skill profile = %q, want %q (assets: %+v)", got["default-skill"], "default", tracker.Assets)
+	}
+}
+
+//  2. `sx install --profile gh` stamps the gh profile. We simulate the
+//     --profile flag with SetActiveProfile, which is what the flag does.
+func TestInstall_ProfileFlagStampsThatProfile(t *testing.T) {
+	env := NewTestEnv(t)
+	setupTwoProfiles(t, env)
+	env.Chdir(env.MkdirAll(filepath.Join(env.TempDir, "work")))
+
+	config.SetActiveProfile("gh")
+	t.Cleanup(func() { config.SetActiveProfile("") })
+
+	cmd := NewInstallCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --profile gh failed: %v", err)
+	}
+
+	tracker, err := assets.LoadTracker()
+	if err != nil {
+		t.Fatalf("LoadTracker: %v", err)
+	}
+	got := profileByName(tracker.Assets)
+	if got["gh-skill"] != "gh" {
+		t.Errorf("gh-skill profile = %q, want %q (assets: %+v)", got["gh-skill"], "gh", tracker.Assets)
+	}
+}
+
+//  3. `sx vault list --installed` shows assets for the current profile plus
+//     untagged (empty-profile) ones, and hides other profiles' assets.
+func TestVaultListInstalled_FiltersByCurrentProfile(t *testing.T) {
+	env := NewTestEnv(t)
+	setupTwoProfiles(t, env)
+	env.Chdir(env.MkdirAll(filepath.Join(env.TempDir, "work")))
+
+	if err := assets.SaveTracker(&assets.Tracker{
+		Version: assets.TrackerFormatVersion,
+		Assets: []assets.InstalledAsset{
+			{Name: "default-skill", Version: "1.0.0", Type: "skill", Profile: "default", Clients: []string{"claude-code"}},
+			{Name: "gh-skill", Version: "1.0.0", Type: "skill", Profile: "gh", Clients: []string{"claude-code"}},
+			{Name: "legacy-skill", Version: "1.0.0", Type: "skill", Profile: "", Clients: []string{"claude-code"}},
+		},
+	}); err != nil {
+		t.Fatalf("seed tracker: %v", err)
+	}
+
+	cmd := NewVaultCommand()
+	cmd.SetArgs([]string{"list", "--installed"})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("vault list --installed failed: %v", err)
+	}
+	out := stdout.String()
+
+	mustContain(t, out, "default-skill") // current profile
+	mustContain(t, out, "legacy-skill")  // empty profile = current
+	mustNotContain(t, out, "gh-skill")   // other profile hidden
+}
+
+func profileByName(in []assets.InstalledAsset) map[string]string {
+	m := map[string]string{}
+	for _, a := range in {
+		m[a.Name] = a.Profile
+	}
+	return m
+}
+
+func mustContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Errorf("expected output to contain %q, got:\n%s", sub, s)
+	}
+}
+
+func mustNotContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		return
+	}
+	t.Errorf("expected output to NOT contain %q, got:\n%s", sub, s)
+}

--- a/internal/commands/install_save_state_test.go
+++ b/internal/commands/install_save_state_test.go
@@ -47,7 +47,7 @@ func TestSaveInstallationState_SkipsFailedAssets(t *testing.T) {
 	cmd.SetErr(&bytes.Buffer{})
 	out := newOutputHelper(cmd)
 
-	saveInstallationState(tracker, sortedAssets, assetsToInstall, nil, installResult, currentScope, []string{"claude-code"}, out)
+	saveInstallationState(tracker, sortedAssets, assetsToInstall, nil, installResult, currentScope, []string{"claude-code"}, nil, out)
 
 	// Verify: skill-ok should be saved (attempted + succeeded)
 	// Verify: skill-fail should NOT be saved (attempted + failed)
@@ -91,9 +91,75 @@ func TestSaveInstallationState_NilInstallResult(t *testing.T) {
 	out := newOutputHelper(cmd)
 
 	// nil assetsToInstall and nil installResult (nothing-to-install path)
-	saveInstallationState(tracker, sortedAssets, nil, nil, nil, currentScope, []string{"claude-code"}, out)
+	saveInstallationState(tracker, sortedAssets, nil, nil, nil, currentScope, []string{"claude-code"}, nil, out)
 
 	if len(tracker.Assets) != 2 {
 		t.Errorf("expected 2 assets saved, got %d", len(tracker.Assets))
+	}
+}
+
+// saveInstallationState must stamp each asset with the profile that installed
+// it, taken from assetOrigin. Assets missing from assetOrigin get an empty
+// profile (default).
+func TestSaveInstallationState_RecordsProfileFromOrigin(t *testing.T) {
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	tracker := &assets.Tracker{Version: "3", Assets: []assets.InstalledAsset{}}
+	currentScope := &scope.Scope{Type: lockfile.ScopeGlobal}
+
+	sortedAssets := []*lockfile.Asset{
+		{Name: "skill-gh", Version: "1.0.0", Type: asset.TypeSkill},
+		{Name: "skill-default", Version: "1.0.0", Type: asset.TypeSkill},
+	}
+	assetOrigin := map[string]string{"skill-gh": "gh"} // skill-default has no origin
+
+	cmd := &cobra.Command{}
+	cmd.SetErr(&bytes.Buffer{})
+	out := newOutputHelper(cmd)
+
+	saveInstallationState(tracker, sortedAssets, nil, nil, nil, currentScope, []string{"claude-code"}, assetOrigin, out)
+
+	got := map[string]string{}
+	for _, a := range tracker.Assets {
+		got[a.Name] = a.Profile
+	}
+	if got["skill-gh"] != "gh" {
+		t.Errorf("skill-gh profile = %q, want %q", got["skill-gh"], "gh")
+	}
+	if got["skill-default"] != "" {
+		t.Errorf("skill-default profile = %q, want empty", got["skill-default"])
+	}
+}
+
+// On a repair run there is no assetOrigin, so the existing profile on a tracked
+// asset must be preserved rather than blanked.
+func TestSaveInstallationState_PreservesProfileWhenNoOrigin(t *testing.T) {
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	tracker := &assets.Tracker{
+		Version: "3",
+		Assets: []assets.InstalledAsset{
+			{Name: "skill-gh", Version: "1.0.0", Type: "skill", Profile: "gh"},
+		},
+	}
+	currentScope := &scope.Scope{Type: lockfile.ScopeGlobal}
+
+	sortedAssets := []*lockfile.Asset{
+		{Name: "skill-gh", Version: "1.0.0", Type: asset.TypeSkill},
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetErr(&bytes.Buffer{})
+	out := newOutputHelper(cmd)
+
+	// assetOrigin is nil (repair path)
+	saveInstallationState(tracker, sortedAssets, nil, nil, nil, currentScope, []string{"claude-code"}, nil, out)
+
+	found := tracker.FindAsset(assets.AssetKey{Name: "skill-gh"})
+	if found == nil {
+		t.Fatal("skill-gh missing after save")
+	}
+	if found.Profile != "gh" {
+		t.Errorf("profile = %q, want %q (preserved on repair)", found.Profile, "gh")
 	}
 }

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -42,8 +42,8 @@ also remove system hooks from all clients.
 Use ` + e("--clients") + ` to limit which clients are affected (applies to both asset
 removal and hook removal).
 
-Note: ` + e("--profile") + ` has no effect on uninstall. All installed assets are removed
-regardless of which profile originally installed them.
+Uninstall only touches assets installed by the current profile (use ` + e("--profile") + `
+to act on another one). Untagged assets count as the current profile.
 
 ` + s.Header.Render("Examples:") + `
   ` + m("# Uninstall repo assets (must be inside a repo)") + `
@@ -112,6 +112,7 @@ type AssetUninstallPlan struct {
 	IsGlobal   bool
 	Repository string   // Empty for global scope
 	Path       string   // Path within repo (if path-scoped)
+	Profile    string   // Profile that installed it; empty means default
 	Clients    []string // client IDs that have this installed
 	LockEntry  *lockfile.Asset
 }
@@ -175,7 +176,15 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 	// Step 3: Build uninstall plan
 	plan := buildUninstallPlanFromTracker(lockFile, tracker, gitContext, trackingBase)
 
-	// Step 4: Filter plan by scope (without --all, only current repo's assets)
+	// Step 4: Filter to the current profile (empty profile counts as current),
+	// so uninstalling under one profile leaves other profiles' installs alone.
+	// If the profile can't be resolved, skip this filter rather than wrongly
+	// dropping everything.
+	if cfg, cfgErr := config.Load(); cfgErr == nil && cfg.ProfileName != "" {
+		plan = filterUninstallPlanByProfile(plan, cfg.ProfileName)
+	}
+
+	// Step 5: Filter plan by scope (without --all, only current repo's assets)
 	plan = filterUninstallPlanByScope(plan, opts.All)
 
 	if len(plan.Assets) == 0 {
@@ -377,6 +386,7 @@ func buildUninstallPlanFromTracker(lockFile *lockfile.LockFile, tracker *assets.
 				IsGlobal:   installed.IsGlobal(),
 				Repository: installed.Repository,
 				Path:       installed.Path,
+				Profile:    installed.Profile,
 				Clients:    installed.Clients,
 			})
 			continue
@@ -389,6 +399,7 @@ func buildUninstallPlanFromTracker(lockFile *lockfile.LockFile, tracker *assets.
 			IsGlobal:   lockEntry.IsGlobal(),
 			Repository: installed.Repository,
 			Path:       installed.Path,
+			Profile:    installed.Profile,
 			Clients:    installed.Clients,
 			LockEntry:  lockEntry,
 		})
@@ -401,6 +412,21 @@ func buildUninstallPlanFromTracker(lockFile *lockfile.LockFile, tracker *assets.
 // Without --all: only repo-scoped assets matching the current repo (global assets are never included).
 // Outside a repo without --all: returns an empty plan (no-op).
 // With --all: returns all assets unfiltered.
+// filterUninstallPlanByProfile keeps only assets installed by the current
+// profile. An empty profile counts as the current profile, matching
+// `vault list --installed`, so untagged leftovers are removed too while
+// another profile's installs are left alone.
+func filterUninstallPlanByProfile(plan UninstallPlan, currentProfile string) UninstallPlan {
+	var filtered []AssetUninstallPlan
+	for _, a := range plan.Assets {
+		if a.Profile == "" || a.Profile == currentProfile {
+			filtered = append(filtered, a)
+		}
+	}
+	plan.Assets = filtered
+	return plan
+}
+
 func filterUninstallPlanByScope(plan UninstallPlan, all bool) UninstallPlan {
 	if all {
 		return plan

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -42,8 +42,8 @@ also remove system hooks from all clients.
 Use ` + e("--clients") + ` to limit which clients are affected (applies to both asset
 removal and hook removal).
 
-Uninstall only touches assets installed by the current profile (use ` + e("--profile") + `
-to act on another one). Untagged assets count as the current profile.
+Uninstall only touches assets installed by the current profile (use the global
+` + e("--profile") + ` flag to act on another one). Untagged assets count as the current profile.
 
 ` + s.Header.Render("Examples:") + `
   ` + m("# Uninstall repo assets (must be inside a repo)") + `
@@ -178,9 +178,10 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 
 	// Step 4: Filter to the current profile (empty profile counts as current),
 	// so uninstalling under one profile leaves other profiles' installs alone.
-	// If the profile can't be resolved, skip this filter rather than wrongly
-	// dropping everything.
-	if cfg, cfgErr := config.Load(); cfgErr == nil && cfg.ProfileName != "" {
+	// An empty ProfileName is the default profile, not a resolution failure, so
+	// still filter (filterUninstallPlanByProfile keeps untagged entries). Only a
+	// config load error skips the filter, to avoid wrongly dropping everything.
+	if cfg, cfgErr := config.Load(); cfgErr == nil {
 		plan = filterUninstallPlanByProfile(plan, cfg.ProfileName)
 	}
 
@@ -408,10 +409,6 @@ func buildUninstallPlanFromTracker(lockFile *lockfile.LockFile, tracker *assets.
 	return plan
 }
 
-// filterUninstallPlanByScope filters the plan based on git context and --all flag.
-// Without --all: only repo-scoped assets matching the current repo (global assets are never included).
-// Outside a repo without --all: returns an empty plan (no-op).
-// With --all: returns all assets unfiltered.
 // filterUninstallPlanByProfile keeps only assets installed by the current
 // profile. An empty profile counts as the current profile, matching
 // `vault list --installed`, so untagged leftovers are removed too while
@@ -427,6 +424,10 @@ func filterUninstallPlanByProfile(plan UninstallPlan, currentProfile string) Uni
 	return plan
 }
 
+// filterUninstallPlanByScope filters the plan based on git context and --all flag.
+// Without --all: only repo-scoped assets matching the current repo (global assets are never included).
+// Outside a repo without --all: returns an empty plan (no-op).
+// With --all: returns all assets unfiltered.
 func filterUninstallPlanByScope(plan UninstallPlan, all bool) UninstallPlan {
 	if all {
 		return plan

--- a/internal/commands/uninstall_profile_test.go
+++ b/internal/commands/uninstall_profile_test.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"bytes"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/assets"
+)
+
+// `sx uninstall` should only remove assets installed by the current profile.
+// An empty profile counts as the current profile (matching
+// `vault list --installed`), so untagged leftovers are removed too, but
+// another profile's assets are left alone.
+func TestFilterUninstallPlanByProfile(t *testing.T) {
+	plan := UninstallPlan{
+		Assets: []AssetUninstallPlan{
+			{Name: "gh-skill", Profile: "gh"},
+			{Name: "default-skill", Profile: "default"},
+			{Name: "untagged-skill", Profile: ""},
+		},
+	}
+
+	t.Run("current profile gh keeps gh + empty", func(t *testing.T) {
+		got := planNames(filterUninstallPlanByProfile(plan, "gh"))
+		want := []string{"gh-skill", "untagged-skill"}
+		if !eqStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("current profile default keeps default + empty", func(t *testing.T) {
+		got := planNames(filterUninstallPlanByProfile(plan, "default"))
+		want := []string{"default-skill", "untagged-skill"}
+		if !eqStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+// End-to-end: install default-skill under the default profile, plant a gh
+// entry in the tracker, then `sx uninstall --all` under default. The default
+// (and the on-disk asset) goes; gh's entry is left alone.
+func TestUninstallAll_LeavesOtherProfileAssets(t *testing.T) {
+	env := NewTestEnv(t)
+	setupTwoProfiles(t, env)
+	env.Chdir(env.MkdirAll(filepath.Join(env.TempDir, "work")))
+
+	installCmd := NewInstallCommand()
+	installCmd.SetOut(&bytes.Buffer{})
+	installCmd.SetErr(&bytes.Buffer{})
+	if err := installCmd.Execute(); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	// Plant a gh-profile entry that the default-profile uninstall must not touch.
+	tracker, err := assets.LoadTracker()
+	if err != nil {
+		t.Fatalf("LoadTracker: %v", err)
+	}
+	tracker.UpsertAsset(assets.InstalledAsset{
+		Name: "gh-skill", Version: "1.0.0", Type: "skill", Profile: "gh", Clients: []string{"claude-code"},
+	})
+	if err := assets.SaveTracker(tracker); err != nil {
+		t.Fatalf("SaveTracker: %v", err)
+	}
+
+	uninstallCmd := NewUninstallCommand()
+	uninstallCmd.SetArgs([]string{"--all", "--yes"})
+	uninstallCmd.SetOut(&bytes.Buffer{})
+	uninstallCmd.SetErr(&bytes.Buffer{})
+	if err := uninstallCmd.Execute(); err != nil {
+		t.Fatalf("uninstall --all failed: %v", err)
+	}
+
+	after, err := assets.LoadTracker()
+	if err != nil {
+		t.Fatalf("LoadTracker after: %v", err)
+	}
+	got := profileByName(after.Assets)
+	if _, stillThere := got["default-skill"]; stillThere {
+		t.Errorf("default-skill should be uninstalled, tracker: %+v", after.Assets)
+	}
+	if got["gh-skill"] != "gh" {
+		t.Errorf("gh-skill should be left alone, tracker: %+v", after.Assets)
+	}
+}
+
+func planNames(plan UninstallPlan) []string {
+	out := make([]string, 0, len(plan.Assets))
+	for _, a := range plan.Assets {
+		out = append(out, a.Name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/commands/vault.go
+++ b/internal/commands/vault.go
@@ -140,6 +140,19 @@ func runVaultList(cmd *cobra.Command, typeFilter string, jsonOutput, installedOn
 		if jsonOutput {
 			return printInstalledListJSON(out, lfAssets, typeFilter)
 		}
+		// The tracker had entries but none survived the profile filter — say so
+		// rather than printing a bare header, so it's clear the assets belong to
+		// another profile rather than nothing being installed. Only when there's
+		// no type filter, otherwise an empty result means "none of that type" and
+		// the type-labelled header below already conveys that.
+		if len(filtered) == 0 && typeFilter == "" {
+			profile := cfg.ProfileName
+			if profile == "" {
+				profile = config.DefaultProfileName
+			}
+			out.println(fmt.Sprintf("No assets installed under profile %q. Other profiles may have installs; switch with --profile.", profile))
+			return nil
+		}
 		return printInstalledListText(out, lfAssets, typeFilter)
 	}
 
@@ -498,6 +511,15 @@ func printInstalledListText(out *outputHelper, assets []lockfile.Asset, typeFilt
 			scopeInfo := ""
 			if a.IsGlobal() {
 				scopeInfo = uiOut.MutedText(" (global)")
+			} else if len(a.Scopes) == 1 {
+				// Name the repo (and path) so entries from another repo are
+				// distinguishable rather than blending into the current one.
+				s := a.Scopes[0]
+				label := s.Repo
+				if len(s.Paths) > 0 {
+					label += ":" + strings.Join(s.Paths, ",")
+				}
+				scopeInfo = uiOut.MutedText(" (" + label + ")")
 			} else if len(a.Scopes) > 0 {
 				scopeInfo = uiOut.MutedText(fmt.Sprintf(" (%d scopes)", len(a.Scopes)))
 			}

--- a/internal/commands/vault.go
+++ b/internal/commands/vault.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/assets"
 	"github.com/sleuth-io/sx/internal/config"
 	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
@@ -112,7 +113,37 @@ func runVaultList(cmd *cobra.Command, typeFilter string, jsonOutput, installedOn
 		}
 	}
 
-	// Get lock file (needed for both modes)
+	// --installed reads the local install tracker — what's actually on disk —
+	// not the vault manifest. It's offline: no GetLockFile / network needed.
+	// Entries are filtered to the current profile (empty profile counts as the
+	// current one), so `--profile X` shows only what X installed.
+	if installedOnly {
+		if status != nil {
+			status.Done("")
+		}
+
+		tracker, err := assets.LoadTracker()
+		if err != nil {
+			return fmt.Errorf("failed to load installed assets: %w", err)
+		}
+
+		if len(tracker.Assets) == 0 {
+			if jsonOutput {
+				return printInstalledListJSON(out, nil, typeFilter)
+			}
+			out.println("No assets installed. Run 'sx install' to install assets.")
+			return nil
+		}
+
+		filtered := filterInstalledForProfile(tracker.Assets, cfg.ProfileName, typeFilter)
+		lfAssets := installedToLockfileAssets(filtered)
+		if jsonOutput {
+			return printInstalledListJSON(out, lfAssets, typeFilter)
+		}
+		return printInstalledListText(out, lfAssets, typeFilter)
+	}
+
+	// Vault-query mode needs the lock file to mark which vault assets are installed.
 	var lf *lockfile.LockFile
 	lockFileData, _, _, lfErr := vault.GetLockFile(ctx, "")
 	if lfErr == nil {
@@ -122,28 +153,6 @@ func runVaultList(cmd *cobra.Command, typeFilter string, jsonOutput, installedOn
 			log := logger.Get()
 			log.Warn("failed to parse lock file", "error", parseErr)
 		}
-	}
-
-	// If --installed, use lock file data instead of querying vault
-	if installedOnly {
-		if status != nil {
-			status.Done("")
-		}
-
-		if lf == nil {
-			if jsonOutput {
-				return printInstalledListJSON(out, nil, typeFilter)
-			}
-			out.println("No assets installed. Run 'sx install' to install assets.")
-			return nil
-		}
-
-		// Convert lock file assets to vault result format
-		assets := filterAssetsByType(lf.Assets, typeFilter)
-		if jsonOutput {
-			return printInstalledListJSON(out, assets, typeFilter)
-		}
-		return printInstalledListText(out, assets, typeFilter)
 	}
 
 	result, err := vault.ListAssets(ctx, vaultpkg.ListAssetsOptions{

--- a/internal/commands/vault_installed.go
+++ b/internal/commands/vault_installed.go
@@ -32,6 +32,10 @@ func filterInstalledForProfile(all []assets.InstalledAsset, currentProfile, type
 // installedToLockfileAssets adapts tracker entries to lockfile.Asset so the
 // shared installed-list printers can render them. Each tracker entry is a
 // single scope: global entries get no scopes, repo/path entries get one.
+// Profile and Clients are intentionally not carried over: lockfile.Asset has
+// no place for them and the installed-list printers don't display them. A
+// future profile-scoped view would need to read those fields off the tracker
+// entry directly rather than through this adapter.
 func installedToLockfileAssets(in []assets.InstalledAsset) []lockfile.Asset {
 	out := make([]lockfile.Asset, 0, len(in))
 	for _, a := range in {

--- a/internal/commands/vault_installed.go
+++ b/internal/commands/vault_installed.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/assets"
+	"github.com/sleuth-io/sx/internal/lockfile"
+)
+
+// filterInstalledForProfile keeps the tracker entries that belong to the
+// current profile. An empty profile counts as the current profile, so
+// untagged leftovers show under whatever profile you're using. When typeFilter
+// is set, only that asset type is kept.
+func filterInstalledForProfile(all []assets.InstalledAsset, currentProfile, typeFilter string) []assets.InstalledAsset {
+	wantType := ""
+	if typeFilter != "" {
+		wantType = asset.FromString(typeFilter).Key
+	}
+
+	var out []assets.InstalledAsset
+	for _, a := range all {
+		if a.Profile != "" && a.Profile != currentProfile {
+			continue
+		}
+		if wantType != "" && a.Type != wantType {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// installedToLockfileAssets adapts tracker entries to lockfile.Asset so the
+// shared installed-list printers can render them. Each tracker entry is a
+// single scope: global entries get no scopes, repo/path entries get one.
+func installedToLockfileAssets(in []assets.InstalledAsset) []lockfile.Asset {
+	out := make([]lockfile.Asset, 0, len(in))
+	for _, a := range in {
+		la := lockfile.Asset{
+			Name:    a.Name,
+			Version: a.Version,
+			Type:    asset.FromString(a.Type),
+		}
+		if a.Repository != "" {
+			s := lockfile.Scope{Repo: a.Repository}
+			if a.Path != "" {
+				s.Paths = []string{a.Path}
+			}
+			la.Scopes = []lockfile.Scope{s}
+		}
+		out = append(out, la)
+	}
+	return out
+}

--- a/internal/commands/vault_installed_test.go
+++ b/internal/commands/vault_installed_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/assets"
+)
+
+func namesOfInstalled(in []assets.InstalledAsset) []string {
+	out := make([]string, 0, len(in))
+	for _, a := range in {
+		out = append(out, a.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// `vault list --installed --profile X` shows assets installed by X. An empty
+// profile counts as the current profile, so untagged leftovers show under
+// whatever profile you're using. Assets stamped with a different profile are
+// hidden.
+func TestFilterInstalledForProfile(t *testing.T) {
+	all := []assets.InstalledAsset{
+		{Name: "gh-skill", Type: "skill", Profile: "gh"},
+		{Name: "default-skill", Type: "skill", Profile: "default"},
+		{Name: "untagged-skill", Type: "skill", Profile: ""}, // empty = current profile
+		{Name: "gh-agent", Type: "agent", Profile: "gh"},
+	}
+
+	t.Run("current profile gh, no type filter", func(t *testing.T) {
+		got := namesOfInstalled(filterInstalledForProfile(all, "gh", ""))
+		want := []string{"gh-agent", "gh-skill", "untagged-skill"}
+		if !eqStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("current profile default", func(t *testing.T) {
+		got := namesOfInstalled(filterInstalledForProfile(all, "default", ""))
+		want := []string{"default-skill", "untagged-skill"}
+		if !eqStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("type filter applies on top of profile", func(t *testing.T) {
+		got := namesOfInstalled(filterInstalledForProfile(all, "gh", "skill"))
+		want := []string{"gh-skill", "untagged-skill"}
+		if !eqStrings(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}

--- a/internal/commands/vault_test.go
+++ b/internal/commands/vault_test.go
@@ -773,8 +773,10 @@ func TestVaultListInstalled(t *testing.T) {
 		if !strings.Contains(output, "(global)") {
 			t.Errorf("Expected '(global)' scope info, got:\n%s", output)
 		}
-		if !strings.Contains(output, "(1 scopes)") {
-			t.Errorf("Expected '(1 scopes)' scope info, got:\n%s", output)
+		// Repo-scoped entries name their repo so cross-repo installs are
+		// distinguishable rather than showing an opaque scope count.
+		if !strings.Contains(output, "(https://github.com/test/repo)") {
+			t.Errorf("Expected repo name in scope info, got:\n%s", output)
 		}
 	})
 

--- a/internal/commands/vault_test.go
+++ b/internal/commands/vault_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/assets"
 	"github.com/sleuth-io/sx/internal/lockfile"
 )
 
@@ -724,36 +725,20 @@ func TestVaultCommandEmptyRepository(t *testing.T) {
 // TestVaultListInstalled tests the --installed flag
 func TestVaultListInstalled(t *testing.T) {
 	env := NewTestEnv(t)
-	vaultDir := env.SetupPathVault()
+	env.SetupPathVault()
 
-	// Add skills to vault with different scopes
-	env.AddSkillToVault(vaultDir, "global-skill", "1.0.0")
-	env.AddSkillToVault(vaultDir, "scoped-skill", "2.0.0")
-	env.WriteFile(filepath.Join(vaultDir, "assets", "global-skill", "list.txt"), "1.0.0\n")
-	env.WriteFile(filepath.Join(vaultDir, "assets", "scoped-skill", "list.txt"), "2.0.0\n")
-
-	// Write lock file with installed assets
-	// Note: IsGlobal() returns true when there are no scopes
-	env.WriteLockFile(vaultDir, `
-[[assets]]
-name = "global-skill"
-version = "1.0.0"
-type = "skill"
-
-[assets.source-path]
-path = "assets/global-skill/1.0.0"
-
-[[assets]]
-name = "scoped-skill"
-version = "2.0.0"
-type = "skill"
-
-[assets.source-path]
-path = "assets/scoped-skill/2.0.0"
-
-[[assets.scopes]]
-repo = "https://github.com/test/repo"
-`)
+	// --installed reads the local install tracker, not the vault manifest.
+	// Seed it directly. Empty profile means "current profile", so these show
+	// regardless of which profile is active.
+	if err := assets.SaveTracker(&assets.Tracker{
+		Version: assets.TrackerFormatVersion,
+		Assets: []assets.InstalledAsset{
+			{Name: "global-skill", Version: "1.0.0", Type: "skill", Clients: []string{"claude-code"}},
+			{Name: "scoped-skill", Version: "2.0.0", Type: "skill", Repository: "https://github.com/test/repo", Clients: []string{"claude-code"}},
+		},
+	}); err != nil {
+		t.Fatalf("seed tracker: %v", err)
+	}
 
 	workingDir := env.MkdirAll(filepath.Join(env.TempDir, "working"))
 	env.Chdir(workingDir)


### PR DESCRIPTION
- Add Profile field to the install tracker
- Profile is set on `install`, `repair` and up-to-date runs
- Make `vault list --installed` read the tracker, filter by profile <- old profile-less entries are counted towards every profile, just like they were until now
- Filter uninstall to the current profile (empty = current)


`~/.cache/sx/installed.json`:
<img width="597" height="262" alt="image" src="https://github.com/user-attachments/assets/2364150d-c87b-4616-8bef-3dbe47c9c1f5" />
