### PR TITLE
SK-536: Add sx vault copy for lossless cross-vault migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ make build && ./dist/sx <command>
 - [Manifest Spec](docs/manifest-spec.md) - sx.toml format (source of truth)
 - [Lock Spec](docs/lock-spec.md) - Per-user resolved lock file format
 - [Scoping](docs/scoping.md) - Overview of every install scope (org/repo/path/team/user/bot), links to per-scope docs
+- [Vault copy](docs/copy.md) - `sx vault copy` cross-vault migration (assets, teams, bots, scopes, audit, usage)
 - [Orgs](docs/orgs.md) - Org-scoped (global) installs
 - [Repos](docs/repos.md) - Repo and path-scoped installs (monorepo patterns)
 - [Teams](docs/teams.md) - Team management and team-scoped installs

--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ sx audit                                   # recent team/install mutations
 sx audit --actor alice@acme.com --since 30d --event install.set
 ```
 
+**Migrate a whole vault** (assets + versions, teams, bots, scopes, audit, usage):
+
+```bash
+sx vault copy --from skills-new --to git-vault   # preview (read-only)
+sx vault copy --from skills-new --to git-vault --yes
+```
+
+See [docs/copy.md](docs/copy.md) for directionality and what's lossy.
+
 ### Already using Claude Code?
 
 If you've built up skills, plugins, or MCP configs in your `.claude` directory, `sx` helps you version, sync across machines, and share with teammates.
@@ -280,6 +289,7 @@ See LICENSE file for details.
 - [Manifest Spec](docs/manifest-spec.md) - sx.toml source-of-truth format (assets, scopes, teams)
 - [Lock Spec](docs/lock-spec.md) - Per-user resolved lock file
 - [Scoping](docs/scoping.md) - Install targets and links to per-scope docs (orgs, repos, teams, users, bots)
+- [Vault copy](docs/copy.md) - `sx vault copy` cross-vault migration (assets, teams, bots, scopes, audit, usage)
 - [Audit log](docs/audit.md) - Event catalog, `sx audit` filters, storage format
 - [Usage analytics](docs/stats.md) - `sx stats` dashboard, JSON output, event format
 - [Metadata Spec](docs/metadata-spec.md) - Asset metadata format

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -74,10 +74,10 @@ audit, and usage in both directions, with these exceptions:
 - **Audit and usage import is additive.** If a copy's audit/usage stage fails
   part-way and you re-run it, the already-imported events are duplicated on the
   destination.
-- **Uploading an asset to skills.new publishes it org-wide by default.** An asset
-  that had *no* installations in the source therefore lands as a global install
-  in a skills.new destination — skills.new has no "uploaded but uninstalled"
-  state.
+
+(skills.new publishes an uploaded asset org-wide by default; the copy detects a
+source asset that has no installations and clears that auto-applied install on
+the destination, so an uninstalled asset stays uninstalled.)
 
 The preview/report always names what was skipped, so nothing is lost silently.
 

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -1,0 +1,88 @@
+# Copying a vault: `sx vault copy`
+
+Move everything in one vault into another — assets and all their versions,
+teams, bots, installation scopes, audit history, and usage history. The source
+and destination can be any backend, so you can convert a skills.new vault into a
+git vault (or vice versa) without leaving the contents behind.
+
+```bash
+sx vault copy --from <profile> --to <profile> [--only ...] [--dry-run] [--yes]
+```
+
+`--from` and `--to` name [profiles](profiles.md) — each profile points at one
+vault (skills.new, git, or path). The command reads from the source profile's
+vault and writes to the destination profile's vault; the two must be different.
+
+## What gets copied
+
+| Category | Detail |
+|----------|--------|
+| Teams | name, members, admins, and team→repository associations |
+| Bots | name, description, and team memberships (API keys are **not** copyable — regenerate them) |
+| Assets | every version of every asset, content included |
+| Installation scopes | each asset's org/repo/path/team/user/bot installs |
+| Audit history | every event, with its original timestamp and actor preserved |
+| Usage history | every usage event, with its original actor preserved |
+
+Copying runs in dependency order — teams and bots first, then assets (so an
+asset's team/bot scopes have something to resolve against), then audit and
+usage.
+
+### Smart, version-aware asset copy
+
+Assets are uploaded version by version, oldest first. The destination's own
+versioning absorbs them: content that already exists is skipped, and changed
+content lands as a new version. Re-running a copy doesn't duplicate asset
+versions.
+
+## Previewing
+
+Without `--yes`, the command performs a **read-only preview** and prints what it
+would copy plus anything that can't transfer. Apply with `--yes`:
+
+```bash
+sx vault copy --from skills-new --to git-vault            # preview only
+sx vault copy --from skills-new --to git-vault --dry-run  # explicit preview
+sx vault copy --from skills-new --to git-vault --yes      # apply
+```
+
+Use `--only` to restrict to specific categories:
+
+```bash
+sx vault copy --from a --to b --only assets,teams --yes
+```
+
+The copy is **best-effort**: if one item fails (an asset that won't download, a
+scope that won't resolve), it's recorded as a warning and the copy continues —
+one bad item never aborts the whole migration. The final report lists every
+warning.
+
+## Directionality and what's lossy
+
+Copies between **git and path vaults are fully lossless** — those backends store
+everything (manifest, audit, usage) as files.
+
+Copies involving **skills.new** are lossless for assets, teams, bots, scopes,
+audit, and usage in both directions, with these exceptions:
+
+- **Bot API keys** can't be copied (they're shown once at creation). Regenerate
+  them on the destination.
+- **Cross-org copies** require the referenced entities to exist in the
+  destination org: a team can only include members who are users of that org,
+  and repo/user-scoped installs only land if that repo/user exists there.
+  Targets that can't be resolved are skipped with a warning.
+- **Audit and usage import is additive.** If a copy's audit/usage stage fails
+  part-way and you re-run it, the already-imported events are duplicated on the
+  destination.
+- **Uploading an asset to skills.new publishes it org-wide by default.** An asset
+  that had *no* installations in the source therefore lands as a global install
+  in a skills.new destination — skills.new has no "uploaded but uninstalled"
+  state.
+
+The preview/report always names what was skipped, so nothing is lost silently.
+
+## See also
+
+- [Scoping](scoping.md) — the install scopes that travel with each asset
+- [Audit log](audit.md) and [Usage analytics](stats.md) — the histories copied
+- [Profiles](profiles.md) — how `--from`/`--to` resolve to vaults

--- a/internal/commands/vault.go
+++ b/internal/commands/vault.go
@@ -32,6 +32,7 @@ func NewVaultCommand() *cobra.Command {
 	cmd.AddCommand(newVaultShowCommand())
 	cmd.AddCommand(newVaultRemoveCommand())
 	cmd.AddCommand(newVaultRenameCommand())
+	cmd.AddCommand(newVaultCopyCommand())
 
 	return cmd
 }

--- a/internal/commands/vault_copy.go
+++ b/internal/commands/vault_copy.go
@@ -1,0 +1,166 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/internal/config"
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+	"github.com/sleuth-io/sx/internal/vaultcopy"
+)
+
+func newVaultCopyCommand() *cobra.Command {
+	var (
+		fromProfile string
+		toProfile   string
+		only        []string
+		dryRun      bool
+		yes         bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "copy --from <profile> --to <profile>",
+		Short: "Copy a vault's contents into another vault",
+		Long: `Copy teams, bots, assets (all versions), installation scopes, audit
+history, and usage history from one vault (profile) into another.
+
+The copy is "smart": assets are uploaded version-by-version, so matching
+content is deduplicated and changed content lands as a new version in the
+destination. Audit and usage events keep their original timestamps and actors.
+
+By default every category is copied. Use --only to restrict (e.g.
+--only assets,teams). A preview is always shown first; pass --yes to apply.
+
+Some transfers are lossy depending on direction (e.g. into skills.new: bot API
+keys must be regenerated). The preview lists anything that won't transfer.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runVaultCopy(cmd, fromProfile, toProfile, only, dryRun, yes)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromProfile, "from", "", "source profile name (required)")
+	cmd.Flags().StringVar(&toProfile, "to", "", "destination profile name (required)")
+	cmd.Flags().StringSliceVar(&only, "only", nil, "restrict to categories: teams,bots,assets,audit,usage")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what would copy without writing")
+	cmd.Flags().BoolVar(&yes, "yes", false, "apply the copy (without this, only a preview is shown)")
+	_ = cmd.MarkFlagRequired("from")
+	_ = cmd.MarkFlagRequired("to")
+
+	return cmd
+}
+
+func runVaultCopy(cmd *cobra.Command, fromProfile, toProfile string, only []string, dryRun, yes bool) error {
+	if fromProfile == toProfile {
+		return errors.New("--from and --to must be different profiles")
+	}
+
+	opts, err := optionsFromOnly(only)
+	if err != nil {
+		return err
+	}
+
+	src, err := vaultFromProfile(fromProfile)
+	if err != nil {
+		return fmt.Errorf("source profile %q: %w", fromProfile, err)
+	}
+	dst, err := vaultFromProfile(toProfile)
+	if err != nil {
+		return fmt.Errorf("destination profile %q: %w", toProfile, err)
+	}
+
+	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+
+	// Always preview first so the user sees scope + losses before any writes.
+	preview := opts
+	preview.DryRun = true
+	previewReport, err := vaultcopy.Copy(ctx, src, dst, preview)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Preview: copy %s → %s\n", fromProfile, toProfile)
+	printReport(out, previewReport, true)
+
+	if dryRun {
+		return nil
+	}
+	if !yes {
+		fmt.Fprintln(out, "\nRe-run with --yes to apply, or --dry-run to preview only.")
+		return nil
+	}
+
+	opts.DryRun = false
+	report, err := vaultcopy.Copy(ctx, src, dst, opts)
+	if err != nil {
+		printReport(out, report, false)
+		return err
+	}
+	fmt.Fprintf(out, "\nCopied %s → %s\n", fromProfile, toProfile)
+	printReport(out, report, false)
+	return nil
+}
+
+func optionsFromOnly(only []string) (vaultcopy.Options, error) {
+	if len(only) == 0 {
+		return vaultcopy.DefaultOptions(), nil
+	}
+	var opts vaultcopy.Options
+	for _, c := range only {
+		switch strings.ToLower(strings.TrimSpace(c)) {
+		case "teams":
+			opts.Teams = true
+		case "bots":
+			opts.Bots = true
+		case "assets":
+			opts.Assets = true
+		case "audit":
+			opts.Audit = true
+		case "usage":
+			opts.Usage = true
+		default:
+			return opts, fmt.Errorf("unknown category %q (valid: teams,bots,assets,audit,usage)", c)
+		}
+	}
+	return opts, nil
+}
+
+func vaultFromProfile(name string) (vaultpkg.Vault, error) {
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		return nil, err
+	}
+	profile, ok := mpc.GetProfile(name)
+	if !ok {
+		return nil, errors.New("profile not found (run 'sx profile list')")
+	}
+	return vaultpkg.NewFromConfig(profile.ToConfig(nil, nil))
+}
+
+func printReport(out io.Writer, r *vaultcopy.Report, planned bool) {
+	verb := "Copied"
+	if planned {
+		verb = "Would copy"
+	}
+	fmt.Fprintf(out, "  %s: %d teams, %d bots, %d assets (%d versions), %d scopes, %d audit events, %d usage events\n",
+		verb, r.Teams, r.Bots, r.Assets, r.Versions, r.Scopes, r.AuditEvents, r.UsageEvents)
+	if r.SkippedVersions > 0 {
+		fmt.Fprintf(out, "  Skipped %d already-present versions\n", r.SkippedVersions)
+	}
+	if len(r.Warnings) > 0 {
+		// De-duplicate repeated warnings for a tidy report.
+		seen := map[string]bool{}
+		fmt.Fprintln(out, "  Notes / losses:")
+		for _, w := range r.Warnings {
+			if seen[w] {
+				continue
+			}
+			seen[w] = true
+			fmt.Fprintf(out, "    - %s\n", w)
+		}
+	}
+}

--- a/internal/commands/vault_copy.go
+++ b/internal/commands/vault_copy.go
@@ -33,10 +33,15 @@ content is deduplicated and changed content lands as a new version in the
 destination. Audit and usage events keep their original timestamps and actors.
 
 By default every category is copied. Use --only to restrict (e.g.
---only assets,teams). A preview is always shown first; pass --yes to apply.
+--only assets,teams). Without --yes a read-only preview is shown; pass --yes
+to apply directly.
 
 Some transfers are lossy depending on direction (e.g. into skills.new: bot API
-keys must be regenerated). The preview lists anything that won't transfer.`,
+keys must be regenerated). The preview lists anything that won't transfer.
+
+Note: audit and usage import is additive — re-running a copy whose audit/usage
+stage previously failed part-way will duplicate the already-imported events on
+the destination.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runVaultCopy(cmd, fromProfile, toProfile, only, dryRun, yes)
@@ -47,7 +52,7 @@ keys must be regenerated). The preview lists anything that won't transfer.`,
 	cmd.Flags().StringVar(&toProfile, "to", "", "destination profile name (required)")
 	cmd.Flags().StringSliceVar(&only, "only", nil, "restrict to categories: teams,bots,assets,audit,usage")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what would copy without writing")
-	cmd.Flags().BoolVar(&yes, "yes", false, "apply the copy (without this, only a preview is shown)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "apply the copy (without this, only a read-only preview is shown)")
 	_ = cmd.MarkFlagRequired("from")
 	_ = cmd.MarkFlagRequired("to")
 
@@ -76,32 +81,28 @@ func runVaultCopy(cmd *cobra.Command, fromProfile, toProfile string, only []stri
 	ctx := cmd.Context()
 	out := cmd.OutOrStdout()
 
-	// Always preview first so the user sees scope + losses before any writes.
-	preview := opts
-	preview.DryRun = true
-	previewReport, err := vaultcopy.Copy(ctx, src, dst, preview)
+	// --yes applies directly. We deliberately don't run a separate preview pass
+	// first: a preview re-reads the entire source (audit + usage history), so
+	// previewing then applying would read everything twice. Use --dry-run for a
+	// read-only preview.
+	if yes && !dryRun {
+		opts.DryRun = false
+		report, err := vaultcopy.Copy(ctx, src, dst, opts)
+		fmt.Fprintf(out, "Copied %s → %s\n", fromProfile, toProfile)
+		printReport(out, report, false)
+		return err
+	}
+
+	opts.DryRun = true
+	report, err := vaultcopy.Copy(ctx, src, dst, opts)
 	if err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "Preview: copy %s → %s\n", fromProfile, toProfile)
-	printReport(out, previewReport, true)
-
-	if dryRun {
-		return nil
-	}
-	if !yes {
+	printReport(out, report, true)
+	if !dryRun {
 		fmt.Fprintln(out, "\nRe-run with --yes to apply, or --dry-run to preview only.")
-		return nil
 	}
-
-	opts.DryRun = false
-	report, err := vaultcopy.Copy(ctx, src, dst, opts)
-	if err != nil {
-		printReport(out, report, false)
-		return err
-	}
-	fmt.Fprintf(out, "\nCopied %s → %s\n", fromProfile, toProfile)
-	printReport(out, report, false)
 	return nil
 }
 

--- a/internal/mgmt/usage.go
+++ b/internal/mgmt/usage.go
@@ -110,7 +110,14 @@ func SummarizeUsage(vaultRoot string, filter UsageFilter) (*UsageSummary, error)
 	if err != nil {
 		return nil, err
 	}
+	return SummarizeUsageEvents(events), nil
+}
 
+// SummarizeUsageEvents computes per-asset and per-actor rollups over an
+// in-memory event slice. Shared by the file-backed SummarizeUsage and by
+// server-backed vaults that fetch raw events over the wire, so both produce
+// identical UsageSummary shapes.
+func SummarizeUsageEvents(events []UsageEvent) *UsageSummary {
 	type assetKey struct{ name, typ string }
 	assetAgg := make(map[assetKey]*AssetUsageCount)
 	assetActors := make(map[assetKey]map[string]struct{})
@@ -155,7 +162,7 @@ func SummarizeUsage(vaultRoot string, filter UsageFilter) (*UsageSummary, error)
 		return summary.PerActor[i].Actor < summary.PerActor[j].Actor
 	})
 
-	return summary, nil
+	return summary
 }
 
 func matchesUsageFilter(ev UsageEvent, f UsageFilter) bool {

--- a/internal/vault/chunk_test.go
+++ b/internal/vault/chunk_test.go
@@ -1,0 +1,37 @@
+package vault
+
+import "testing"
+
+func TestChunkSlice(t *testing.T) {
+	// Boundaries that mirror the audit (5000) and usage (1000) chunk sizes:
+	// exactly one over the size must produce two chunks with a 1-element tail.
+	cases := []struct {
+		n, size    int
+		wantChunks []int // expected length of each chunk
+	}{
+		{0, 1000, nil},
+		{1, 1000, []int{1}},
+		{1000, 1000, []int{1000}},
+		{1001, 1000, []int{1000, 1}},
+		{5001, 5000, []int{5000, 1}},
+		{10000, 5000, []int{5000, 5000}},
+		{3, 0, []int{3}}, // non-positive size => single chunk
+	}
+	for _, c := range cases {
+		items := make([]int, c.n)
+		chunks := chunkSlice(items, c.size)
+		if len(chunks) != len(c.wantChunks) {
+			t.Fatalf("chunkSlice(n=%d,size=%d) => %d chunks, want %d", c.n, c.size, len(chunks), len(c.wantChunks))
+		}
+		total := 0
+		for i, ch := range chunks {
+			if len(ch) != c.wantChunks[i] {
+				t.Errorf("chunkSlice(n=%d,size=%d) chunk[%d] len=%d, want %d", c.n, c.size, i, len(ch), c.wantChunks[i])
+			}
+			total += len(ch)
+		}
+		if total != c.n {
+			t.Errorf("chunkSlice(n=%d,size=%d) covered %d elements, want %d", c.n, c.size, total, c.n)
+		}
+	}
+}

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -419,6 +419,13 @@ func (g *GitVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (
 	return mgmt.SummarizeUsage(g.repoPath, filter)
 }
 
+func (g *GitVault) ReadUsageEvents(ctx context.Context, filter mgmt.UsageFilter) ([]mgmt.UsageEvent, error) {
+	if err := g.cloneOrUpdate(ctx); err != nil {
+		return nil, err
+	}
+	return mgmt.ReadUsageEvents(g.repoPath, filter)
+}
+
 func (g *GitVault) ImportAuditEvents(ctx context.Context, events []mgmt.AuditEvent) error {
 	if len(events) == 0 {
 		return nil

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -419,6 +419,15 @@ func (g *GitVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (
 	return mgmt.SummarizeUsage(g.repoPath, filter)
 }
 
+func (g *GitVault) ImportAuditEvents(ctx context.Context, events []mgmt.AuditEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	return g.runInVaultTx(ctx, "Import audit events", func(vaultRoot string, _ mgmt.Actor) error {
+		return mgmt.AppendAuditEvents(vaultRoot, events)
+	})
+}
+
 func (g *GitVault) QueryAuditEvents(ctx context.Context, filter mgmt.AuditFilter) ([]mgmt.AuditEvent, error) {
 	if err := g.cloneOrUpdate(ctx); err != nil {
 		return nil, err

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -587,6 +587,101 @@ var AllAssetType = []AssetType{
 	AssetTypeClaudeCodePlugin,
 }
 
+// AssetUsageEventsAssetUsageEventsAssetUsageEventConnection includes the requested fields of the GraphQL type AssetUsageEventConnection.
+type AssetUsageEventsAssetUsageEventsAssetUsageEventConnection struct {
+	// Pagination data for this connection.
+	PageInfo AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo               `json:"pageInfo"`
+	Nodes    []AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent `json:"nodes"`
+}
+
+// GetPageInfo returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnection) GetPageInfo() AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo {
+	return v.PageInfo
+}
+
+// GetNodes returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnection) GetNodes() []AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent {
+	return v.Nodes
+}
+
+// AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent includes the requested fields of the GraphQL type AssetUsageEvent.
+// The GraphQL type's documentation follows.
+//
+// A single raw asset usage event.
+//
+// Exposes the individual rows behind the aggregated usage dashboards so an
+// external tool (the sx CLI) can export usage history losslessly — actor,
+// timestamp, and asset coordinates included.
+type AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent struct {
+	Timestamp    time.Time `json:"timestamp"`
+	ActorEmail   *string   `json:"actorEmail"`
+	AssetName    string    `json:"assetName"`
+	AssetVersion string    `json:"assetVersion"`
+	AssetType    string    `json:"assetType"`
+	BotName      *string   `json:"botName"`
+}
+
+// GetTimestamp returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.Timestamp, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetTimestamp() time.Time {
+	return v.Timestamp
+}
+
+// GetActorEmail returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.ActorEmail, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetActorEmail() *string {
+	return v.ActorEmail
+}
+
+// GetAssetName returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.AssetName, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetAssetName() string {
+	return v.AssetName
+}
+
+// GetAssetVersion returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.AssetVersion, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetAssetVersion() string {
+	return v.AssetVersion
+}
+
+// GetAssetType returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.AssetType, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetAssetType() string {
+	return v.AssetType
+}
+
+// GetBotName returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.BotName, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetBotName() *string {
+	return v.BotName
+}
+
+// AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+type AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor *string `json:"endCursor"`
+}
+
+// GetHasNextPage returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// GetEndCursor returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo) GetEndCursor() *string {
+	return v.EndCursor
+}
+
+// AssetUsageEventsResponse is returned by AssetUsageEvents on success.
+type AssetUsageEventsResponse struct {
+	AssetUsageEvents AssetUsageEventsAssetUsageEventsAssetUsageEventConnection `json:"assetUsageEvents"`
+}
+
+// GetAssetUsageEvents returns AssetUsageEventsResponse.AssetUsageEvents, and is useful for accessing the field via an interface.
+func (v *AssetUsageEventsResponse) GetAssetUsageEvents() AssetUsageEventsAssetUsageEventsAssetUsageEventConnection {
+	return v.AssetUsageEvents
+}
+
 // BotApiKeysBotManagedBot includes the requested fields of the GraphQL type ManagedBot.
 type BotApiKeysBotManagedBot struct {
 	ApiKeys []BotApiKeysBotManagedBotApiKeysBotApiKey `json:"apiKeys"`
@@ -1633,6 +1728,95 @@ func (v *GetMeUser) GetFirstName() string { return v.FirstName }
 // GetLastName returns GetMeUser.LastName, and is useful for accessing the field via an interface.
 func (v *GetMeUser) GetLastName() string { return v.LastName }
 
+type ImportAuditEventInput struct {
+	// When the event occurred (original timestamp)
+	Timestamp time.Time `json:"timestamp"`
+	// Email of the original actor
+	Actor *string `json:"actor"`
+	// Event name, stored verbatim (e.g. team.created)
+	Event string `json:"event"`
+	// Target type, stored verbatim (e.g. team, asset)
+	TargetType string `json:"targetType"`
+	// Target name/identifier
+	Target *string `json:"target"`
+	// Event-specific payload
+	Data *json.RawMessage `json:"data"`
+}
+
+// GetTimestamp returns ImportAuditEventInput.Timestamp, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventInput) GetTimestamp() time.Time { return v.Timestamp }
+
+// GetActor returns ImportAuditEventInput.Actor, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventInput) GetActor() *string { return v.Actor }
+
+// GetEvent returns ImportAuditEventInput.Event, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventInput) GetEvent() string { return v.Event }
+
+// GetTargetType returns ImportAuditEventInput.TargetType, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventInput) GetTargetType() string { return v.TargetType }
+
+// GetTarget returns ImportAuditEventInput.Target, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventInput) GetTarget() *string { return v.Target }
+
+// GetData returns ImportAuditEventInput.Data, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventInput) GetData() *json.RawMessage { return v.Data }
+
+// ImportAuditEventsImportAuditEventsImportAuditEventsMutation includes the requested fields of the GraphQL type ImportAuditEventsMutation.
+// The GraphQL type's documentation follows.
+//
+// Import historical audit events from another vault, verbatim.
+//
+// Preserves the original timestamp, actor (resolved by email within the org;
+// unresolved actors fall back to the caller with the original email kept in
+// data), event name, target type, and payload — so migrating a vault into
+// skills.new doesn't lose its audit trail.
+type ImportAuditEventsImportAuditEventsImportAuditEventsMutation struct {
+	ImportedCount int                                                                          `json:"importedCount"`
+	Errors        []ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType `json:"errors"`
+}
+
+// GetImportedCount returns ImportAuditEventsImportAuditEventsImportAuditEventsMutation.ImportedCount, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventsImportAuditEventsImportAuditEventsMutation) GetImportedCount() int {
+	return v.ImportedCount
+}
+
+// GetErrors returns ImportAuditEventsImportAuditEventsImportAuditEventsMutation.Errors, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventsImportAuditEventsImportAuditEventsMutation) GetErrors() []ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType {
+	return v.Errors
+}
+
+// ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType includes the requested fields of the GraphQL type ErrorType.
+type ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType struct {
+	Field    string   `json:"field"`
+	Messages []string `json:"messages"`
+}
+
+// GetField returns ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType.Field, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType) GetField() string {
+	return v.Field
+}
+
+// GetMessages returns ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType.Messages, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventsImportAuditEventsImportAuditEventsMutationErrorsErrorType) GetMessages() []string {
+	return v.Messages
+}
+
+// ImportAuditEventsResponse is returned by ImportAuditEvents on success.
+type ImportAuditEventsResponse struct {
+	// Import historical audit events from another vault, verbatim.
+	//
+	// Preserves the original timestamp, actor (resolved by email within the org;
+	// unresolved actors fall back to the caller with the original email kept in
+	// data), event name, target type, and payload — so migrating a vault into
+	// skills.new doesn't lose its audit trail.
+	ImportAuditEvents *ImportAuditEventsImportAuditEventsImportAuditEventsMutation `json:"importAuditEvents"`
+}
+
+// GetImportAuditEvents returns ImportAuditEventsResponse.ImportAuditEvents, and is useful for accessing the field via an interface.
+func (v *ImportAuditEventsResponse) GetImportAuditEvents() *ImportAuditEventsImportAuditEventsImportAuditEventsMutation {
+	return v.ImportAuditEvents
+}
+
 // InstallSkillToBotInstallSkillToBotInstallSkillToBotMutation includes the requested fields of the GraphQL type InstallSkillToBotMutation.
 type InstallSkillToBotInstallSkillToBotInstallSkillToBotMutation struct {
 	Success bool                                                                         `json:"success"`
@@ -2117,10 +2301,11 @@ func (v *RevokeBotRuntimeTokensRevokeBotRuntimeTokensRevokeBotRuntimeTokensMutat
 }
 
 type SetAssetInstallationsInput struct {
-	AssetName    string                        `json:"assetName"`
-	AssetVersion *string                       `json:"assetVersion"`
-	Repositories []RepositoryInstallationInput `json:"repositories"`
-	PersonalOnly *bool                         `json:"personalOnly"`
+	AssetName     string                        `json:"assetName"`
+	AssetVersion  *string                       `json:"assetVersion"`
+	Repositories  []RepositoryInstallationInput `json:"repositories"`
+	PersonalOnly  *bool                         `json:"personalOnly"`
+	Installations []AssetInstallationInput      `json:"installations"`
 }
 
 // GetAssetName returns SetAssetInstallationsInput.AssetName, and is useful for accessing the field via an interface.
@@ -2136,6 +2321,11 @@ func (v *SetAssetInstallationsInput) GetRepositories() []RepositoryInstallationI
 
 // GetPersonalOnly returns SetAssetInstallationsInput.PersonalOnly, and is useful for accessing the field via an interface.
 func (v *SetAssetInstallationsInput) GetPersonalOnly() *bool { return v.PersonalOnly }
+
+// GetInstallations returns SetAssetInstallationsInput.Installations, and is useful for accessing the field via an interface.
+func (v *SetAssetInstallationsInput) GetInstallations() []AssetInstallationInput {
+	return v.Installations
+}
 
 // SetAssetInstallationsResponse is returned by SetAssetInstallations on success.
 type SetAssetInstallationsResponse struct {
@@ -4018,6 +4208,38 @@ type __AssetGIDInput struct {
 // GetSearch returns __AssetGIDInput.Search, and is useful for accessing the field via an interface.
 func (v *__AssetGIDInput) GetSearch() string { return v.Search }
 
+// __AssetUsageEventsInput is used internally by genqlient
+type __AssetUsageEventsInput struct {
+	AssetName *string    `json:"assetName"`
+	AssetType *string    `json:"assetType"`
+	Actor     *string    `json:"actor"`
+	Since     *time.Time `json:"since"`
+	Until     *time.Time `json:"until"`
+	First     *int       `json:"first"`
+	After     *string    `json:"after"`
+}
+
+// GetAssetName returns __AssetUsageEventsInput.AssetName, and is useful for accessing the field via an interface.
+func (v *__AssetUsageEventsInput) GetAssetName() *string { return v.AssetName }
+
+// GetAssetType returns __AssetUsageEventsInput.AssetType, and is useful for accessing the field via an interface.
+func (v *__AssetUsageEventsInput) GetAssetType() *string { return v.AssetType }
+
+// GetActor returns __AssetUsageEventsInput.Actor, and is useful for accessing the field via an interface.
+func (v *__AssetUsageEventsInput) GetActor() *string { return v.Actor }
+
+// GetSince returns __AssetUsageEventsInput.Since, and is useful for accessing the field via an interface.
+func (v *__AssetUsageEventsInput) GetSince() *time.Time { return v.Since }
+
+// GetUntil returns __AssetUsageEventsInput.Until, and is useful for accessing the field via an interface.
+func (v *__AssetUsageEventsInput) GetUntil() *time.Time { return v.Until }
+
+// GetFirst returns __AssetUsageEventsInput.First, and is useful for accessing the field via an interface.
+func (v *__AssetUsageEventsInput) GetFirst() *int { return v.First }
+
+// GetAfter returns __AssetUsageEventsInput.After, and is useful for accessing the field via an interface.
+func (v *__AssetUsageEventsInput) GetAfter() *string { return v.After }
+
 // __BotApiKeysInput is used internally by genqlient
 type __BotApiKeysInput struct {
 	Slug string `json:"slug"`
@@ -4117,6 +4339,14 @@ type __FindUserInput struct {
 
 // GetTerm returns __FindUserInput.Term, and is useful for accessing the field via an interface.
 func (v *__FindUserInput) GetTerm() string { return v.Term }
+
+// __ImportAuditEventsInput is used internally by genqlient
+type __ImportAuditEventsInput struct {
+	Events []ImportAuditEventInput `json:"events"`
+}
+
+// GetEvents returns __ImportAuditEventsInput.Events, and is useful for accessing the field via an interface.
+func (v *__ImportAuditEventsInput) GetEvents() []ImportAuditEventInput { return v.Events }
 
 // __InstallSkillToBotInput is used internally by genqlient
 type __InstallSkillToBotInput struct {
@@ -4320,6 +4550,63 @@ func AssetGID(
 	}
 
 	data_ = &AssetGIDResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by AssetUsageEvents.
+const AssetUsageEvents_Operation = `
+query AssetUsageEvents ($assetName: String, $assetType: String, $actor: String, $since: DateTime, $until: DateTime, $first: Int, $after: String) {
+	assetUsageEvents(assetName: $assetName, assetType: $assetType, actor: $actor, since: $since, until: $until, first: $first, after: $after) {
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
+		nodes {
+			timestamp
+			actorEmail
+			assetName
+			assetVersion
+			assetType
+			botName
+		}
+	}
+}
+`
+
+func AssetUsageEvents(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	assetName *string,
+	assetType *string,
+	actor *string,
+	since *time.Time,
+	until *time.Time,
+	first *int,
+	after *string,
+) (data_ *AssetUsageEventsResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "AssetUsageEvents",
+		Query:  AssetUsageEvents_Operation,
+		Variables: &__AssetUsageEventsInput{
+			AssetName: assetName,
+			AssetType: assetType,
+			Actor:     actor,
+			Since:     since,
+			Until:     until,
+			First:     first,
+			After:     after,
+		},
+	}
+
+	data_ = &AssetUsageEventsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(
@@ -4782,6 +5069,44 @@ func GetMe(
 	}
 
 	data_ = &GetMeResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The mutation executed by ImportAuditEvents.
+const ImportAuditEvents_Operation = `
+mutation ImportAuditEvents ($events: [ImportAuditEventInput!]!) {
+	importAuditEvents(events: $events) {
+		importedCount
+		errors {
+			field
+			messages
+		}
+	}
+}
+`
+
+func ImportAuditEvents(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	events []ImportAuditEventInput,
+) (data_ *ImportAuditEventsResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "ImportAuditEvents",
+		Query:  ImportAuditEvents_Operation,
+		Variables: &__ImportAuditEventsInput{
+			Events: events,
+		},
+	}
+
+	data_ = &ImportAuditEventsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -2120,6 +2120,86 @@ func (v *McpToolInput) GetDescription() *string { return v.Description }
 // GetEstimatedTokens returns McpToolInput.EstimatedTokens, and is useful for accessing the field via an interface.
 func (v *McpToolInput) GetEstimatedTokens() *int { return v.EstimatedTokens }
 
+// OrgRepositoriesOrganizationOrganizationType includes the requested fields of the GraphQL type OrganizationType.
+type OrgRepositoriesOrganizationOrganizationType struct {
+	Repositories OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection `json:"repositories"`
+}
+
+// GetRepositories returns OrgRepositoriesOrganizationOrganizationType.Repositories, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationType) GetRepositories() OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection {
+	return v.Repositories
+}
+
+// OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection includes the requested fields of the GraphQL type RepositoryConnection.
+type OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection struct {
+	// Pagination data for this connection.
+	PageInfo OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo              `json:"pageInfo"`
+	Nodes    []OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType `json:"nodes"`
+}
+
+// GetPageInfo returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection) GetPageInfo() OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo {
+	return v.PageInfo
+}
+
+// GetNodes returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnection) GetNodes() []OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType {
+	return v.Nodes
+}
+
+// OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType includes the requested fields of the GraphQL type RepositoryType.
+type OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType struct {
+	Id    *string `json:"id"`
+	Owner string  `json:"owner"`
+	Name  string  `json:"name"`
+}
+
+// GetId returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType.Id, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType) GetId() *string {
+	return v.Id
+}
+
+// GetOwner returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType.Owner, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType) GetOwner() string {
+	return v.Owner
+}
+
+// GetName returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType.Name, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType) GetName() string {
+	return v.Name
+}
+
+// OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+type OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor *string `json:"endCursor"`
+}
+
+// GetHasNextPage returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// GetEndCursor returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo) GetEndCursor() *string {
+	return v.EndCursor
+}
+
+// OrgRepositoriesResponse is returned by OrgRepositories on success.
+type OrgRepositoriesResponse struct {
+	Organization OrgRepositoriesOrganizationOrganizationType `json:"organization"`
+}
+
+// GetOrganization returns OrgRepositoriesResponse.Organization, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesResponse) GetOrganization() OrgRepositoriesOrganizationOrganizationType {
+	return v.Organization
+}
+
 type RemoveAssetInstallationsInput struct {
 	AssetName string `json:"assetName"`
 	Delete    *bool  `json:"delete"`
@@ -4376,6 +4456,18 @@ func (v *__ListTeamsInput) GetTerm() *string { return v.Term }
 // GetMemberFirst returns __ListTeamsInput.MemberFirst, and is useful for accessing the field via an interface.
 func (v *__ListTeamsInput) GetMemberFirst() int { return v.MemberFirst }
 
+// __OrgRepositoriesInput is used internally by genqlient
+type __OrgRepositoriesInput struct {
+	First int     `json:"first"`
+	After *string `json:"after"`
+}
+
+// GetFirst returns __OrgRepositoriesInput.First, and is useful for accessing the field via an interface.
+func (v *__OrgRepositoriesInput) GetFirst() int { return v.First }
+
+// GetAfter returns __OrgRepositoriesInput.After, and is useful for accessing the field via an interface.
+func (v *__OrgRepositoriesInput) GetAfter() *string { return v.After }
+
 // __RemoveAssetInstallationsInput is used internally by genqlient
 type __RemoveAssetInstallationsInput struct {
 	Input RemoveAssetInstallationsInput `json:"input"`
@@ -5253,6 +5345,52 @@ func ListTeams(
 	}
 
 	data_ = &ListTeamsResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by OrgRepositories.
+const OrgRepositories_Operation = `
+query OrgRepositories ($first: Int!, $after: String) {
+	organization {
+		repositories(first: $first, after: $after) {
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+			nodes {
+				id
+				owner
+				name
+			}
+		}
+	}
+}
+`
+
+func OrgRepositories(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	first int,
+	after *string,
+) (data_ *OrgRepositoriesResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "OrgRepositories",
+		Query:  OrgRepositories_Operation,
+		Variables: &__OrgRepositoriesInput{
+			First: first,
+			After: after,
+		},
+	}
+
+	data_ = &OrgRepositoriesResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -698,6 +698,7 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnection) __premarshalJSON() 
 // AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent includes the requested fields of the GraphQL type Agent.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent struct {
 	Typename      *string                                                                                                `json:"__typename"`
+	Slug          string                                                                                                 `json:"slug"`
 	Name          string                                                                                                 `json:"name"`
 	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
 }
@@ -705,6 +706,11 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent struct {
 // GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent.Typename, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent) GetTypename() *string {
 	return v.Typename
+}
+
+// GetSlug returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent.Slug, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent) GetSlug() string {
+	return v.Slug
 }
 
 // GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent.Name, and is useful for accessing the field via an interface.
@@ -720,6 +726,7 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent) GetInstal
 // AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin includes the requested fields of the GraphQL type ClaudeCodePlugin.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin struct {
 	Typename      *string                                                                                                `json:"__typename"`
+	Slug          string                                                                                                 `json:"slug"`
 	Name          string                                                                                                 `json:"name"`
 	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
 }
@@ -727,6 +734,11 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin str
 // GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Typename, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetTypename() *string {
 	return v.Typename
+}
+
+// GetSlug returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Slug, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetSlug() string {
+	return v.Slug
 }
 
 // GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Name, and is useful for accessing the field via an interface.
@@ -742,6 +754,7 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin
 // AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand includes the requested fields of the GraphQL type Command.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand struct {
 	Typename      *string                                                                                                `json:"__typename"`
+	Slug          string                                                                                                 `json:"slug"`
 	Name          string                                                                                                 `json:"name"`
 	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
 }
@@ -749,6 +762,11 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand struct {
 // GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand.Typename, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand) GetTypename() *string {
 	return v.Typename
+}
+
+// GetSlug returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand.Slug, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand) GetSlug() string {
+	return v.Slug
 }
 
 // GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand.Name, and is useful for accessing the field via an interface.
@@ -764,6 +782,7 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand) GetInst
 // AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook includes the requested fields of the GraphQL type Hook.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook struct {
 	Typename      *string                                                                                                `json:"__typename"`
+	Slug          string                                                                                                 `json:"slug"`
 	Name          string                                                                                                 `json:"name"`
 	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
 }
@@ -772,6 +791,9 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook struct {
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) GetTypename() *string {
 	return v.Typename
 }
+
+// GetSlug returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook.Slug, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) GetSlug() string { return v.Slug }
 
 // GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook.Name, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) GetName() string { return v.Name }
@@ -784,6 +806,7 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) GetInstall
 // AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer includes the requested fields of the GraphQL type McpServer.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer struct {
 	Typename      *string                                                                                                `json:"__typename"`
+	Slug          string                                                                                                 `json:"slug"`
 	Name          string                                                                                                 `json:"name"`
 	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
 }
@@ -791,6 +814,11 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer struct {
 // GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer.Typename, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer) GetTypename() *string {
 	return v.Typename
+}
+
+// GetSlug returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer.Slug, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer) GetSlug() string {
+	return v.Slug
 }
 
 // GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer.Name, and is useful for accessing the field via an interface.
@@ -806,6 +834,7 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer) GetIn
 // AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule includes the requested fields of the GraphQL type Rule.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule struct {
 	Typename      *string                                                                                                `json:"__typename"`
+	Slug          string                                                                                                 `json:"slug"`
 	Name          string                                                                                                 `json:"name"`
 	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
 }
@@ -814,6 +843,9 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule struct {
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) GetTypename() *string {
 	return v.Typename
 }
+
+// GetSlug returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule.Slug, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) GetSlug() string { return v.Slug }
 
 // GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule.Name, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) GetName() string { return v.Name }
@@ -829,6 +861,7 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) GetInstall
 // GraphQL type for skill.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill struct {
 	Typename      *string                                                                                                `json:"__typename"`
+	Slug          string                                                                                                 `json:"slug"`
 	Name          string                                                                                                 `json:"name"`
 	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
 }
@@ -836,6 +869,11 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill struct {
 // GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill.Typename, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill) GetTypename() *string {
 	return v.Typename
+}
+
+// GetSlug returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill.Slug, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill) GetSlug() string {
+	return v.Slug
 }
 
 // GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill.Name, and is useful for accessing the field via an interface.
@@ -865,6 +903,8 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset interface
 	implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
 	GetTypename() *string
+	// GetSlug returns the interface-field "slug" from its implementation.
+	GetSlug() string
 	// GetName returns the interface-field "name" from its implementation.
 	GetName() string
 	// GetInstallations returns the interface-field "installations" from its implementation.
@@ -1089,7 +1129,6 @@ type AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEve
 	AssetName    string    `json:"assetName"`
 	AssetVersion string    `json:"assetVersion"`
 	AssetType    string    `json:"assetType"`
-	BotName      *string   `json:"botName"`
 }
 
 // GetTimestamp returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.Timestamp, and is useful for accessing the field via an interface.
@@ -1115,11 +1154,6 @@ func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsag
 // GetAssetType returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.AssetType, and is useful for accessing the field via an interface.
 func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetAssetType() string {
 	return v.AssetType
-}
-
-// GetBotName returns AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent.BotName, and is useful for accessing the field via an interface.
-func (v *AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionNodesAssetUsageEvent) GetBotName() *string {
-	return v.BotName
 }
 
 // AssetUsageEventsAssetUsageEventsAssetUsageEventConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
@@ -4155,7 +4189,14 @@ func (v *VaultAssetsVault) GetAssets() VaultAssetsVaultAssetsVaultAssetsConnecti
 //
 // Paginated list of vault assets.
 type VaultAssetsVaultAssetsVaultAssetsConnection struct {
-	Nodes []VaultAssetsVaultAssetsVaultAssetsConnectionNodesVaultAsset `json:"-"`
+	// Pagination data for this connection.
+	PageInfo VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo          `json:"pageInfo"`
+	Nodes    []VaultAssetsVaultAssetsVaultAssetsConnectionNodesVaultAsset `json:"-"`
+}
+
+// GetPageInfo returns VaultAssetsVaultAssetsVaultAssetsConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *VaultAssetsVaultAssetsVaultAssetsConnection) GetPageInfo() VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo {
+	return v.PageInfo
 }
 
 // GetNodes returns VaultAssetsVaultAssetsVaultAssetsConnection.Nodes, and is useful for accessing the field via an interface.
@@ -4203,6 +4244,8 @@ func (v *VaultAssetsVaultAssetsVaultAssetsConnection) UnmarshalJSON(b []byte) er
 }
 
 type __premarshalVaultAssetsVaultAssetsVaultAssetsConnection struct {
+	PageInfo VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo `json:"pageInfo"`
+
 	Nodes []json.RawMessage `json:"nodes"`
 }
 
@@ -4217,6 +4260,7 @@ func (v *VaultAssetsVaultAssetsVaultAssetsConnection) MarshalJSON() ([]byte, err
 func (v *VaultAssetsVaultAssetsVaultAssetsConnection) __premarshalJSON() (*__premarshalVaultAssetsVaultAssetsVaultAssetsConnection, error) {
 	var retval __premarshalVaultAssetsVaultAssetsVaultAssetsConnection
 
+	retval.PageInfo = v.PageInfo
 	{
 
 		dst := &retval.Nodes
@@ -4743,6 +4787,27 @@ func __marshalVaultAssetsVaultAssetsVaultAssetsConnectionNodesVaultAsset(v *Vaul
 	}
 }
 
+// VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+type VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor *string `json:"endCursor"`
+}
+
+// GetHasNextPage returns VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// GetEndCursor returns VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *VaultAssetsVaultAssetsVaultAssetsConnectionPageInfo) GetEndCursor() *string {
+	return v.EndCursor
+}
+
 // __AssetAuditLogInput is used internally by genqlient
 type __AssetAuditLogInput struct {
 	First *int    `json:"first"`
@@ -5038,12 +5103,16 @@ func (v *__VaultAssetsByNameInput) GetSearch() string { return v.Search }
 // __VaultAssetsInput is used internally by genqlient
 type __VaultAssetsInput struct {
 	First     *int      `json:"first"`
+	After     *string   `json:"after"`
 	AssetType AssetType `json:"assetType"`
 	Search    *string   `json:"search"`
 }
 
 // GetFirst returns __VaultAssetsInput.First, and is useful for accessing the field via an interface.
 func (v *__VaultAssetsInput) GetFirst() *int { return v.First }
+
+// GetAfter returns __VaultAssetsInput.After, and is useful for accessing the field via an interface.
+func (v *__VaultAssetsInput) GetAfter() *string { return v.After }
 
 // GetAssetType returns __VaultAssetsInput.AssetType, and is useful for accessing the field via an interface.
 func (v *__VaultAssetsInput) GetAssetType() AssetType { return v.AssetType }
@@ -5149,6 +5218,7 @@ query AssetInstallations ($search: String!) {
 		assets(search: $search, first: 50) {
 			nodes {
 				__typename
+				slug
 				name
 				installations {
 					entityType
@@ -5201,7 +5271,6 @@ query AssetUsageEvents ($assetName: String, $assetType: String, $actor: String, 
 			assetName
 			assetVersion
 			assetType
-			botName
 		}
 	}
 }
@@ -6285,9 +6354,13 @@ func UpdateTeam(
 
 // The query executed by VaultAssets.
 const VaultAssets_Operation = `
-query VaultAssets ($first: Int, $assetType: AssetType!, $search: String) {
+query VaultAssets ($first: Int, $after: String, $assetType: AssetType!, $search: String) {
 	vault {
-		assets(first: $first, type: $assetType, search: $search) {
+		assets(first: $first, after: $after, type: $assetType, search: $search) {
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
 			nodes {
 				__typename
 				slug
@@ -6307,6 +6380,7 @@ func VaultAssets(
 	ctx_ context.Context,
 	client_ graphql.Client,
 	first *int,
+	after *string,
 	assetType AssetType,
 	search *string,
 ) (data_ *VaultAssetsResponse, err_ error) {
@@ -6315,6 +6389,7 @@ func VaultAssets(
 		Query:  VaultAssets_Operation,
 		Variables: &__VaultAssetsInput{
 			First:     first,
+			After:     after,
 			AssetType: assetType,
 			Search:    search,
 		},

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -1043,11 +1043,10 @@ func __marshalAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset(
 //
 // Installation location for a vault asset.
 type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation struct {
-	EntityType         VaultAssetInstallationEntityType `json:"entityType"`
-	EntityName         string                           `json:"entityName"`
-	EntityId           *string                          `json:"entityId"`
-	MonoRepoConfigId   *string                          `json:"monoRepoConfigId"`
-	MonoRepoConfigName *string                          `json:"monoRepoConfigName"`
+	EntityType       VaultAssetInstallationEntityType `json:"entityType"`
+	EntityName       string                           `json:"entityName"`
+	EntityId         *string                          `json:"entityId"`
+	MonoRepoConfigId *string                          `json:"monoRepoConfigId"`
 }
 
 // GetEntityType returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityType, and is useful for accessing the field via an interface.
@@ -1068,11 +1067,6 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstal
 // GetMonoRepoConfigId returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.MonoRepoConfigId, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetMonoRepoConfigId() *string {
 	return v.MonoRepoConfigId
-}
-
-// GetMonoRepoConfigName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.MonoRepoConfigName, and is useful for accessing the field via an interface.
-func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetMonoRepoConfigName() *string {
-	return v.MonoRepoConfigName
 }
 
 type AssetType string
@@ -5278,7 +5272,6 @@ query AssetInstallations ($search: String!) {
 					entityName
 					entityId
 					monoRepoConfigId
-					monoRepoConfigName
 				}
 			}
 		}

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -1046,6 +1046,7 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallati
 	EntityType         VaultAssetInstallationEntityType `json:"entityType"`
 	EntityName         string                           `json:"entityName"`
 	EntityId           *string                          `json:"entityId"`
+	MonoRepoConfigId   *string                          `json:"monoRepoConfigId"`
 	MonoRepoConfigName *string                          `json:"monoRepoConfigName"`
 }
 
@@ -1062,6 +1063,11 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstal
 // GetEntityId returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityId, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetEntityId() *string {
 	return v.EntityId
+}
+
+// GetMonoRepoConfigId returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.MonoRepoConfigId, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetMonoRepoConfigId() *string {
+	return v.MonoRepoConfigId
 }
 
 // GetMonoRepoConfigName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.MonoRepoConfigName, and is useful for accessing the field via an interface.
@@ -2852,6 +2858,45 @@ type RenameAssetResponse struct {
 // GetRenameAsset returns RenameAssetResponse.RenameAsset, and is useful for accessing the field via an interface.
 func (v *RenameAssetResponse) GetRenameAsset() *RenameAssetRenameAssetRenameAssetMutation {
 	return v.RenameAsset
+}
+
+// RepoMonoRepoConfigsRepositoryRepositoryType includes the requested fields of the GraphQL type RepositoryType.
+type RepoMonoRepoConfigsRepositoryRepositoryType struct {
+	MonoRepoConfigs []RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType `json:"monoRepoConfigs"`
+}
+
+// GetMonoRepoConfigs returns RepoMonoRepoConfigsRepositoryRepositoryType.MonoRepoConfigs, and is useful for accessing the field via an interface.
+func (v *RepoMonoRepoConfigsRepositoryRepositoryType) GetMonoRepoConfigs() []RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType {
+	return v.MonoRepoConfigs
+}
+
+// RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType includes the requested fields of the GraphQL type MonoRepoConfigType.
+// The GraphQL type's documentation follows.
+//
+// GraphQL type for monorepo configuration
+type RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType struct {
+	Id                       *string   `json:"id"`
+	SourcePathPrefixIncludes []*string `json:"sourcePathPrefixIncludes"`
+}
+
+// GetId returns RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType.Id, and is useful for accessing the field via an interface.
+func (v *RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType) GetId() *string {
+	return v.Id
+}
+
+// GetSourcePathPrefixIncludes returns RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType.SourcePathPrefixIncludes, and is useful for accessing the field via an interface.
+func (v *RepoMonoRepoConfigsRepositoryRepositoryTypeMonoRepoConfigsMonoRepoConfigType) GetSourcePathPrefixIncludes() []*string {
+	return v.SourcePathPrefixIncludes
+}
+
+// RepoMonoRepoConfigsResponse is returned by RepoMonoRepoConfigs on success.
+type RepoMonoRepoConfigsResponse struct {
+	Repository *RepoMonoRepoConfigsRepositoryRepositoryType `json:"repository"`
+}
+
+// GetRepository returns RepoMonoRepoConfigsResponse.Repository, and is useful for accessing the field via an interface.
+func (v *RepoMonoRepoConfigsResponse) GetRepository() *RepoMonoRepoConfigsRepositoryRepositoryType {
+	return v.Repository
 }
 
 type RepositoryInstallationInput struct {
@@ -5040,6 +5085,14 @@ type __RenameAssetInput struct {
 // GetInput returns __RenameAssetInput.Input, and is useful for accessing the field via an interface.
 func (v *__RenameAssetInput) GetInput() RenameAssetInput { return v.Input }
 
+// __RepoMonoRepoConfigsInput is used internally by genqlient
+type __RepoMonoRepoConfigsInput struct {
+	Id string `json:"id"`
+}
+
+// GetId returns __RepoMonoRepoConfigsInput.Id, and is useful for accessing the field via an interface.
+func (v *__RepoMonoRepoConfigsInput) GetId() string { return v.Id }
+
 // __RevokeBotRuntimeTokensInput is used internally by genqlient
 type __RevokeBotRuntimeTokensInput struct {
 	BotId string `json:"botId"`
@@ -5224,6 +5277,7 @@ query AssetInstallations ($search: String!) {
 					entityType
 					entityName
 					entityId
+					monoRepoConfigId
 					monoRepoConfigName
 				}
 			}
@@ -6107,6 +6161,43 @@ func RenameAsset(
 	}
 
 	data_ = &RenameAssetResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by RepoMonoRepoConfigs.
+const RepoMonoRepoConfigs_Operation = `
+query RepoMonoRepoConfigs ($id: ID!) {
+	repository(id: $id) {
+		monoRepoConfigs {
+			id
+			sourcePathPrefixIncludes
+		}
+	}
+}
+`
+
+func RepoMonoRepoConfigs(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	id string,
+) (data_ *RepoMonoRepoConfigsResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "RepoMonoRepoConfigs",
+		Query:  RepoMonoRepoConfigs_Operation,
+		Variables: &__RepoMonoRepoConfigsInput{
+			Id: id,
+		},
+	}
+
+	data_ = &RepoMonoRepoConfigsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -13,7 +13,14 @@ import (
 
 // AssetAuditLogAssetAuditLogAssetAuditEventConnection includes the requested fields of the GraphQL type AssetAuditEventConnection.
 type AssetAuditLogAssetAuditLogAssetAuditEventConnection struct {
-	Nodes []AssetAuditLogAssetAuditLogAssetAuditEventConnectionNodesAssetAuditEvent `json:"nodes"`
+	// Pagination data for this connection.
+	PageInfo AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo               `json:"pageInfo"`
+	Nodes    []AssetAuditLogAssetAuditLogAssetAuditEventConnectionNodesAssetAuditEvent `json:"nodes"`
+}
+
+// GetPageInfo returns AssetAuditLogAssetAuditLogAssetAuditEventConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *AssetAuditLogAssetAuditLogAssetAuditEventConnection) GetPageInfo() AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo {
+	return v.PageInfo
 }
 
 // GetNodes returns AssetAuditLogAssetAuditLogAssetAuditEventConnection.Nodes, and is useful for accessing the field via an interface.
@@ -71,6 +78,27 @@ func (v *AssetAuditLogAssetAuditLogAssetAuditEventConnectionNodesAssetAuditEvent
 // GetData returns AssetAuditLogAssetAuditLogAssetAuditEventConnectionNodesAssetAuditEvent.Data, and is useful for accessing the field via an interface.
 func (v *AssetAuditLogAssetAuditLogAssetAuditEventConnectionNodesAssetAuditEvent) GetData() *json.RawMessage {
 	return v.Data
+}
+
+// AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+type AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor *string `json:"endCursor"`
+}
+
+// GetHasNextPage returns AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// GetEndCursor returns AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *AssetAuditLogAssetAuditLogAssetAuditEventConnectionPageInfo) GetEndCursor() *string {
+	return v.EndCursor
 }
 
 // AssetAuditLogResponse is returned by AssetAuditLog on success.
@@ -557,6 +585,449 @@ func (v *AssetInstallationInput) GetMonoRepoConfigId() *string { return v.MonoRe
 
 // GetMonoRepoConfigName returns AssetInstallationInput.MonoRepoConfigName, and is useful for accessing the field via an interface.
 func (v *AssetInstallationInput) GetMonoRepoConfigName() *string { return v.MonoRepoConfigName }
+
+// AssetInstallationsResponse is returned by AssetInstallations on success.
+type AssetInstallationsResponse struct {
+	Vault AssetInstallationsVault `json:"vault"`
+}
+
+// GetVault returns AssetInstallationsResponse.Vault, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsResponse) GetVault() AssetInstallationsVault { return v.Vault }
+
+// AssetInstallationsVault includes the requested fields of the GraphQL type Vault.
+// The GraphQL type's documentation follows.
+//
+// Vault containing assets.
+type AssetInstallationsVault struct {
+	Assets AssetInstallationsVaultAssetsVaultAssetsConnection `json:"assets"`
+}
+
+// GetAssets returns AssetInstallationsVault.Assets, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVault) GetAssets() AssetInstallationsVaultAssetsVaultAssetsConnection {
+	return v.Assets
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnection includes the requested fields of the GraphQL type VaultAssetsConnection.
+// The GraphQL type's documentation follows.
+//
+// Paginated list of vault assets.
+type AssetInstallationsVaultAssetsVaultAssetsConnection struct {
+	Nodes []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset `json:"-"`
+}
+
+// GetNodes returns AssetInstallationsVaultAssetsVaultAssetsConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnection) GetNodes() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset {
+	return v.Nodes
+}
+
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnection) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AssetInstallationsVaultAssetsVaultAssetsConnection
+		Nodes []json.RawMessage `json:"nodes"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AssetInstallationsVaultAssetsVaultAssetsConnection = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Nodes
+		src := firstPass.Nodes
+		*dst = make(
+			[]AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = __unmarshalAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"unable to unmarshal AssetInstallationsVaultAssetsVaultAssetsConnection.Nodes: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalAssetInstallationsVaultAssetsVaultAssetsConnection struct {
+	Nodes []json.RawMessage `json:"nodes"`
+}
+
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnection) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnection) __premarshalJSON() (*__premarshalAssetInstallationsVaultAssetsVaultAssetsConnection, error) {
+	var retval __premarshalAssetInstallationsVaultAssetsVaultAssetsConnection
+
+	{
+
+		dst := &retval.Nodes
+		src := v.Nodes
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"unable to marshal AssetInstallationsVaultAssetsVaultAssetsConnection.Nodes: %w", err)
+			}
+		}
+	}
+	return &retval, nil
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent includes the requested fields of the GraphQL type Agent.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent struct {
+	Typename      *string                                                                                                `json:"__typename"`
+	Name          string                                                                                                 `json:"name"`
+	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
+}
+
+// GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent.Typename, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent.Name, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent) GetName() string {
+	return v.Name
+}
+
+// GetInstallations returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent.Installations, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent) GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation {
+	return v.Installations
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin includes the requested fields of the GraphQL type ClaudeCodePlugin.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin struct {
+	Typename      *string                                                                                                `json:"__typename"`
+	Name          string                                                                                                 `json:"name"`
+	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
+}
+
+// GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Typename, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Name, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetName() string {
+	return v.Name
+}
+
+// GetInstallations returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Installations, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation {
+	return v.Installations
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand includes the requested fields of the GraphQL type Command.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand struct {
+	Typename      *string                                                                                                `json:"__typename"`
+	Name          string                                                                                                 `json:"name"`
+	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
+}
+
+// GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand.Typename, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand.Name, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand) GetName() string {
+	return v.Name
+}
+
+// GetInstallations returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand.Installations, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand) GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation {
+	return v.Installations
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook includes the requested fields of the GraphQL type Hook.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook struct {
+	Typename      *string                                                                                                `json:"__typename"`
+	Name          string                                                                                                 `json:"name"`
+	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
+}
+
+// GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook.Typename, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook.Name, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) GetName() string { return v.Name }
+
+// GetInstallations returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook.Installations, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation {
+	return v.Installations
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer includes the requested fields of the GraphQL type McpServer.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer struct {
+	Typename      *string                                                                                                `json:"__typename"`
+	Name          string                                                                                                 `json:"name"`
+	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
+}
+
+// GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer.Typename, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer.Name, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer) GetName() string {
+	return v.Name
+}
+
+// GetInstallations returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer.Installations, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer) GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation {
+	return v.Installations
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule includes the requested fields of the GraphQL type Rule.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule struct {
+	Typename      *string                                                                                                `json:"__typename"`
+	Name          string                                                                                                 `json:"name"`
+	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
+}
+
+// GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule.Typename, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule.Name, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) GetName() string { return v.Name }
+
+// GetInstallations returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule.Installations, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation {
+	return v.Installations
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill includes the requested fields of the GraphQL type Skill.
+// The GraphQL type's documentation follows.
+//
+// GraphQL type for skill.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill struct {
+	Typename      *string                                                                                                `json:"__typename"`
+	Name          string                                                                                                 `json:"name"`
+	Installations []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation `json:"installations"`
+}
+
+// GetTypename returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill.Typename, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill.Name, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill) GetName() string {
+	return v.Name
+}
+
+// GetInstallations returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill.Installations, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill) GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation {
+	return v.Installations
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset includes the requested fields of the GraphQL interface VaultAsset.
+//
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset is implemented by the following types:
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill
+// The GraphQL type's documentation follows.
+//
+// Asset in the vault (Skill, MCP, Agent, etc.).
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset interface {
+	implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+	// GetName returns the interface-field "name" from its implementation.
+	GetName() string
+	// GetInstallations returns the interface-field "installations" from its implementation.
+	GetInstallations() []AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation
+}
+
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent) implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand) implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook) implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer) implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule) implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill) implementsGraphQLInterfaceAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+
+func __unmarshalAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset(b []byte, v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Agent":
+		*v = new(AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent)
+		return json.Unmarshal(b, *v)
+	case "ClaudeCodePlugin":
+		*v = new(AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin)
+		return json.Unmarshal(b, *v)
+	case "Command":
+		*v = new(AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand)
+		return json.Unmarshal(b, *v)
+	case "Hook":
+		*v = new(AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook)
+		return json.Unmarshal(b, *v)
+	case "McpServer":
+		*v = new(AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer)
+		return json.Unmarshal(b, *v)
+	case "Rule":
+		*v = new(AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule)
+		return json.Unmarshal(b, *v)
+	case "Skill":
+		*v = new(AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing VaultAsset.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalAssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset(v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent:
+		typename = "Agent"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AssetInstallationsVaultAssetsVaultAssetsConnectionNodesAgent
+		}{typename, v}
+		return json.Marshal(result)
+	case *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin:
+		typename = "ClaudeCodePlugin"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AssetInstallationsVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin
+		}{typename, v}
+		return json.Marshal(result)
+	case *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand:
+		typename = "Command"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AssetInstallationsVaultAssetsVaultAssetsConnectionNodesCommand
+		}{typename, v}
+		return json.Marshal(result)
+	case *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook:
+		typename = "Hook"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AssetInstallationsVaultAssetsVaultAssetsConnectionNodesHook
+		}{typename, v}
+		return json.Marshal(result)
+	case *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer:
+		typename = "McpServer"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AssetInstallationsVaultAssetsVaultAssetsConnectionNodesMcpServer
+		}{typename, v}
+		return json.Marshal(result)
+	case *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule:
+		typename = "Rule"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AssetInstallationsVaultAssetsVaultAssetsConnectionNodesRule
+		}{typename, v}
+		return json.Marshal(result)
+	case *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill:
+		typename = "Skill"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*AssetInstallationsVaultAssetsVaultAssetsConnectionNodesSkill
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset: "%T"`, v)
+	}
+}
+
+// AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation includes the requested fields of the GraphQL type VaultAssetInstallation.
+// The GraphQL type's documentation follows.
+//
+// Installation location for a vault asset.
+type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation struct {
+	EntityType         VaultAssetInstallationEntityType `json:"entityType"`
+	EntityName         string                           `json:"entityName"`
+	EntityId           *string                          `json:"entityId"`
+	MonoRepoConfigName *string                          `json:"monoRepoConfigName"`
+}
+
+// GetEntityType returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityType, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetEntityType() VaultAssetInstallationEntityType {
+	return v.EntityType
+}
+
+// GetEntityName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityName, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetEntityName() string {
+	return v.EntityName
+}
+
+// GetEntityId returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityId, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetEntityId() *string {
+	return v.EntityId
+}
+
+// GetMonoRepoConfigName returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.MonoRepoConfigName, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetMonoRepoConfigName() *string {
+	return v.MonoRepoConfigName
+}
 
 type AssetType string
 
@@ -4274,11 +4745,15 @@ func __marshalVaultAssetsVaultAssetsVaultAssetsConnectionNodesVaultAsset(v *Vaul
 
 // __AssetAuditLogInput is used internally by genqlient
 type __AssetAuditLogInput struct {
-	First *int `json:"first"`
+	First *int    `json:"first"`
+	After *string `json:"after"`
 }
 
 // GetFirst returns __AssetAuditLogInput.First, and is useful for accessing the field via an interface.
 func (v *__AssetAuditLogInput) GetFirst() *int { return v.First }
+
+// GetAfter returns __AssetAuditLogInput.After, and is useful for accessing the field via an interface.
+func (v *__AssetAuditLogInput) GetAfter() *string { return v.After }
 
 // __AssetGIDInput is used internally by genqlient
 type __AssetGIDInput struct {
@@ -4287,6 +4762,14 @@ type __AssetGIDInput struct {
 
 // GetSearch returns __AssetGIDInput.Search, and is useful for accessing the field via an interface.
 func (v *__AssetGIDInput) GetSearch() string { return v.Search }
+
+// __AssetInstallationsInput is used internally by genqlient
+type __AssetInstallationsInput struct {
+	Search string `json:"search"`
+}
+
+// GetSearch returns __AssetInstallationsInput.Search, and is useful for accessing the field via an interface.
+func (v *__AssetInstallationsInput) GetSearch() string { return v.Search }
 
 // __AssetUsageEventsInput is used internally by genqlient
 type __AssetUsageEventsInput struct {
@@ -4570,8 +5053,12 @@ func (v *__VaultAssetsInput) GetSearch() *string { return v.Search }
 
 // The query executed by AssetAuditLog.
 const AssetAuditLog_Operation = `
-query AssetAuditLog ($first: Int) {
-	assetAuditLog(first: $first) {
+query AssetAuditLog ($first: Int, $after: String) {
+	assetAuditLog(first: $first, after: $after) {
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
 		nodes {
 			id
 			date
@@ -4590,12 +5077,14 @@ func AssetAuditLog(
 	ctx_ context.Context,
 	client_ graphql.Client,
 	first *int,
+	after *string,
 ) (data_ *AssetAuditLogResponse, err_ error) {
 	req_ := &graphql.Request{
 		OpName: "AssetAuditLog",
 		Query:  AssetAuditLog_Operation,
 		Variables: &__AssetAuditLogInput{
 			First: first,
+			After: after,
 		},
 	}
 
@@ -4642,6 +5131,51 @@ func AssetGID(
 	}
 
 	data_ = &AssetGIDResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by AssetInstallations.
+const AssetInstallations_Operation = `
+query AssetInstallations ($search: String!) {
+	vault {
+		assets(search: $search, first: 50) {
+			nodes {
+				__typename
+				name
+				installations {
+					entityType
+					entityName
+					entityId
+					monoRepoConfigName
+				}
+			}
+		}
+	}
+}
+`
+
+func AssetInstallations(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	search string,
+) (data_ *AssetInstallationsResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "AssetInstallations",
+		Query:  AssetInstallations_Operation,
+		Variables: &__AssetInstallationsInput{
+			Search: search,
+		},
+	}
+
+	data_ = &AssetInstallationsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/vault/graphql/operations/asset_audit_log.graphql
+++ b/internal/vault/graphql/operations/asset_audit_log.graphql
@@ -1,5 +1,9 @@
-query AssetAuditLog($first: Int) {
-  assetAuditLog(first: $first) {
+query AssetAuditLog($first: Int, $after: String) {
+  assetAuditLog(first: $first, after: $after) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
     nodes {
       id
       date

--- a/internal/vault/graphql/operations/asset_installations.graphql
+++ b/internal/vault/graphql/operations/asset_installations.graphql
@@ -1,0 +1,15 @@
+query AssetInstallations($search: String!) {
+  vault {
+    assets(search: $search, first: 50) {
+      nodes {
+        name
+        installations {
+          entityType
+          entityName
+          entityId
+          monoRepoConfigName
+        }
+      }
+    }
+  }
+}

--- a/internal/vault/graphql/operations/asset_installations.graphql
+++ b/internal/vault/graphql/operations/asset_installations.graphql
@@ -2,6 +2,7 @@ query AssetInstallations($search: String!) {
   vault {
     assets(search: $search, first: 50) {
       nodes {
+        slug
         name
         installations {
           entityType

--- a/internal/vault/graphql/operations/asset_installations.graphql
+++ b/internal/vault/graphql/operations/asset_installations.graphql
@@ -9,7 +9,6 @@ query AssetInstallations($search: String!) {
           entityName
           entityId
           monoRepoConfigId
-          monoRepoConfigName
         }
       }
     }

--- a/internal/vault/graphql/operations/asset_installations.graphql
+++ b/internal/vault/graphql/operations/asset_installations.graphql
@@ -8,6 +8,7 @@ query AssetInstallations($search: String!) {
           entityType
           entityName
           entityId
+          monoRepoConfigId
           monoRepoConfigName
         }
       }

--- a/internal/vault/graphql/operations/asset_usage_events.graphql
+++ b/internal/vault/graphql/operations/asset_usage_events.graphql
@@ -26,7 +26,6 @@ query AssetUsageEvents(
       assetName
       assetVersion
       assetType
-      botName
     }
   }
 }

--- a/internal/vault/graphql/operations/asset_usage_events.graphql
+++ b/internal/vault/graphql/operations/asset_usage_events.graphql
@@ -1,0 +1,32 @@
+query AssetUsageEvents(
+  $assetName: String
+  $assetType: String
+  $actor: String
+  $since: DateTime
+  $until: DateTime
+  $first: Int
+  $after: String
+) {
+  assetUsageEvents(
+    assetName: $assetName
+    assetType: $assetType
+    actor: $actor
+    since: $since
+    until: $until
+    first: $first
+    after: $after
+  ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      timestamp
+      actorEmail
+      assetName
+      assetVersion
+      assetType
+      botName
+    }
+  }
+}

--- a/internal/vault/graphql/operations/import_audit_events.graphql
+++ b/internal/vault/graphql/operations/import_audit_events.graphql
@@ -1,0 +1,9 @@
+mutation ImportAuditEvents($events: [ImportAuditEventInput!]!) {
+  importAuditEvents(events: $events) {
+    importedCount
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/internal/vault/graphql/operations/org_repositories.graphql
+++ b/internal/vault/graphql/operations/org_repositories.graphql
@@ -1,0 +1,15 @@
+query OrgRepositories($first: Int!, $after: String) {
+  organization {
+    repositories(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        owner
+        name
+      }
+    }
+  }
+}

--- a/internal/vault/graphql/operations/repo_mono_configs.graphql
+++ b/internal/vault/graphql/operations/repo_mono_configs.graphql
@@ -1,0 +1,8 @@
+query RepoMonoRepoConfigs($id: ID!) {
+  repository(id: $id) {
+    monoRepoConfigs {
+      id
+      sourcePathPrefixIncludes
+    }
+  }
+}

--- a/internal/vault/graphql/operations/vault_assets.graphql
+++ b/internal/vault/graphql/operations/vault_assets.graphql
@@ -1,6 +1,10 @@
-query VaultAssets($first: Int, $assetType: AssetType!, $search: String) {
+query VaultAssets($first: Int, $after: String, $assetType: AssetType!, $search: String) {
   vault {
-    assets(first: $first, type: $assetType, search: $search) {
+    assets(first: $first, after: $after, type: $assetType, search: $search) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
       nodes {
         slug
         type

--- a/internal/vault/graphql/schema.graphql
+++ b/internal/vault/graphql/schema.graphql
@@ -4164,6 +4164,40 @@ type AssetAuditEventEdge {
   node: AssetAuditEvent!
 }
 
+"""
+A single raw asset usage event.
+
+Exposes the individual rows behind the aggregated usage dashboards so an
+external tool (the sx CLI) can export usage history losslessly — actor,
+timestamp, and asset coordinates included.
+"""
+type AssetUsageEvent {
+  timestamp: DateTime!
+  actorEmail: String
+  assetName: String!
+  assetVersion: String!
+  assetType: String!
+  botName: String
+}
+
+type AssetUsageEventConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [AssetUsageEventEdge!]!
+  nodes: [AssetUsageEvent!]!
+
+  """Total count of edges."""
+  totalCount: Int!
+}
+
+type AssetUsageEventEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: AssetUsageEvent!
+}
+
 """Source metadata for a Pulse-managed asset."""
 type AssetManagedSource implements AssetSource {
   """Whether this asset is read-only"""
@@ -4825,6 +4859,30 @@ type Query {
     before: String
     after: String
   ): AssetAuditEventConnection!
+  assetUsageEvents(
+    """Filter by asset name (slug)"""
+    assetName: String
+
+    """Filter by asset type"""
+    assetType: String
+
+    """Filter by actor email"""
+    actor: String
+
+    """Only events at or after this time"""
+    since: DateTime
+
+    """Only events at or before this time"""
+    until: DateTime
+
+    """Maximum allowed value is 50."""
+    first: Int
+
+    """Maximum allowed value is 50."""
+    last: Int
+    before: String
+    after: String
+  ): AssetUsageEventConnection!
   skillUsageTimeSeries(
     timeRange: SkillUsageTimeRange = DAYS_30
     skillId: ID
@@ -5436,6 +5494,16 @@ type Mutation {
   retractInstallationRequest(requestId: ID!): RetractInstallationRequestMutation
   setAssetInstallations(input: SetAssetInstallationsInput!): SetAssetInstallationsMutation
   removeAssetInstallations(input: RemoveAssetInstallationsInput!): RemoveAssetInstallationsMutation
+
+  """
+  Import historical audit events from another vault, verbatim.
+  
+  Preserves the original timestamp, actor (resolved by email within the org;
+  unresolved actors fall back to the caller with the original email kept in
+  data), event name, target type, and payload — so migrating a vault into
+  skills.new doesn't lose its audit trail.
+  """
+  importAuditEvents(events: [ImportAuditEventInput!]!): ImportAuditEventsMutation
   updateSkillsSettings(input: UpdateSkillsSettingsInput!): UpdateSkillsSettingsMutation
 
   """Import an external (non-managed) asset as a new managed asset."""
@@ -5981,11 +6049,25 @@ input SetAssetInstallationsInput {
   assetVersion: String
   repositories: [RepositoryInstallationInput!]!
   personalOnly: Boolean
+  installations: [AssetInstallationInput!]
 }
 
 input RepositoryInstallationInput {
   url: String!
   paths: [String!]
+}
+
+input AssetInstallationInput {
+  entityType: VaultAssetInstallationEntityType!
+
+  """GID of the entity (null for organization-wide)"""
+  entityId: ID
+  entityName: String
+  entityProvider: String
+
+  """GID of the mono-repo config (repository targets only)"""
+  monoRepoConfigId: ID
+  monoRepoConfigName: String
 }
 
 type RemoveAssetInstallationsMutation {
@@ -5996,6 +6078,39 @@ type RemoveAssetInstallationsMutation {
 input RemoveAssetInstallationsInput {
   assetName: String!
   delete: Boolean = false
+}
+
+"""
+Import historical audit events from another vault, verbatim.
+
+Preserves the original timestamp, actor (resolved by email within the org;
+unresolved actors fall back to the caller with the original email kept in
+data), event name, target type, and payload — so migrating a vault into
+skills.new doesn't lose its audit trail.
+"""
+type ImportAuditEventsMutation {
+  importedCount: Int!
+  errors: [ErrorType!]!
+}
+
+input ImportAuditEventInput {
+  """When the event occurred (original timestamp)"""
+  timestamp: DateTime!
+
+  """Email of the original actor"""
+  actor: String
+
+  """Event name, stored verbatim (e.g. team.created)"""
+  event: String!
+
+  """Target type, stored verbatim (e.g. team, asset)"""
+  targetType: String!
+
+  """Target name/identifier"""
+  target: String
+
+  """Event-specific payload"""
+  data: JSONString
 }
 
 type UpdateSkillsSettingsMutation {
@@ -6277,19 +6392,6 @@ input CreateAssetInput {
   ruleTitle: String
   ruleGlobs: [String!]
   pluginMarketplaceUrl: String
-}
-
-input AssetInstallationInput {
-  entityType: VaultAssetInstallationEntityType!
-
-  """GID of the entity (null for organization-wide)"""
-  entityId: ID
-  entityName: String
-  entityProvider: String
-
-  """GID of the mono-repo config (repository targets only)"""
-  monoRepoConfigId: ID
-  monoRepoConfigName: String
 }
 
 input McpToolInput {

--- a/internal/vault/import_audit_e2e_test.go
+++ b/internal/vault/import_audit_e2e_test.go
@@ -1,0 +1,82 @@
+package vault
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/mgmt"
+)
+
+// TestPathVault_ImportAuditEventsRoundTrip verifies that audit events imported
+// into a file-backed vault are persisted verbatim — original timestamp, actor,
+// event, target, and data all survive a write/read round-trip.
+func TestPathVault_ImportAuditEventsRoundTrip(t *testing.T) {
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "alice@example.com")
+	runGit(t, dir, "config", "user.name", "Alice Admin")
+
+	if err := manifest.Save(dir, &manifest.Manifest{SchemaVersion: manifest.CurrentSchemaVersion}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	ctx := context.Background()
+
+	ts := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	events := []mgmt.AuditEvent{
+		{
+			Timestamp:  ts,
+			Actor:      "bob@example.com",
+			Event:      "team.created",
+			TargetType: "team",
+			Target:     "platform",
+			Data:       map[string]any{"description": "core"},
+		},
+		{
+			Timestamp:  ts.Add(time.Hour),
+			Actor:      "carol@example.com",
+			Event:      "install.set",
+			TargetType: "installation",
+			Target:     "my-skill",
+		},
+	}
+
+	if err := v.ImportAuditEvents(ctx, events); err != nil {
+		t.Fatalf("ImportAuditEvents: %v", err)
+	}
+
+	got, err := v.QueryAuditEvents(ctx, mgmt.AuditFilter{})
+	if err != nil {
+		t.Fatalf("QueryAuditEvents: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+
+	// Newest first.
+	if got[0].Event != "install.set" || got[0].Actor != "carol@example.com" {
+		t.Errorf("event[0] = %q by %q, want install.set by carol@example.com", got[0].Event, got[0].Actor)
+	}
+	if !got[1].Timestamp.Equal(ts) {
+		t.Errorf("event[1] timestamp = %v, want %v", got[1].Timestamp, ts)
+	}
+	if got[1].Event != "team.created" || got[1].TargetType != "team" || got[1].Target != "platform" {
+		t.Errorf("event[1] = %+v, want team.created/team/platform", got[1])
+	}
+	if got[1].Data["description"] != "core" {
+		t.Errorf("event[1] data = %v, want description=core", got[1].Data)
+	}
+
+	// Empty import is a no-op.
+	if err := v.ImportAuditEvents(ctx, nil); err != nil {
+		t.Fatalf("ImportAuditEvents(nil): %v", err)
+	}
+}

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -141,16 +141,20 @@ func manifestAssetScopes(vaultRoot, name string) ([]manifest.Scope, bool) {
 	return a.Scopes, true
 }
 
-// ManifestAssetScopes exposes the named asset's complete authoring scopes and
-// whether it has a manifest entry. See manifestAssetScopes.
-func (p *PathVault) ManifestAssetScopes(name string) ([]manifest.Scope, bool) {
-	return manifestAssetScopes(p.repoPath, name)
+// AssetInstallScopes exposes the named asset's complete authoring scopes and
+// whether it has a manifest entry. The ctx/error signature matches the
+// server-backed implementation so the copy engine can read scopes uniformly.
+// See manifestAssetScopes.
+func (p *PathVault) AssetInstallScopes(_ context.Context, name string) ([]manifest.Scope, bool, error) {
+	scopes, present := manifestAssetScopes(p.repoPath, name)
+	return scopes, present, nil
 }
 
-// ManifestAssetScopes exposes the named asset's complete authoring scopes and
+// AssetInstallScopes exposes the named asset's complete authoring scopes and
 // whether it has a manifest entry. See manifestAssetScopes.
-func (g *GitVault) ManifestAssetScopes(name string) ([]manifest.Scope, bool) {
-	return manifestAssetScopes(g.repoPath, name)
+func (g *GitVault) AssetInstallScopes(_ context.Context, name string) ([]manifest.Scope, bool, error) {
+	scopes, present := manifestAssetScopes(g.repoPath, name)
+	return scopes, present, nil
 }
 
 // findAssetInManifest returns (asset, true) when the named asset exists

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -124,27 +124,32 @@ func renameAssetInManifest(vaultRoot, oldName, newName string) error {
 
 // manifestAssetScopes returns the complete authoring scopes (org/repo/path/
 // team/user/bot) for an asset from the manifest — unlike ExistingAssetScopes,
-// which flattens to repo/path only. Used by the cross-vault copy engine to
-// replay every installation target.
-func manifestAssetScopes(vaultRoot, name string) []manifest.Scope {
+// which flattens to repo/path only. The bool reports whether the asset has a
+// manifest entry at all: a registered org-wide asset returns (nil/empty, true)
+// while an asset present only as uploaded files returns (nil, false). The copy
+// engine needs that distinction to register org-wide installs without
+// registering files-only assets.
+func manifestAssetScopes(vaultRoot, name string) ([]manifest.Scope, bool) {
 	m, err := loadManifest(vaultRoot)
 	if err != nil || m == nil {
-		return nil
+		return nil, false
 	}
 	a := m.FindAsset(name)
 	if a == nil {
-		return nil
+		return nil, false
 	}
-	return a.Scopes
+	return a.Scopes, true
 }
 
-// ManifestAssetScopes exposes the named asset's complete authoring scopes.
-func (p *PathVault) ManifestAssetScopes(name string) []manifest.Scope {
+// ManifestAssetScopes exposes the named asset's complete authoring scopes and
+// whether it has a manifest entry. See manifestAssetScopes.
+func (p *PathVault) ManifestAssetScopes(name string) ([]manifest.Scope, bool) {
 	return manifestAssetScopes(p.repoPath, name)
 }
 
-// ManifestAssetScopes exposes the named asset's complete authoring scopes.
-func (g *GitVault) ManifestAssetScopes(name string) []manifest.Scope {
+// ManifestAssetScopes exposes the named asset's complete authoring scopes and
+// whether it has a manifest entry. See manifestAssetScopes.
+func (g *GitVault) ManifestAssetScopes(name string) ([]manifest.Scope, bool) {
 	return manifestAssetScopes(g.repoPath, name)
 }
 

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -122,6 +122,32 @@ func renameAssetInManifest(vaultRoot, oldName, newName string) error {
 	return manifest.Save(vaultRoot, m)
 }
 
+// manifestAssetScopes returns the complete authoring scopes (org/repo/path/
+// team/user/bot) for an asset from the manifest — unlike ExistingAssetScopes,
+// which flattens to repo/path only. Used by the cross-vault copy engine to
+// replay every installation target.
+func manifestAssetScopes(vaultRoot, name string) []manifest.Scope {
+	m, err := loadManifest(vaultRoot)
+	if err != nil || m == nil {
+		return nil
+	}
+	a := m.FindAsset(name)
+	if a == nil {
+		return nil
+	}
+	return a.Scopes
+}
+
+// ManifestAssetScopes exposes the named asset's complete authoring scopes.
+func (p *PathVault) ManifestAssetScopes(name string) []manifest.Scope {
+	return manifestAssetScopes(p.repoPath, name)
+}
+
+// ManifestAssetScopes exposes the named asset's complete authoring scopes.
+func (g *GitVault) ManifestAssetScopes(name string) []manifest.Scope {
+	return manifestAssetScopes(g.repoPath, name)
+}
+
 // findAssetInManifest returns (asset, true) when the named asset exists
 // in the vault. Used by callers that need to check before modifying.
 func findAssetInManifest(vaultRoot, name string) (*lockfile.Asset, bool) {

--- a/internal/vault/pathrepo_mgmt.go
+++ b/internal/vault/pathrepo_mgmt.go
@@ -246,6 +246,19 @@ func (p *PathVault) ImportAuditEvents(ctx context.Context, events []mgmt.AuditEv
 	})
 }
 
+func (p *PathVault) ReadUsageEvents(ctx context.Context, filter mgmt.UsageFilter) ([]mgmt.UsageEvent, error) {
+	var out []mgmt.UsageEvent
+	err := p.withReadLock(ctx, func() error {
+		events, err := mgmt.ReadUsageEvents(p.repoPath, filter)
+		if err != nil {
+			return err
+		}
+		out = events
+		return nil
+	})
+	return out, err
+}
+
 func (p *PathVault) QueryAuditEvents(ctx context.Context, filter mgmt.AuditFilter) ([]mgmt.AuditEvent, error) {
 	var out []mgmt.AuditEvent
 	err := p.withReadLock(ctx, func() error {

--- a/internal/vault/pathrepo_mgmt.go
+++ b/internal/vault/pathrepo_mgmt.go
@@ -237,6 +237,15 @@ func (p *PathVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) 
 	return out, err
 }
 
+func (p *PathVault) ImportAuditEvents(ctx context.Context, events []mgmt.AuditEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	return p.withLock(ctx, func(_ mgmt.Actor) error {
+		return mgmt.AppendAuditEvents(p.repoPath, events)
+	})
+}
+
 func (p *PathVault) QueryAuditEvents(ctx context.Context, filter mgmt.AuditFilter) ([]mgmt.AuditEvent, error) {
 	var out []mgmt.AuditEvent
 	err := p.withReadLock(ctx, func() error {

--- a/internal/vault/repository.go
+++ b/internal/vault/repository.go
@@ -205,6 +205,14 @@ type Vault interface {
 
 	// QueryAuditEvents returns audit events matching the filter.
 	QueryAuditEvents(ctx context.Context, filter mgmt.AuditFilter) ([]mgmt.AuditEvent, error)
+
+	// ImportAuditEvents appends pre-existing audit events to the vault's audit
+	// trail verbatim, preserving each event's timestamp, actor, event name, and
+	// target. Used to copy audit history between vaults losslessly. File-backed
+	// vaults write the JSONL directly; the Sleuth vault delegates to the
+	// importAuditEvents mutation (which resolves actors by email and falls back
+	// to the caller for unknown ones).
+	ImportAuditEvents(ctx context.Context, events []mgmt.AuditEvent) error
 }
 
 // InstallKind identifies which kind of installation a CLI command is asking

--- a/internal/vault/repository.go
+++ b/internal/vault/repository.go
@@ -203,6 +203,10 @@ type Vault interface {
 	// GetUsageStats returns an aggregated usage summary across the vault.
 	GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (*mgmt.UsageSummary, error)
 
+	// ReadUsageEvents returns the raw usage events matching the filter (not
+	// aggregated). Used to copy usage history between vaults losslessly.
+	ReadUsageEvents(ctx context.Context, filter mgmt.UsageFilter) ([]mgmt.UsageEvent, error)
+
 	// QueryAuditEvents returns audit events matching the filter.
 	QueryAuditEvents(ctx context.Context, filter mgmt.AuditFilter) ([]mgmt.AuditEvent, error)
 

--- a/internal/vault/sleuth.go
+++ b/internal/vault/sleuth.go
@@ -615,12 +615,6 @@ func (s *SleuthVault) ListAssets(ctx context.Context, opts ListAssetsOptions) (*
 
 // listAssetsByType retrieves assets of a specific type from the vault
 func (s *SleuthVault) listAssetsByType(ctx context.Context, opts ListAssetsOptions) (*ListAssetsResult, error) {
-	// Set default limit if not specified (max 50 enforced by backend)
-	limit := opts.Limit
-	if limit == 0 || limit > 50 {
-		limit = 50
-	}
-
 	gqlType := sxAssetTypeToGQL(asset.FromString(opts.Type))
 	if gqlType == "" {
 		// Type not supported by backend, return empty result
@@ -632,35 +626,50 @@ func (s *SleuthVault) listAssetsByType(ctx context.Context, opts ListAssetsOptio
 		searchPtr = &opts.Search
 	}
 
-	resp, err := vaultgql.VaultAssets(ctx, s.gqlClient(), &limit, gqlType, searchPtr)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert to result struct. VaultAsset is a polymorphic interface;
-	// shared getters cover every concrete subtype (Skill, MCP, Agent, ...).
-	result := &ListAssetsResult{
-		Assets: make([]AssetSummary, 0, len(resp.Vault.Assets.Nodes)),
-	}
-	for _, node := range resp.Vault.Assets.Nodes {
-		assetType := gqlAssetTypeToSX(node.GetType())
-		if !assetType.IsValid() {
-			log := logger.Get()
-			log.Warn("unknown asset type from GraphQL", "type", string(node.GetType()), "asset", node.GetSlug())
+	// The server caps `first` at 50, so page through with the endCursor rather
+	// than truncating — a vault copy must see every asset, not just the first
+	// page. opts.Limit (when > 0) bounds the total returned.
+	result := &ListAssetsResult{Assets: []AssetSummary{}}
+	pageSize := sleuthAssetsPageSize
+	var after *string
+	for {
+		resp, err := vaultgql.VaultAssets(ctx, s.gqlClient(), &pageSize, after, gqlType, searchPtr)
+		if err != nil {
+			return nil, err
 		}
-		result.Assets = append(result.Assets, AssetSummary{
-			Name:          node.GetSlug(),
-			Type:          assetType,
-			LatestVersion: node.GetLatestVersion(),
-			VersionsCount: node.GetVersionsCount(),
-			Description:   node.GetDescription(),
-			CreatedAt:     node.GetCreatedAt(),
-			UpdatedAt:     node.GetUpdatedAt(),
-		})
+		conn := resp.Vault.Assets
+		// VaultAsset is a polymorphic interface; shared getters cover every
+		// concrete subtype (Skill, MCP, Agent, ...).
+		for _, node := range conn.Nodes {
+			assetType := gqlAssetTypeToSX(node.GetType())
+			if !assetType.IsValid() {
+				logger.Get().Warn("unknown asset type from GraphQL", "type", string(node.GetType()), "asset", node.GetSlug())
+			}
+			result.Assets = append(result.Assets, AssetSummary{
+				Name:          node.GetSlug(),
+				Type:          assetType,
+				LatestVersion: node.GetLatestVersion(),
+				VersionsCount: node.GetVersionsCount(),
+				Description:   node.GetDescription(),
+				CreatedAt:     node.GetCreatedAt(),
+				UpdatedAt:     node.GetUpdatedAt(),
+			})
+			if opts.Limit > 0 && len(result.Assets) >= opts.Limit {
+				return result, nil
+			}
+		}
+		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+			break
+		}
+		after = conn.PageInfo.EndCursor
 	}
 
 	return result, nil
 }
+
+// sleuthAssetsPageSize is the server-side maximum for the vault.assets `first`
+// argument; we page through with the endCursor.
+const sleuthAssetsPageSize = 50
 
 // GetAssetDetails retrieves detailed information about a specific asset using GraphQL
 func (s *SleuthVault) GetAssetDetails(ctx context.Context, name string) (*AssetDetails, error) {

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -260,11 +260,129 @@ func (s *SleuthVault) SetTeamAdmin(ctx context.Context, team, email string, admi
 }
 
 func (s *SleuthVault) AddTeamRepository(ctx context.Context, team, repoURL string) error {
-	return fmt.Errorf("%w: add team repository on sleuth vaults (use the skills.new web UI)", ErrNotImplemented)
+	return s.setTeamRepositories(ctx, team, repoURL, true)
 }
 
 func (s *SleuthVault) RemoveTeamRepository(ctx context.Context, team, repoURL string) error {
-	return fmt.Errorf("%w: remove team repository on sleuth vaults (use the skills.new web UI)", ErrNotImplemented)
+	return s.setTeamRepositories(ctx, team, repoURL, false)
+}
+
+// setTeamRepositories adds or removes one repository from a team's skills
+// repository set. The updateTeam mutation replaces the whole set, so we
+// read the team's current members + repositories, resolve them to GIDs, and
+// re-send the full list with the one repo added or removed. Members are
+// resent unchanged so the replace doesn't drop them (admin flags persist
+// server-side since the membership rows are unchanged).
+func (s *SleuthVault) setTeamRepositories(ctx context.Context, team, repoURL string, add bool) error {
+	existing, err := s.GetTeam(ctx, team)
+	if err != nil {
+		return err
+	}
+	repoMap, err := s.orgRepoGIDsByOwnerName(ctx)
+	if err != nil {
+		return err
+	}
+
+	targetKey := trailingOwnerName(repoURL)
+	if add {
+		if _, ok := repoMap[targetKey]; !ok {
+			return fmt.Errorf("repository %q not found in the skills.new organization", repoURL)
+		}
+	}
+
+	// Build the desired owner/name set from the team's current repositories,
+	// then apply the add/remove.
+	desired := make(map[string]struct{}, len(existing.Repositories))
+	for _, r := range existing.Repositories {
+		desired[trailingOwnerName(r)] = struct{}{}
+	}
+	if add {
+		desired[targetKey] = struct{}{}
+	} else {
+		delete(desired, targetKey)
+	}
+
+	var skillsRepos []vaultgql.SkillsRepositoryInput
+	for key := range desired {
+		gid, ok := repoMap[key]
+		if !ok {
+			// A current repo that no longer resolves in this org — skip it
+			// rather than fail the whole update, but make the drop visible.
+			logger.Get().Warn("team repository no longer in org; dropping from set", "team", team, "repo", key)
+			continue
+		}
+		skillsRepos = append(skillsRepos, vaultgql.SkillsRepositoryInput{RepositoryId: gid})
+	}
+
+	memberGIDs, err := s.resolveUserGIDs(ctx, existing.Members)
+	if err != nil {
+		return err
+	}
+	teamGID, err := s.teamGIDByName(ctx, team)
+	if err != nil {
+		return err
+	}
+	resp, err := vaultgql.UpdateTeam(ctx, s.gqlClient(), vaultgql.UpdateTeamInput{
+		Id:                 teamGID,
+		Members:            memberGIDs,
+		SkillsRepositories: skillsRepos,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.UpdateTeam == nil {
+		return nil
+	}
+	return gqlMutationErrors(resp.UpdateTeam.Errors)
+}
+
+// orgRepoGIDsByOwnerName pages the organization's repositories into a map
+// keyed by lowercase "owner/name" -> repository GID, used to resolve repo
+// identifiers (URLs or slugs) to the GIDs updateTeam needs.
+func (s *SleuthVault) orgRepoGIDsByOwnerName(ctx context.Context) (map[string]string, error) {
+	const pageSize = 50
+	out := map[string]string{}
+	var after *string
+	for {
+		resp, err := vaultgql.OrgRepositories(ctx, s.gqlClient(), pageSize, after)
+		if err != nil {
+			return nil, err
+		}
+		conn := resp.Organization.Repositories
+		for _, n := range conn.Nodes {
+			if n.Id == nil {
+				continue
+			}
+			out[strings.ToLower(n.Owner+"/"+n.Name)] = *n.Id
+		}
+		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+			break
+		}
+		after = conn.PageInfo.EndCursor
+	}
+	return out, nil
+}
+
+// trailingOwnerName reduces a repo identifier (a full URL, an "owner/name"
+// slug, or a normalized host/owner/name string) to a lowercase "owner/name"
+// key for matching against the org repo map. Strips a scheme, a trailing
+// ".git", and any leading host path segments.
+func trailingOwnerName(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	// Handle scp-style SSH remotes (git@github.com:owner/repo) and host:port
+	// prefixes by keeping everything after the last colon.
+	if i := strings.LastIndex(s, ":"); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.TrimSuffix(strings.Trim(s, "/"), ".git")
+	parts := strings.Split(s, "/")
+	if len(parts) >= 2 {
+		s = parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+	return strings.ToLower(s)
 }
 
 func (s *SleuthVault) SetAssetInstallation(ctx context.Context, assetName string, target InstallTarget) error {

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -1152,6 +1152,54 @@ func (s *SleuthVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter
 // field documents a maximum of 50); we page through with the endCursor.
 const sleuthUsageEventsPageSize = 50
 
+// sleuthAuditImportChunkSize matches the server's IMPORT_AUDIT_EVENTS_MAX cap;
+// larger imports are split across calls.
+const sleuthAuditImportChunkSize = 5000
+
+func (s *SleuthVault) ImportAuditEvents(ctx context.Context, events []mgmt.AuditEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	for start := 0; start < len(events); start += sleuthAuditImportChunkSize {
+		end := min(start+sleuthAuditImportChunkSize, len(events))
+		inputs := make([]vaultgql.ImportAuditEventInput, 0, end-start)
+		for _, ev := range events[start:end] {
+			in := vaultgql.ImportAuditEventInput{
+				Timestamp:  timeOrNow(ev.Timestamp),
+				Event:      ev.Event,
+				TargetType: ev.TargetType,
+			}
+			if ev.Actor != "" {
+				actor := ev.Actor
+				in.Actor = &actor
+			}
+			if ev.Target != "" {
+				target := ev.Target
+				in.Target = &target
+			}
+			if len(ev.Data) > 0 {
+				raw, err := json.Marshal(ev.Data)
+				if err != nil {
+					return err
+				}
+				rm := json.RawMessage(raw)
+				in.Data = &rm
+			}
+			inputs = append(inputs, in)
+		}
+		resp, err := vaultgql.ImportAuditEvents(ctx, s.gqlClient(), inputs)
+		if err != nil {
+			return err
+		}
+		if resp.ImportAuditEvents != nil {
+			if err := gqlMutationErrors(resp.ImportAuditEvents.Errors); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // sleuthAuditDefaultPageSize is the server-side cap we ask for when the
 // caller didn't set filter.Limit. The server-side query plus client-side
 // filtering means a small server page paired with selective filters can

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -431,17 +431,24 @@ func (s *SleuthVault) SetAssetInstallation(ctx context.Context, assetName string
 }
 
 // SetAssetInstallations replaces an asset's entire installation set in a single
-// server call. Because the skills.new mutation replaces (rather than appends),
-// the per-target SetAssetInstallation would let each call clobber the previous
-// one for a multi-scope asset; this sends every target at once so they all
-// stick. Org-wide is exclusive — if any target is org, the asset goes global.
-func (s *SleuthVault) SetAssetInstallations(ctx context.Context, assetName string, targets []InstallTarget) error {
+// server call. The skills.new mutation replaces (rather than appends), so
+// setting targets one at a time would let each call clobber the previous one for
+// a multi-scope asset; sending every target at once makes them all stick.
+//
+// It is best-effort on a per-target basis: team/user/bot targets whose entity
+// can't be resolved in the destination org are skipped and returned in
+// unresolved (rather than failing the whole call), so the resolvable targets
+// still land in one atomic call — no clobbering. A returned error means the
+// single GraphQL call itself failed (e.g. a repository URL the server rejects),
+// in which case nothing was applied. Org-wide is exclusive — if any target is
+// org, the asset goes global.
+func (s *SleuthVault) SetAssetInstallations(ctx context.Context, assetName string, targets []InstallTarget) (unresolved []InstallTarget, err error) {
 	if len(targets) == 0 {
-		return nil
+		return nil, nil
 	}
 	for _, t := range targets {
 		if t.Kind == InstallKindOrg {
-			return s.setAssetInstallationsGraphQL(ctx, assetName, nil, false, nil)
+			return nil, s.setAssetInstallationsGraphQL(ctx, assetName, nil, false, nil)
 		}
 	}
 	var repositories []vaultgql.RepositoryInstallationInput
@@ -455,34 +462,45 @@ func (s *SleuthVault) SetAssetInstallations(ctx context.Context, assetName strin
 		case InstallKindPath:
 			repositories = append(repositories, vaultgql.RepositoryInstallationInput{Url: t.Repo, Paths: t.Paths})
 		case InstallKindTeam:
-			gid, err := s.teamGIDByName(ctx, t.Team)
-			if err != nil {
-				return err
+			gid, gerr := s.teamGIDByName(ctx, t.Team)
+			if gerr != nil {
+				unresolved = append(unresolved, t)
+				continue
 			}
 			installations = append(installations, vaultgql.AssetInstallationInput{
 				EntityType: vaultgql.VaultAssetInstallationEntityTypeTeam, EntityId: &gid,
 			})
 		case InstallKindUser:
-			gid, err := s.userGIDByEmail(ctx, t.User)
-			if err != nil {
-				return err
+			gid, gerr := s.userGIDByEmail(ctx, t.User)
+			if gerr != nil {
+				unresolved = append(unresolved, t)
+				continue
 			}
 			installations = append(installations, vaultgql.AssetInstallationInput{
 				EntityType: vaultgql.VaultAssetInstallationEntityTypeUser, EntityId: &gid,
 			})
 		case InstallKindBot:
-			gid, err := s.botGIDByName(ctx, t.Bot)
-			if err != nil {
-				return err
+			gid, gerr := s.botGIDByName(ctx, t.Bot)
+			if gerr != nil {
+				unresolved = append(unresolved, t)
+				continue
 			}
 			installations = append(installations, vaultgql.AssetInstallationInput{
 				EntityType: vaultgql.VaultAssetInstallationEntityTypeBot, EntityId: &gid,
 			})
 		default:
-			return fmt.Errorf("unknown install kind: %q", t.Kind)
+			return unresolved, fmt.Errorf("unknown install kind: %q", t.Kind)
 		}
 	}
-	return s.setAssetInstallationsGraphQL(ctx, assetName, repositories, false, installations)
+	if len(repositories) == 0 && len(installations) == 0 {
+		// Nothing resolved. Don't send an empty set — the server reads that as
+		// org-wide, which would wrongly globalize the asset. Leave it as-is.
+		return unresolved, nil
+	}
+	if err := s.setAssetInstallationsGraphQL(ctx, assetName, repositories, false, installations); err != nil {
+		return unresolved, err
+	}
+	return unresolved, nil
 }
 
 // AssetInstallScopes reads an asset's installation targets from the server and

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -1216,9 +1216,17 @@ func (s *SleuthVault) RecordUsageEvents(ctx context.Context, events []mgmt.Usage
 }
 
 func (s *SleuthVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (*mgmt.UsageSummary, error) {
+	events, err := s.ReadUsageEvents(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	return mgmt.SummarizeUsageEvents(events), nil
+}
+
+func (s *SleuthVault) ReadUsageEvents(ctx context.Context, filter mgmt.UsageFilter) ([]mgmt.UsageEvent, error) {
 	// Pull raw usage rows via the assetUsageEvents export (server-side filtered),
-	// paging through the connection, then aggregate with the same summarizer the
-	// file-backed vaults use so the UsageSummary shape is identical everywhere.
+	// paging through the connection. The aggregation lives in GetUsageStats so
+	// this stays the lossless raw read the copy engine needs.
 	strPtr := func(v string) *string {
 		if v == "" {
 			return nil
@@ -1263,7 +1271,7 @@ func (s *SleuthVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter
 		}
 		after = conn.PageInfo.EndCursor
 	}
-	return mgmt.SummarizeUsageEvents(events), nil
+	return events, nil
 }
 
 // sleuthUsageEventsPageSize is the server-side cap on assetUsageEvents (the

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/logger"
+	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
 	vaultgql "github.com/sleuth-io/sx/internal/vault/graphql"
 )
@@ -427,6 +428,45 @@ func (s *SleuthVault) SetAssetInstallation(ctx context.Context, assetName string
 		return s.installSkillToBot(ctx, assetName, target.Bot)
 	}
 	return fmt.Errorf("unknown install kind: %q", target.Kind)
+}
+
+// AssetInstallScopes reads an asset's installation targets from the server and
+// maps them to manifest scopes, so the copy engine can replay scopes when the
+// SOURCE is a skills.new vault (the file-backed vaults read them from sx.toml).
+// An org-wide install is reported as present with no scopes, matching the
+// file-backed convention.
+func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]manifest.Scope, bool, error) {
+	resp, err := vaultgql.AssetInstallations(ctx, s.gqlClient(), name)
+	if err != nil {
+		return nil, false, err
+	}
+	var node *vaultgql.AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset
+	for i := range resp.Vault.Assets.Nodes {
+		if strings.EqualFold(resp.Vault.Assets.Nodes[i].GetName(), name) {
+			node = &resp.Vault.Assets.Nodes[i]
+			break
+		}
+	}
+	if node == nil {
+		return nil, false, nil
+	}
+	var scopes []manifest.Scope
+	for _, inst := range (*node).GetInstallations() {
+		switch inst.EntityType {
+		case vaultgql.VaultAssetInstallationEntityTypeOrganization:
+			// Org-wide is exclusive; report it as present-with-no-scopes.
+			return nil, true, nil
+		case vaultgql.VaultAssetInstallationEntityTypeRepository:
+			scopes = append(scopes, manifest.Scope{Kind: manifest.ScopeKindRepo, Repo: inst.EntityName})
+		case vaultgql.VaultAssetInstallationEntityTypeTeam:
+			scopes = append(scopes, manifest.Scope{Kind: manifest.ScopeKindTeam, Team: inst.EntityName})
+		case vaultgql.VaultAssetInstallationEntityTypeUser:
+			scopes = append(scopes, manifest.Scope{Kind: manifest.ScopeKindUser, User: inst.EntityName})
+		case vaultgql.VaultAssetInstallationEntityTypeBot:
+			scopes = append(scopes, manifest.Scope{Kind: manifest.ScopeKindBot, Bot: inst.EntityName})
+		}
+	}
+	return scopes, true, nil
 }
 
 func (s *SleuthVault) RemoveAssetInstallation(ctx context.Context, assetName string, target InstallTarget) error {
@@ -1326,78 +1366,75 @@ func (s *SleuthVault) ImportAuditEvents(ctx context.Context, events []mgmt.Audit
 	return nil
 }
 
-// sleuthAuditDefaultPageSize is the server-side cap we ask for when the
-// caller didn't set filter.Limit. The server-side query plus client-side
-// filtering means a small server page paired with selective filters can
-// return zero rows even though matches exist further back in the log.
-// Setting this high (1000) makes truncation very unlikely; a warning
-// fires if we saturate so operators notice when they need a higher cap
-// or server-side filter support.
-const sleuthAuditDefaultPageSize = 1000
+// sleuthAuditPageSize is the server-side maximum for the assetAuditLog `first`
+// argument; we page through with the endCursor to retrieve everything.
+const sleuthAuditPageSize = 50
 
 func (s *SleuthVault) QueryAuditEvents(ctx context.Context, filter mgmt.AuditFilter) ([]mgmt.AuditEvent, error) {
-	// If the caller specified a limit, honor it directly; otherwise use
-	// the wide default so client-side filters don't silently drop rows
-	// that existed just beyond a small server page.
-	userLimit := filter.Limit
-	first := userLimit
-	if first <= 0 {
-		first = sleuthAuditDefaultPageSize
-	}
-	resp, err := vaultgql.AssetAuditLog(ctx, s.gqlClient(), &first)
-	if err != nil {
-		return nil, err
-	}
-	// Warn when the server returned exactly the page we asked for and the
-	// caller didn't choose that limit themselves — a saturation signal
-	// that older entries may have been dropped before client-side
-	// filtering ran.
-	if userLimit == 0 && len(resp.AssetAuditLog.Nodes) >= first {
-		logger.Get().Warn("QueryAuditEvents result saturated page size; older events may be truncated",
-			"page_size", first,
-			"returned", len(resp.AssetAuditLog.Nodes))
-	}
+	pageSize := sleuthAuditPageSize
 	var out []mgmt.AuditEvent
-	for _, node := range resp.AssetAuditLog.Nodes {
-		ev := mgmt.AuditEvent{
-			Timestamp:  node.Date,
-			Actor:      derefStr(node.ActorEmail),
-			Event:      node.Event,
-			TargetType: node.TargetType,
-			Target:     derefStr(node.TargetName),
+	var after *string
+	for {
+		resp, err := vaultgql.AssetAuditLog(ctx, s.gqlClient(), &pageSize, after)
+		if err != nil {
+			return nil, err
 		}
-		// node.Data is a JSONString scalar that normally wire-encodes as a
-		// JSON-encoded string ("{\"foo\":...}"), but older payloads may
-		// wire the object directly. Dispatch on the first non-whitespace
-		// byte so both shapes are handled explicitly.
-		if node.Data != nil {
-			raw := bytes.TrimSpace(*node.Data)
-			switch {
-			case len(raw) == 0, bytes.Equal(raw, []byte("null")):
-				// empty payload — nothing to decode
-			case raw[0] == '"':
-				var inner string
-				if err := json.Unmarshal(raw, &inner); err != nil || inner == "" {
-					if err != nil {
-						logger.Get().Warn("audit log: malformed JSONString Data", "err", err)
-					}
-					break
-				}
-				if err := json.Unmarshal([]byte(inner), &ev.Data); err != nil {
-					logger.Get().Warn("audit log: failed to decode inner Data object", "err", err)
-				}
-			default:
-				if err := json.Unmarshal(raw, &ev.Data); err != nil {
-					logger.Get().Warn("audit log: failed to decode Data object", "err", err)
-				}
+		conn := resp.AssetAuditLog
+		for _, node := range conn.Nodes {
+			ev := sleuthAuditNodeToEvent(node)
+			if !sleuthAuditMatches(ev, filter) {
+				continue
+			}
+			out = append(out, ev)
+			if filter.Limit > 0 && len(out) >= filter.Limit {
+				return out, nil
 			}
 		}
-		if !sleuthAuditMatches(ev, filter) {
-			continue
+		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+			break
 		}
-		out = append(out, ev)
+		after = conn.PageInfo.EndCursor
 	}
 	return out, nil
+}
+
+// sleuthAuditNodeToEvent converts a generated audit-log node into the internal
+// mgmt.AuditEvent, decoding the JSONString Data scalar.
+func sleuthAuditNodeToEvent(node vaultgql.AssetAuditLogAssetAuditLogAssetAuditEventConnectionNodesAssetAuditEvent) mgmt.AuditEvent {
+	ev := mgmt.AuditEvent{
+		Timestamp:  node.Date,
+		Actor:      derefStr(node.ActorEmail),
+		Event:      node.Event,
+		TargetType: node.TargetType,
+		Target:     derefStr(node.TargetName),
+	}
+	// node.Data is a JSONString scalar that normally wire-encodes as a
+	// JSON-encoded string ("{\"foo\":...}"), but older payloads may wire the
+	// object directly. Dispatch on the first non-whitespace byte so both
+	// shapes are handled explicitly.
+	if node.Data != nil {
+		raw := bytes.TrimSpace(*node.Data)
+		switch {
+		case len(raw) == 0, bytes.Equal(raw, []byte("null")):
+			// empty payload — nothing to decode
+		case raw[0] == '"':
+			var inner string
+			if err := json.Unmarshal(raw, &inner); err != nil || inner == "" {
+				if err != nil {
+					logger.Get().Warn("audit log: malformed JSONString Data", "err", err)
+				}
+				break
+			}
+			if err := json.Unmarshal([]byte(inner), &ev.Data); err != nil {
+				logger.Get().Warn("audit log: failed to decode inner Data object", "err", err)
+			}
+		default:
+			if err := json.Unmarshal(raw, &ev.Data); err != nil {
+				logger.Get().Warn("audit log: failed to decode Data object", "err", err)
+			}
+		}
+	}
+	return ev
 }
 
 // derefStr returns the pointee or "" when nil. Used for nullable string

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -270,30 +270,37 @@ func (s *SleuthVault) RemoveTeamRepository(ctx context.Context, team, repoURL st
 func (s *SleuthVault) SetAssetInstallation(ctx context.Context, assetName string, target InstallTarget) error {
 	switch target.Kind {
 	case InstallKindOrg:
-		return s.setAssetInstallationsGraphQL(ctx, assetName, nil, false)
+		return s.setAssetInstallationsGraphQL(ctx, assetName, nil, false, nil)
 	case InstallKindRepo:
-		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: target.Repo}}, false)
+		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: target.Repo}}, false, nil)
 	case InstallKindPath:
-		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: target.Repo, Paths: target.Paths}}, false)
+		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: target.Repo, Paths: target.Paths}}, false, nil)
 	case InstallKindUser:
-		// Sleuth's setAssetInstallations GraphQL mutation supports exactly
-		// one user-scoped shape: personalOnly=true with empty repositories,
-		// which installs the asset for the authenticated caller ONLY.
-		// See sleuth/apps/skills/graphql/mutations.py:SetAssetInstallationsMutation.
-		// We must never pass repositories=[] with personalOnly=false — that
-		// would be interpreted as an org-wide install on the server, which
-		// is a silent privilege escalation. Reject if the target user does
-		// not match the caller so the intent is unambiguous.
+		// The setAssetInstallations `installations` input now accepts an explicit
+		// USER target by GID, so we can scope to any user in the org (not just the
+		// caller). personalOnly stays the lighter-weight path for self-installs.
 		actor, err := s.CurrentActor(ctx)
 		if err != nil {
 			return err
 		}
-		if mgmt.NormalizeEmail(target.User) != actor.Email {
-			return fmt.Errorf("%w: user-scoped installs on sleuth vaults can only target the authenticated caller (personalOnly)", ErrNotImplemented)
+		if mgmt.NormalizeEmail(target.User) == actor.Email {
+			return s.setAssetInstallationsGraphQL(ctx, assetName, nil, true, nil)
 		}
-		return s.setAssetInstallationsGraphQL(ctx, assetName, nil, true)
+		userGID, err := s.userGIDByEmail(ctx, target.User)
+		if err != nil {
+			return err
+		}
+		return s.setAssetInstallationsGraphQL(ctx, assetName, nil, false, []vaultgql.AssetInstallationInput{
+			{EntityType: vaultgql.VaultAssetInstallationEntityTypeUser, EntityId: &userGID},
+		})
 	case InstallKindTeam:
-		return fmt.Errorf("%w: team-scoped installs on sleuth vaults (the existing GraphQL setAssetInstallations mutation does not expose team targets; use the skills.new web UI)", ErrNotImplemented)
+		teamGID, err := s.teamGIDByName(ctx, target.Team)
+		if err != nil {
+			return err
+		}
+		return s.setAssetInstallationsGraphQL(ctx, assetName, nil, false, []vaultgql.AssetInstallationInput{
+			{EntityType: vaultgql.VaultAssetInstallationEntityTypeTeam, EntityId: &teamGID},
+		})
 	case InstallKindBot:
 		// Bot installs go through the dedicated installSkillToBot
 		// mutation, not setAssetInstallations — the latter does not yet
@@ -1057,12 +1064,13 @@ func (s *SleuthVault) ClearAssetInstallations(ctx context.Context, assetName str
 func (s *SleuthVault) RecordUsageEvents(ctx context.Context, events []mgmt.UsageEvent) error {
 	// Usage events go through the existing PostUsageStats HTTP path for
 	// sleuth vaults — it talks to /api/usage, not GraphQL. Marshal each
-	// event to the legacy wire format and delegate.
+	// event to the wire format and delegate.
 	//
-	// Note: ev.Actor is intentionally dropped from the wire payload — the
-	// server always attributes events to the bearer-token holder. Any
-	// caller that sets Actor to another user will see it silently
-	// rewritten to the authenticated caller on ingestion.
+	// ev.Actor is sent as the optional `actor` field: the server resolves it
+	// to a user in the org (case-insensitively) so imported usage keeps its
+	// original attribution, falling back to the bearer-token holder when the
+	// email doesn't resolve. Omitted when empty so live (non-import) events
+	// attribute to the caller as before.
 	if len(events) == 0 {
 		return nil
 	}
@@ -1071,12 +1079,16 @@ func (s *SleuthVault) RecordUsageEvents(ctx context.Context, events []mgmt.Usage
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		line, err := json.Marshal(map[string]any{
+		payload := map[string]any{
 			"asset_name":    ev.AssetName,
 			"asset_version": ev.AssetVersion,
 			"asset_type":    ev.AssetType,
 			"timestamp":     timeOrNow(ev.Timestamp).Format(time.RFC3339),
-		})
+		}
+		if ev.Actor != "" {
+			payload["actor"] = ev.Actor
+		}
+		line, err := json.Marshal(payload)
 		if err != nil {
 			return err
 		}
@@ -1086,11 +1098,59 @@ func (s *SleuthVault) RecordUsageEvents(ctx context.Context, events []mgmt.Usage
 }
 
 func (s *SleuthVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (*mgmt.UsageSummary, error) {
-	// Sleuth usage stats come from the server's PQL fragments
-	// (asset.usage). Rather than reimplementing the dashboard math, surface
-	// a clear ErrNotImplemented so callers know to use the web UI.
-	return nil, fmt.Errorf("%w: sleuth vault usage stats (use the skills.new web UI dashboards)", ErrNotImplemented)
+	// Pull raw usage rows via the assetUsageEvents export (server-side filtered),
+	// paging through the connection, then aggregate with the same summarizer the
+	// file-backed vaults use so the UsageSummary shape is identical everywhere.
+	strPtr := func(v string) *string {
+		if v == "" {
+			return nil
+		}
+		return &v
+	}
+	timePtr := func(t time.Time) *time.Time {
+		if t.IsZero() {
+			return nil
+		}
+		return &t
+	}
+
+	first := sleuthUsageEventsPageSize
+	var after *string
+	var events []mgmt.UsageEvent
+	for {
+		resp, err := vaultgql.AssetUsageEvents(
+			ctx, s.gqlClient(),
+			strPtr(filter.AssetName), strPtr(filter.AssetType), strPtr(filter.Actor),
+			timePtr(filter.Since), timePtr(filter.Until), &first, after,
+		)
+		if err != nil {
+			return nil, err
+		}
+		conn := resp.AssetUsageEvents
+		for _, n := range conn.Nodes {
+			actor := ""
+			if n.ActorEmail != nil {
+				actor = *n.ActorEmail
+			}
+			events = append(events, mgmt.UsageEvent{
+				Timestamp:    n.Timestamp,
+				Actor:        actor,
+				AssetName:    n.AssetName,
+				AssetVersion: n.AssetVersion,
+				AssetType:    n.AssetType,
+			})
+		}
+		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+			break
+		}
+		after = conn.PageInfo.EndCursor
+	}
+	return mgmt.SummarizeUsageEvents(events), nil
 }
+
+// sleuthUsageEventsPageSize is the server-side cap on assetUsageEvents (the
+// field documents a maximum of 50); we page through with the endCursor.
+const sleuthUsageEventsPageSize = 50
 
 // sleuthAuditDefaultPageSize is the server-side cap we ask for when the
 // caller didn't set filter.Limit. The server-side query plus client-side
@@ -1327,14 +1387,21 @@ func (s *SleuthVault) resolveUserGIDs(ctx context.Context, emails []string) ([]s
 // empty". Callers must route through SetAssetInstallation, which picks
 // the right arguments per InstallKind and never collapses an intended
 // repo/path/user install into the empty-empty shape.
-func (s *SleuthVault) setAssetInstallationsGraphQL(ctx context.Context, assetName string, repositories []vaultgql.RepositoryInstallationInput, personalOnly bool) error {
+func (s *SleuthVault) setAssetInstallationsGraphQL(
+	ctx context.Context,
+	assetName string,
+	repositories []vaultgql.RepositoryInstallationInput,
+	personalOnly bool,
+	installations []vaultgql.AssetInstallationInput,
+) error {
 	if repositories == nil {
 		repositories = []vaultgql.RepositoryInstallationInput{}
 	}
 	resp, err := vaultgql.SetAssetInstallations(ctx, s.gqlClient(), vaultgql.SetAssetInstallationsInput{
-		AssetName:    assetName,
-		Repositories: repositories,
-		PersonalOnly: &personalOnly,
+		AssetName:     assetName,
+		Repositories:  repositories,
+		PersonalOnly:  &personalOnly,
+		Installations: installations,
 	})
 	if err != nil {
 		return err

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -534,6 +534,9 @@ func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]ma
 		// is org-wide; see below).
 		return nil, false, nil
 	}
+	// Cache a repo's mono-repo configs across this asset's installs so multiple
+	// path-scoped installs against the same repo don't each re-fetch them.
+	repoConfigCache := map[string]map[string][]string{}
 	var scopes []manifest.Scope
 	for _, inst := range insts {
 		switch inst.EntityType {
@@ -544,7 +547,7 @@ func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]ma
 			// A mono-repo config means the install is path-scoped, not whole-repo.
 			// Resolve the actual subpaths so they aren't silently widened.
 			if inst.MonoRepoConfigId != nil && inst.EntityId != nil {
-				paths, perr := s.monoRepoConfigPaths(ctx, *inst.EntityId, *inst.MonoRepoConfigId)
+				paths, perr := s.monoRepoConfigPaths(ctx, *inst.EntityId, *inst.MonoRepoConfigId, repoConfigCache)
 				if perr != nil {
 					return nil, false, perr
 				}
@@ -568,28 +571,33 @@ func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]ma
 // monoRepoConfigPaths resolves a repository's mono-repo config to its include
 // paths, so a path-scoped install read from the server keeps its subpaths
 // instead of widening to the whole repo. repoGID and configGID come from the
-// VaultAssetInstallation row.
-func (s *SleuthVault) monoRepoConfigPaths(ctx context.Context, repoGID, configGID string) ([]string, error) {
-	resp, err := vaultgql.RepoMonoRepoConfigs(ctx, s.gqlClient(), repoGID)
-	if err != nil {
-		return nil, err
-	}
-	if resp.Repository == nil {
-		return nil, nil
-	}
-	for _, cfg := range resp.Repository.MonoRepoConfigs {
-		if cfg.Id == nil || *cfg.Id != configGID {
-			continue
+// VaultAssetInstallation row. cache (repoGID -> configGID -> paths) collapses
+// repeated lookups of the same repo's configs within one read.
+func (s *SleuthVault) monoRepoConfigPaths(ctx context.Context, repoGID, configGID string, cache map[string]map[string][]string) ([]string, error) {
+	configs, ok := cache[repoGID]
+	if !ok {
+		resp, err := vaultgql.RepoMonoRepoConfigs(ctx, s.gqlClient(), repoGID)
+		if err != nil {
+			return nil, err
 		}
-		paths := make([]string, 0, len(cfg.SourcePathPrefixIncludes))
-		for _, p := range cfg.SourcePathPrefixIncludes {
-			if p != nil && *p != "" {
-				paths = append(paths, *p)
+		configs = map[string][]string{}
+		if resp.Repository != nil {
+			for _, cfg := range resp.Repository.MonoRepoConfigs {
+				if cfg.Id == nil {
+					continue
+				}
+				paths := make([]string, 0, len(cfg.SourcePathPrefixIncludes))
+				for _, p := range cfg.SourcePathPrefixIncludes {
+					if p != nil && *p != "" {
+						paths = append(paths, *p)
+					}
+				}
+				configs[*cfg.Id] = paths
 			}
 		}
-		return paths, nil
+		cache[repoGID] = configs
 	}
-	return nil, nil
+	return configs[configGID], nil
 }
 
 func (s *SleuthVault) RemoveAssetInstallation(ctx context.Context, assetName string, target InstallTarget) error {
@@ -1357,10 +1365,9 @@ func (s *SleuthVault) RecordUsageEvents(ctx context.Context, events []mgmt.Usage
 	}
 	// Post in chunks so a large import (a whole vault's history) isn't one giant
 	// request the server has to validate and enqueue in a single shot.
-	for start := 0; start < len(events); start += sleuthUsagePostChunkSize {
-		end := min(start+sleuthUsagePostChunkSize, len(events))
+	for _, batch := range chunkSlice(events, sleuthUsagePostChunkSize) {
 		var b strings.Builder
-		for i, ev := range events[start:end] {
+		for i, ev := range batch {
 			if i > 0 {
 				b.WriteByte('\n')
 			}
@@ -1461,10 +1468,9 @@ func (s *SleuthVault) ImportAuditEvents(ctx context.Context, events []mgmt.Audit
 	if len(events) == 0 {
 		return nil
 	}
-	for start := 0; start < len(events); start += sleuthAuditImportChunkSize {
-		end := min(start+sleuthAuditImportChunkSize, len(events))
-		inputs := make([]vaultgql.ImportAuditEventInput, 0, end-start)
-		for _, ev := range events[start:end] {
+	for _, batch := range chunkSlice(events, sleuthAuditImportChunkSize) {
+		inputs := make([]vaultgql.ImportAuditEventInput, 0, len(batch))
+		for _, ev := range batch {
 			in := vaultgql.ImportAuditEventInput{
 				Timestamp:  timeOrNow(ev.Timestamp),
 				Event:      ev.Event,

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -1232,28 +1232,40 @@ func (s *SleuthVault) RecordUsageEvents(ctx context.Context, events []mgmt.Usage
 	if len(events) == 0 {
 		return nil
 	}
-	var b strings.Builder
-	for i, ev := range events {
-		if i > 0 {
-			b.WriteByte('\n')
+	// Post in chunks so a large import (a whole vault's history) isn't one giant
+	// request the server has to validate and enqueue in a single shot.
+	for start := 0; start < len(events); start += sleuthUsagePostChunkSize {
+		end := min(start+sleuthUsagePostChunkSize, len(events))
+		var b strings.Builder
+		for i, ev := range events[start:end] {
+			if i > 0 {
+				b.WriteByte('\n')
+			}
+			payload := map[string]any{
+				"asset_name":    ev.AssetName,
+				"asset_version": ev.AssetVersion,
+				"asset_type":    ev.AssetType,
+				"timestamp":     timeOrNow(ev.Timestamp).Format(time.RFC3339),
+			}
+			if ev.Actor != "" {
+				payload["actor"] = ev.Actor
+			}
+			line, err := json.Marshal(payload)
+			if err != nil {
+				return err
+			}
+			b.Write(line)
 		}
-		payload := map[string]any{
-			"asset_name":    ev.AssetName,
-			"asset_version": ev.AssetVersion,
-			"asset_type":    ev.AssetType,
-			"timestamp":     timeOrNow(ev.Timestamp).Format(time.RFC3339),
-		}
-		if ev.Actor != "" {
-			payload["actor"] = ev.Actor
-		}
-		line, err := json.Marshal(payload)
-		if err != nil {
+		if err := s.PostUsageStats(ctx, b.String()); err != nil {
 			return err
 		}
-		b.Write(line)
 	}
-	return s.PostUsageStats(ctx, b.String())
+	return nil
 }
+
+// sleuthUsagePostChunkSize bounds how many usage events go in a single
+// /api/usage POST during a bulk import.
+const sleuthUsagePostChunkSize = 1000
 
 func (s *SleuthVault) GetUsageStats(ctx context.Context, filter mgmt.UsageFilter) (*mgmt.UsageSummary, error) {
 	events, err := s.ReadUsageEvents(ctx, filter)

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -430,6 +430,61 @@ func (s *SleuthVault) SetAssetInstallation(ctx context.Context, assetName string
 	return fmt.Errorf("unknown install kind: %q", target.Kind)
 }
 
+// SetAssetInstallations replaces an asset's entire installation set in a single
+// server call. Because the skills.new mutation replaces (rather than appends),
+// the per-target SetAssetInstallation would let each call clobber the previous
+// one for a multi-scope asset; this sends every target at once so they all
+// stick. Org-wide is exclusive — if any target is org, the asset goes global.
+func (s *SleuthVault) SetAssetInstallations(ctx context.Context, assetName string, targets []InstallTarget) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	for _, t := range targets {
+		if t.Kind == InstallKindOrg {
+			return s.setAssetInstallationsGraphQL(ctx, assetName, nil, false, nil)
+		}
+	}
+	var repositories []vaultgql.RepositoryInstallationInput
+	var installations []vaultgql.AssetInstallationInput
+	for _, t := range targets {
+		switch t.Kind {
+		case InstallKindOrg:
+			// Handled before the loop (org is exclusive); unreachable here.
+		case InstallKindRepo:
+			repositories = append(repositories, vaultgql.RepositoryInstallationInput{Url: t.Repo})
+		case InstallKindPath:
+			repositories = append(repositories, vaultgql.RepositoryInstallationInput{Url: t.Repo, Paths: t.Paths})
+		case InstallKindTeam:
+			gid, err := s.teamGIDByName(ctx, t.Team)
+			if err != nil {
+				return err
+			}
+			installations = append(installations, vaultgql.AssetInstallationInput{
+				EntityType: vaultgql.VaultAssetInstallationEntityTypeTeam, EntityId: &gid,
+			})
+		case InstallKindUser:
+			gid, err := s.userGIDByEmail(ctx, t.User)
+			if err != nil {
+				return err
+			}
+			installations = append(installations, vaultgql.AssetInstallationInput{
+				EntityType: vaultgql.VaultAssetInstallationEntityTypeUser, EntityId: &gid,
+			})
+		case InstallKindBot:
+			gid, err := s.botGIDByName(ctx, t.Bot)
+			if err != nil {
+				return err
+			}
+			installations = append(installations, vaultgql.AssetInstallationInput{
+				EntityType: vaultgql.VaultAssetInstallationEntityTypeBot, EntityId: &gid,
+			})
+		default:
+			return fmt.Errorf("unknown install kind: %q", t.Kind)
+		}
+	}
+	return s.setAssetInstallationsGraphQL(ctx, assetName, repositories, false, installations)
+}
+
 // AssetInstallScopes reads an asset's installation targets from the server and
 // maps them to manifest scopes, so the copy engine can replay scopes when the
 // SOURCE is a skills.new vault (the file-backed vaults read them from sx.toml).

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -495,9 +495,12 @@ func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]ma
 	if err != nil {
 		return nil, false, err
 	}
+	// The caller passes the asset slug (AssetSummary.Name is the slug for Sleuth).
+	// Match on slug first — display name may differ — falling back to name.
 	var node *vaultgql.AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAsset
 	for i := range resp.Vault.Assets.Nodes {
-		if strings.EqualFold(resp.Vault.Assets.Nodes[i].GetName(), name) {
+		n := resp.Vault.Assets.Nodes[i]
+		if strings.EqualFold(n.GetSlug(), name) || strings.EqualFold(n.GetName(), name) {
 			node = &resp.Vault.Assets.Nodes[i]
 			break
 		}

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -541,6 +541,18 @@ func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]ma
 			// Org-wide is exclusive; report it as present-with-no-scopes.
 			return nil, true, nil
 		case vaultgql.VaultAssetInstallationEntityTypeRepository:
+			// A mono-repo config means the install is path-scoped, not whole-repo.
+			// Resolve the actual subpaths so they aren't silently widened.
+			if inst.MonoRepoConfigId != nil && inst.EntityId != nil {
+				paths, perr := s.monoRepoConfigPaths(ctx, *inst.EntityId, *inst.MonoRepoConfigId)
+				if perr != nil {
+					return nil, false, perr
+				}
+				if len(paths) > 0 {
+					scopes = append(scopes, manifest.Scope{Kind: manifest.ScopeKindPath, Repo: inst.EntityName, Paths: paths})
+					continue
+				}
+			}
 			scopes = append(scopes, manifest.Scope{Kind: manifest.ScopeKindRepo, Repo: inst.EntityName})
 		case vaultgql.VaultAssetInstallationEntityTypeTeam:
 			scopes = append(scopes, manifest.Scope{Kind: manifest.ScopeKindTeam, Team: inst.EntityName})
@@ -551,6 +563,33 @@ func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]ma
 		}
 	}
 	return scopes, true, nil
+}
+
+// monoRepoConfigPaths resolves a repository's mono-repo config to its include
+// paths, so a path-scoped install read from the server keeps its subpaths
+// instead of widening to the whole repo. repoGID and configGID come from the
+// VaultAssetInstallation row.
+func (s *SleuthVault) monoRepoConfigPaths(ctx context.Context, repoGID, configGID string) ([]string, error) {
+	resp, err := vaultgql.RepoMonoRepoConfigs(ctx, s.gqlClient(), repoGID)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Repository == nil {
+		return nil, nil
+	}
+	for _, cfg := range resp.Repository.MonoRepoConfigs {
+		if cfg.Id == nil || *cfg.Id != configGID {
+			continue
+		}
+		paths := make([]string, 0, len(cfg.SourcePathPrefixIncludes))
+		for _, p := range cfg.SourcePathPrefixIncludes {
+			if p != nil && *p != "" {
+				paths = append(paths, *p)
+			}
+		}
+		return paths, nil
+	}
+	return nil, nil
 }
 
 func (s *SleuthVault) RemoveAssetInstallation(ctx context.Context, assetName string, target InstallTarget) error {

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -505,8 +505,16 @@ func (s *SleuthVault) AssetInstallScopes(ctx context.Context, name string) ([]ma
 	if node == nil {
 		return nil, false, nil
 	}
+	insts := (*node).GetInstallations()
+	if len(insts) == 0 {
+		// The asset exists on the server but is not installed anywhere. That is
+		// NOT org-wide — report it as not-present so the copy leaves it
+		// uninstalled on the destination (only an explicit ORGANIZATION install
+		// is org-wide; see below).
+		return nil, false, nil
+	}
 	var scopes []manifest.Scope
-	for _, inst := range (*node).GetInstallations() {
+	for _, inst := range insts {
 		switch inst.EntityType {
 		case vaultgql.VaultAssetInstallationEntityTypeOrganization:
 			// Org-wide is exclusive; report it as present-with-no-scopes.

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -1344,11 +1344,18 @@ func (s *SleuthVault) ImportAuditEvents(ctx context.Context, events []mgmt.Audit
 				in.Target = &target
 			}
 			if len(ev.Data) > 0 {
-				raw, err := json.Marshal(ev.Data)
+				obj, err := json.Marshal(ev.Data)
 				if err != nil {
 					return err
 				}
-				rm := json.RawMessage(raw)
+				// The `data` field is a JSONString scalar: the server expects a
+				// JSON-encoded STRING (which it json.loads), not a raw object. Wrap
+				// the object as a string — mirrors how QueryAuditEvents decodes it.
+				strForm, err := json.Marshal(string(obj))
+				if err != nil {
+					return err
+				}
+				rm := json.RawMessage(strForm)
 				in.Data = &rm
 			}
 			inputs = append(inputs, in)

--- a/internal/vault/sleuth_repo_test.go
+++ b/internal/vault/sleuth_repo_test.go
@@ -1,0 +1,20 @@
+package vault
+
+import "testing"
+
+func TestTrailingOwnerName(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/acme/repo":      "acme/repo",
+		"https://github.com/acme/repo.git":  "acme/repo",
+		"github.com/acme/Repo":              "acme/repo",
+		"acme/repo":                         "acme/repo",
+		"git@github.com:acme/repo.git":      "acme/repo",
+		"  https://gitlab.com/g/acme/repo ": "acme/repo",
+		"repo":                              "repo",
+	}
+	for in, want := range cases {
+		if got := trailingOwnerName(in); got != want {
+			t.Errorf("trailingOwnerName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/vault/utils.go
+++ b/internal/vault/utils.go
@@ -14,3 +14,20 @@ func parseVersionList(data []byte) []string {
 	}
 	return versions
 }
+
+// chunkSlice splits items into contiguous sub-slices of at most size elements.
+// An empty input yields no chunks; a non-positive size yields a single chunk.
+// Used to bound per-request payloads (audit import, usage POST).
+func chunkSlice[T any](items []T, size int) [][]T {
+	if len(items) == 0 {
+		return nil
+	}
+	if size <= 0 {
+		return [][]T{items}
+	}
+	chunks := make([][]T, 0, (len(items)+size-1)/size)
+	for start := 0; start < len(items); start += size {
+		chunks = append(chunks, items[start:min(start+size, len(items))])
+	}
+	return chunks
+}

--- a/internal/vaultcopy/scopes_test.go
+++ b/internal/vaultcopy/scopes_test.go
@@ -85,9 +85,28 @@ func TestCopyAssetScopes_BulkUnresolvedCountedAndWarned(t *testing.T) {
 	if len(r.Warnings) != 1 {
 		t.Fatalf("want one skipped-scope warning, got %v", r.Warnings)
 	}
+	if f.clearCalls != 0 {
+		t.Fatalf("partial success must not clear, got %d clears", f.clearCalls)
+	}
 }
 
-func TestCopyAssetScopes_BulkErrorWarnsNoFallback(t *testing.T) {
+func TestCopyAssetScopes_BulkAllUnresolvedClears(t *testing.T) {
+	// Every target unresolvable → nothing applied → the asset must not keep the
+	// auto-applied org-wide install; the engine clears it.
+	f := &bulkFake{unresolved: []vault.InstallTarget{{Kind: vault.InstallKindUser, User: "ghost@x.com"}}}
+	r := &Report{}
+	scopes := []manifest.Scope{{Kind: manifest.ScopeKindUser, User: "ghost@x.com"}}
+	copyAssetScopes(context.Background(), f, "skill", scopes, true, false, r)
+
+	if r.Scopes != 0 {
+		t.Fatalf("Scopes = %d, want 0", r.Scopes)
+	}
+	if f.clearCalls != 1 {
+		t.Fatalf("all-unresolved must clear the auto-applied install once, got %d", f.clearCalls)
+	}
+}
+
+func TestCopyAssetScopes_BulkErrorClearsNoFallback(t *testing.T) {
 	f := &bulkFake{bulkErr: errors.New("repo rejected by server")}
 	r := &Report{}
 	scopes := []manifest.Scope{
@@ -99,8 +118,8 @@ func TestCopyAssetScopes_BulkErrorWarnsNoFallback(t *testing.T) {
 	if r.Scopes != 0 {
 		t.Fatalf("Scopes = %d, want 0 on bulk error (no clobbering fallback)", r.Scopes)
 	}
-	if len(r.Warnings) != 1 {
-		t.Fatalf("want one failure warning, got %v", r.Warnings)
+	if f.clearCalls != 1 {
+		t.Fatalf("bulk error must clear the auto-applied install, got %d clears", f.clearCalls)
 	}
 }
 

--- a/internal/vaultcopy/scopes_test.go
+++ b/internal/vaultcopy/scopes_test.go
@@ -1,0 +1,99 @@
+package vaultcopy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/vault"
+)
+
+// fakeInstaller records scope-set calls and implements both the per-target and
+// bulk installer interfaces, optionally failing the bulk call.
+type fakeInstaller struct {
+	bulkCalls   [][]vault.InstallTarget
+	singleCalls []vault.InstallTarget
+	bulkErr     error
+}
+
+func (f *fakeInstaller) SetAssetInstallation(_ context.Context, _ string, t vault.InstallTarget) error {
+	f.singleCalls = append(f.singleCalls, t)
+	return nil
+}
+
+func (f *fakeInstaller) SetAssetInstallations(_ context.Context, _ string, targets []vault.InstallTarget) error {
+	f.bulkCalls = append(f.bulkCalls, targets)
+	return f.bulkErr
+}
+
+func TestCopyAssetScopes_MultiScopeUsesBulk(t *testing.T) {
+	f := &fakeInstaller{}
+	r := &Report{}
+	scopes := []manifest.Scope{
+		{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"},
+		{Kind: manifest.ScopeKindTeam, Team: "platform"},
+	}
+	copyAssetScopes(context.Background(), f, "skill", scopes, true, false, r)
+
+	if len(f.bulkCalls) != 1 || len(f.bulkCalls[0]) != 2 {
+		t.Fatalf("want one bulk call with 2 targets, got bulk=%v single=%v", f.bulkCalls, f.singleCalls)
+	}
+	if len(f.singleCalls) != 0 {
+		t.Fatalf("want no per-target calls when bulk succeeds, got %v", f.singleCalls)
+	}
+	if r.Scopes != 2 {
+		t.Fatalf("Scopes = %d, want 2", r.Scopes)
+	}
+}
+
+func TestCopyAssetScopes_BulkFailureFallsBack(t *testing.T) {
+	f := &fakeInstaller{bulkErr: errors.New("repo not found")}
+	r := &Report{}
+	scopes := []manifest.Scope{
+		{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"},
+		{Kind: manifest.ScopeKindBot, Bot: "ci"},
+	}
+	copyAssetScopes(context.Background(), f, "skill", scopes, true, false, r)
+
+	if len(f.bulkCalls) != 1 {
+		t.Fatalf("want one bulk attempt, got %v", f.bulkCalls)
+	}
+	if len(f.singleCalls) != 2 {
+		t.Fatalf("want per-target fallback (2 calls), got %v", f.singleCalls)
+	}
+	if r.Scopes != 2 {
+		t.Fatalf("Scopes = %d, want 2", r.Scopes)
+	}
+}
+
+func TestCopyAssetScopes_SingleScopeSkipsBulk(t *testing.T) {
+	f := &fakeInstaller{}
+	r := &Report{}
+	copyAssetScopes(context.Background(), f, "skill",
+		[]manifest.Scope{{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"}}, true, false, r)
+
+	if len(f.bulkCalls) != 0 || len(f.singleCalls) != 1 {
+		t.Fatalf("single scope should use per-target, got bulk=%v single=%v", f.bulkCalls, f.singleCalls)
+	}
+}
+
+func TestCopyAssetScopes_OrgWideWhenPresentNoScopes(t *testing.T) {
+	f := &fakeInstaller{}
+	r := &Report{}
+	copyAssetScopes(context.Background(), f, "skill", nil, true, false, r)
+
+	if len(f.singleCalls) != 1 || f.singleCalls[0].Kind != vault.InstallKindOrg {
+		t.Fatalf("present-with-no-scopes should set org-wide, got %v", f.singleCalls)
+	}
+}
+
+func TestCopyAssetScopes_NotPresentDoesNothing(t *testing.T) {
+	f := &fakeInstaller{}
+	r := &Report{}
+	copyAssetScopes(context.Background(), f, "skill", nil, false, false, r)
+
+	if len(f.singleCalls) != 0 || len(f.bulkCalls) != 0 || r.Scopes != 0 {
+		t.Fatalf("not-present asset should set nothing, got bulk=%v single=%v scopes=%d", f.bulkCalls, f.singleCalls, r.Scopes)
+	}
+}

--- a/internal/vaultcopy/scopes_test.go
+++ b/internal/vaultcopy/scopes_test.go
@@ -13,12 +13,18 @@ import (
 // vault. It records calls and can report unresolved targets or a hard error.
 type bulkFake struct {
 	bulkCalls  [][]vault.InstallTarget
+	clearCalls int
 	unresolved []vault.InstallTarget
 	bulkErr    error
 }
 
 func (f *bulkFake) SetAssetInstallation(_ context.Context, _ string, _ vault.InstallTarget) error {
 	panic("bulkFake.SetAssetInstallation must not be called — bulk dests use SetAssetInstallations")
+}
+
+func (f *bulkFake) ClearAssetInstallations(_ context.Context, _ string) error {
+	f.clearCalls++
+	return nil
 }
 
 func (f *bulkFake) SetAssetInstallations(_ context.Context, _ string, targets []vault.InstallTarget) ([]vault.InstallTarget, error) {
@@ -29,10 +35,16 @@ func (f *bulkFake) SetAssetInstallations(_ context.Context, _ string, targets []
 // appendFake implements only the per-target installer, like a file-backed vault.
 type appendFake struct {
 	singleCalls []vault.InstallTarget
+	clearCalls  int
 }
 
 func (f *appendFake) SetAssetInstallation(_ context.Context, _ string, t vault.InstallTarget) error {
 	f.singleCalls = append(f.singleCalls, t)
+	return nil
+}
+
+func (f *appendFake) ClearAssetInstallations(_ context.Context, _ string) error {
+	f.clearCalls++
 	return nil
 }
 
@@ -116,12 +128,28 @@ func TestCopyAssetScopes_OrgWideWhenPresentNoScopes(t *testing.T) {
 	}
 }
 
-func TestCopyAssetScopes_NotPresentDoesNothing(t *testing.T) {
-	f := &appendFake{}
+func TestCopyAssetScopes_NotPresentClearsInstalls(t *testing.T) {
+	// A source asset with no installation should end up uninstalled on the
+	// destination — the engine clears any auto-applied install (e.g. the
+	// org-wide default skills.new applies on upload) and sets no scopes.
+	f := &bulkFake{}
 	r := &Report{}
 	copyAssetScopes(context.Background(), f, "skill", nil, false, false, r)
 
-	if len(f.singleCalls) != 0 || r.Scopes != 0 {
-		t.Fatalf("not-present asset should set nothing, got calls=%v scopes=%d", f.singleCalls, r.Scopes)
+	if len(f.bulkCalls) != 0 || r.Scopes != 0 {
+		t.Fatalf("not-present asset should set no scopes, got bulk=%v scopes=%d", f.bulkCalls, r.Scopes)
+	}
+	if f.clearCalls != 1 {
+		t.Fatalf("not-present asset should clear installs once, got %d", f.clearCalls)
+	}
+}
+
+func TestCopyAssetScopes_NotPresentDryRunNoClear(t *testing.T) {
+	f := &bulkFake{}
+	r := &Report{}
+	copyAssetScopes(context.Background(), f, "skill", nil, false, true, r)
+
+	if f.clearCalls != 0 {
+		t.Fatalf("dry-run must not clear, got %d", f.clearCalls)
 	}
 }

--- a/internal/vaultcopy/scopes_test.go
+++ b/internal/vaultcopy/scopes_test.go
@@ -9,26 +9,35 @@ import (
 	"github.com/sleuth-io/sx/internal/vault"
 )
 
-// fakeInstaller records scope-set calls and implements both the per-target and
-// bulk installer interfaces, optionally failing the bulk call.
-type fakeInstaller struct {
-	bulkCalls   [][]vault.InstallTarget
-	singleCalls []vault.InstallTarget
-	bulkErr     error
+// bulkFake implements the bulk (replace-on-set) installer, like the Sleuth
+// vault. It records calls and can report unresolved targets or a hard error.
+type bulkFake struct {
+	bulkCalls  [][]vault.InstallTarget
+	unresolved []vault.InstallTarget
+	bulkErr    error
 }
 
-func (f *fakeInstaller) SetAssetInstallation(_ context.Context, _ string, t vault.InstallTarget) error {
+func (f *bulkFake) SetAssetInstallation(_ context.Context, _ string, _ vault.InstallTarget) error {
+	panic("bulkFake.SetAssetInstallation must not be called — bulk dests use SetAssetInstallations")
+}
+
+func (f *bulkFake) SetAssetInstallations(_ context.Context, _ string, targets []vault.InstallTarget) ([]vault.InstallTarget, error) {
+	f.bulkCalls = append(f.bulkCalls, targets)
+	return f.unresolved, f.bulkErr
+}
+
+// appendFake implements only the per-target installer, like a file-backed vault.
+type appendFake struct {
+	singleCalls []vault.InstallTarget
+}
+
+func (f *appendFake) SetAssetInstallation(_ context.Context, _ string, t vault.InstallTarget) error {
 	f.singleCalls = append(f.singleCalls, t)
 	return nil
 }
 
-func (f *fakeInstaller) SetAssetInstallations(_ context.Context, _ string, targets []vault.InstallTarget) error {
-	f.bulkCalls = append(f.bulkCalls, targets)
-	return f.bulkErr
-}
-
-func TestCopyAssetScopes_MultiScopeUsesBulk(t *testing.T) {
-	f := &fakeInstaller{}
+func TestCopyAssetScopes_BulkDestSetsAllAtOnce(t *testing.T) {
+	f := &bulkFake{}
 	r := &Report{}
 	scopes := []manifest.Scope{
 		{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"},
@@ -37,49 +46,68 @@ func TestCopyAssetScopes_MultiScopeUsesBulk(t *testing.T) {
 	copyAssetScopes(context.Background(), f, "skill", scopes, true, false, r)
 
 	if len(f.bulkCalls) != 1 || len(f.bulkCalls[0]) != 2 {
-		t.Fatalf("want one bulk call with 2 targets, got bulk=%v single=%v", f.bulkCalls, f.singleCalls)
-	}
-	if len(f.singleCalls) != 0 {
-		t.Fatalf("want no per-target calls when bulk succeeds, got %v", f.singleCalls)
+		t.Fatalf("want one bulk call with 2 targets, got %v", f.bulkCalls)
 	}
 	if r.Scopes != 2 {
 		t.Fatalf("Scopes = %d, want 2", r.Scopes)
 	}
 }
 
-func TestCopyAssetScopes_BulkFailureFallsBack(t *testing.T) {
-	f := &fakeInstaller{bulkErr: errors.New("repo not found")}
+func TestCopyAssetScopes_BulkUnresolvedCountedAndWarned(t *testing.T) {
+	// One target unresolved: the bulk call still applies the rest in one shot
+	// (no per-target clobbering), and only the resolved count is recorded.
+	f := &bulkFake{unresolved: []vault.InstallTarget{{Kind: vault.InstallKindUser, User: "ghost@x.com"}}}
 	r := &Report{}
 	scopes := []manifest.Scope{
 		{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"},
-		{Kind: manifest.ScopeKindBot, Bot: "ci"},
+		{Kind: manifest.ScopeKindUser, User: "ghost@x.com"},
 	}
 	copyAssetScopes(context.Background(), f, "skill", scopes, true, false, r)
 
 	if len(f.bulkCalls) != 1 {
-		t.Fatalf("want one bulk attempt, got %v", f.bulkCalls)
+		t.Fatalf("want one bulk call, got %v", f.bulkCalls)
 	}
-	if len(f.singleCalls) != 2 {
-		t.Fatalf("want per-target fallback (2 calls), got %v", f.singleCalls)
+	if r.Scopes != 1 {
+		t.Fatalf("Scopes = %d, want 1 (resolved only)", r.Scopes)
 	}
-	if r.Scopes != 2 {
-		t.Fatalf("Scopes = %d, want 2", r.Scopes)
+	if len(r.Warnings) != 1 {
+		t.Fatalf("want one skipped-scope warning, got %v", r.Warnings)
 	}
 }
 
-func TestCopyAssetScopes_SingleScopeSkipsBulk(t *testing.T) {
-	f := &fakeInstaller{}
+func TestCopyAssetScopes_BulkErrorWarnsNoFallback(t *testing.T) {
+	f := &bulkFake{bulkErr: errors.New("repo rejected by server")}
 	r := &Report{}
-	copyAssetScopes(context.Background(), f, "skill",
-		[]manifest.Scope{{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"}}, true, false, r)
+	scopes := []manifest.Scope{
+		{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"},
+		{Kind: manifest.ScopeKindTeam, Team: "platform"},
+	}
+	copyAssetScopes(context.Background(), f, "skill", scopes, true, false, r)
 
-	if len(f.bulkCalls) != 0 || len(f.singleCalls) != 1 {
-		t.Fatalf("single scope should use per-target, got bulk=%v single=%v", f.bulkCalls, f.singleCalls)
+	if r.Scopes != 0 {
+		t.Fatalf("Scopes = %d, want 0 on bulk error (no clobbering fallback)", r.Scopes)
+	}
+	if len(r.Warnings) != 1 {
+		t.Fatalf("want one failure warning, got %v", r.Warnings)
+	}
+}
+
+func TestCopyAssetScopes_AppendDestUsesPerTarget(t *testing.T) {
+	f := &appendFake{}
+	r := &Report{}
+	scopes := []manifest.Scope{
+		{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/a"},
+		{Kind: manifest.ScopeKindTeam, Team: "platform"},
+	}
+	copyAssetScopes(context.Background(), f, "skill", scopes, true, false, r)
+
+	if len(f.singleCalls) != 2 || r.Scopes != 2 {
+		t.Fatalf("append dest should set each target, got calls=%v scopes=%d", f.singleCalls, r.Scopes)
 	}
 }
 
 func TestCopyAssetScopes_OrgWideWhenPresentNoScopes(t *testing.T) {
-	f := &fakeInstaller{}
+	f := &appendFake{}
 	r := &Report{}
 	copyAssetScopes(context.Background(), f, "skill", nil, true, false, r)
 
@@ -89,11 +117,11 @@ func TestCopyAssetScopes_OrgWideWhenPresentNoScopes(t *testing.T) {
 }
 
 func TestCopyAssetScopes_NotPresentDoesNothing(t *testing.T) {
-	f := &fakeInstaller{}
+	f := &appendFake{}
 	r := &Report{}
 	copyAssetScopes(context.Background(), f, "skill", nil, false, false, r)
 
-	if len(f.singleCalls) != 0 || len(f.bulkCalls) != 0 || r.Scopes != 0 {
-		t.Fatalf("not-present asset should set nothing, got bulk=%v single=%v scopes=%d", f.bulkCalls, f.singleCalls, r.Scopes)
+	if len(f.singleCalls) != 0 || r.Scopes != 0 {
+		t.Fatalf("not-present asset should set nothing, got calls=%v scopes=%d", f.singleCalls, r.Scopes)
 	}
 }

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -209,12 +209,13 @@ type scopeInstaller interface {
 	SetAssetInstallation(ctx context.Context, name string, target vault.InstallTarget) error
 }
 
-// bulkInstaller is implemented by vaults that can set an asset's whole
-// installation set in one call (the Sleuth vault). It matters because that
-// backend replaces-on-set: setting scopes one at a time would let each call
-// clobber the last, so a multi-scope asset would keep only its final scope.
+// bulkInstaller is implemented by vaults that replace-on-set and so must set an
+// asset's whole installation set in one call (the Sleuth vault): setting scopes
+// one at a time would let each call clobber the last, leaving only the final
+// scope. It returns the targets it couldn't resolve in the destination (skipped,
+// not applied) so the caller can warn without the others being lost.
 type bulkInstaller interface {
-	SetAssetInstallations(ctx context.Context, name string, targets []vault.InstallTarget) error
+	SetAssetInstallations(ctx context.Context, name string, targets []vault.InstallTarget) (unresolved []vault.InstallTarget, err error)
 }
 
 func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scopes []manifest.Scope, present, dryRun bool, r *Report) {
@@ -247,19 +248,24 @@ func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scope
 		return
 	}
 
-	// Prefer one bulk call when the destination supports it (skills.new), so a
-	// multi-scope asset lands atomically rather than each call replacing the
-	// last. Fall back to per-target on any bulk error so one unresolvable
-	// target (e.g. a repo absent from the destination org) doesn't drop the
-	// rest — matching the engine's best-effort behavior.
-	if bulk, ok := dst.(bulkInstaller); ok && len(targets) > 1 {
-		if err := bulk.SetAssetInstallations(ctx, name, targets); err == nil {
-			r.Scopes += len(targets)
+	// On a replace-on-set backend (skills.new) we must set every scope in one
+	// call — per-target calls would clobber each other. The bulk call is
+	// best-effort: it applies all resolvable targets atomically and reports the
+	// rest as unresolved (so we never fall back to clobbering per-target calls).
+	if bulk, ok := dst.(bulkInstaller); ok {
+		unresolved, err := bulk.SetAssetInstallations(ctx, name, targets)
+		if err != nil {
+			r.warnf("set scopes on %q: %v", name, err)
 			return
-		} else {
-			r.warnf("bulk-set scopes on %q failed (%v); retrying per-scope", name, err)
 		}
+		for _, u := range unresolved {
+			r.warnf("scope %s on %q skipped (not found in destination)", u.Describe(), name)
+		}
+		r.Scopes += len(targets) - len(unresolved)
+		return
 	}
+	// Append-on-set backends (file-backed): each target is independent, so a
+	// per-target loop is correct and gives partial success.
 	for _, target := range targets {
 		if err := dst.SetAssetInstallation(ctx, name, target); err != nil {
 			r.warnf("set scope %s on %q: %v", target.Describe(), name, err)

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -203,10 +203,11 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 }
 
 // scopeInstaller is the slice of a vault the scope-copy step needs: set one
-// installation target at a time. Narrowed from vault.Vault so the dispatch
-// logic is unit-testable with a fake.
+// installation target at a time, or clear an asset's installs entirely.
+// Narrowed from vault.Vault so the dispatch logic is unit-testable with a fake.
 type scopeInstaller interface {
 	SetAssetInstallation(ctx context.Context, name string, target vault.InstallTarget) error
+	ClearAssetInstallations(ctx context.Context, name string) error
 }
 
 // bulkInstaller is implemented by vaults that replace-on-set and so must set an
@@ -220,8 +221,17 @@ type bulkInstaller interface {
 
 func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scopes []manifest.Scope, present, dryRun bool, r *Report) {
 	if !present {
-		// Asset exists only as uploaded files (never installed) — nothing to
-		// register on the destination beyond the version content already copied.
+		// The asset has no installation in the source, so it should have none in
+		// the destination. Some backends auto-install on upload (skills.new
+		// publishes uploaded assets org-wide by default), so explicitly clear to
+		// match the source's uninstalled state. No-op on backends that don't
+		// auto-install (file-backed vaults leave an uploaded-but-unregistered
+		// asset alone).
+		if !dryRun {
+			if err := dst.ClearAssetInstallations(ctx, name); err != nil {
+				r.warnf("clear auto-applied install on %q: %v", name, err)
+			}
+		}
 		return
 	}
 

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -64,6 +64,11 @@ type assetScopeReader interface {
 
 const assetListLimit = 10000
 
+// sleuthBotListSoftCap mirrors the Sleuth backend's bot-list soft cap. Kept here
+// only to warn when a copy may have been truncated; if the server cap changes
+// this just affects when the heuristic warning fires, not correctness.
+const sleuthBotListSoftCap = 1000
+
 // Copy migrates the selected categories from src into dst. Each category is
 // independent: a category-level failure is recorded as a warning and the copy
 // moves on to the next, so one broken category (e.g. audit) never costs the
@@ -87,7 +92,13 @@ func Copy(ctx context.Context, src, dst vault.Vault, opts Options) (*Report, err
 			continue
 		}
 		if err := s.fn(ctx, src, dst, opts, r); err != nil {
-			r.warnf("copy %s failed: %v", s.name, err)
+			// Audit/usage import is additive, so a mid-stage failure that already
+			// landed some chunks will double them on retry — say so in the moment.
+			if s.name == "audit" || s.name == "usage" {
+				r.warnf("copy %s failed: %v — re-running may duplicate already-imported events on the destination", s.name, err)
+			} else {
+				r.warnf("copy %s failed: %v", s.name, err)
+			}
 		}
 	}
 	return r, nil
@@ -135,21 +146,60 @@ func copyBots(ctx context.Context, src, dst vault.Vault, opts Options, r *Report
 	if err != nil {
 		return err
 	}
+	// The Sleuth backend lists bots under a soft cap (1000); ListBots exposes no
+	// HasMore, so surface a heuristic warning when we hit it rather than only
+	// emitting a structured log the operator won't see.
+	if len(bots) >= sleuthBotListSoftCap {
+		r.warnf("source returned %d bots (the server's list cap); any beyond that were not copied", len(bots))
+	}
 	for _, b := range bots {
 		r.Bots++
 		if opts.DryRun {
 			continue
 		}
-		// CreateBot may auto-issue a token (Sleuth) — it can't be copied, so we
-		// drop it and note that bot keys must be regenerated.
-		if _, err := dst.CreateBot(ctx, mgmt.Bot{Name: b.Name, Description: b.Description, Teams: b.Teams}); err != nil {
+		// CreateBot on Sleuth auto-issues a default API key (returned once and
+		// otherwise unrecoverable). The copy can't carry keys, so the auto-issued
+		// one would be an orphan — revoke it so the destination doesn't accumulate
+		// dead keys. Operators regenerate keys as needed.
+		rawToken, err := dst.CreateBot(ctx, mgmt.Bot{Name: b.Name, Description: b.Description, Teams: b.Teams})
+		if err != nil {
 			r.warnf("create bot %q: %v", b.Name, err)
+			continue
+		}
+		if rawToken != "" {
+			revokeAutoIssuedBotKeys(ctx, dst, b.Name, r)
 		}
 	}
 	if len(bots) > 0 && !opts.DryRun {
-		r.warnf("bot API keys are not copyable; regenerate them on the destination")
+		r.warnf("bot API keys are not copied; create fresh ones on the destination with 'sx bot key create'")
 	}
 	return nil
+}
+
+// botKeyManager is the slice of a vault needed to clean up an auto-issued bot
+// key (Sleuth implements BotApiKeyManager; file-backed vaults don't issue keys).
+type botKeyManager interface {
+	ListBotApiKeys(ctx context.Context, botName string) ([]mgmt.BotApiKey, error)
+	DeleteBotApiKey(ctx context.Context, botName, keyID string) error
+}
+
+// revokeAutoIssuedBotKeys deletes the key(s) a just-created bot was auto-issued,
+// so a copy doesn't leave orphan, unusable keys on the destination.
+func revokeAutoIssuedBotKeys(ctx context.Context, dst vault.Vault, botName string, r *Report) {
+	km, ok := dst.(botKeyManager)
+	if !ok {
+		return
+	}
+	keys, err := km.ListBotApiKeys(ctx, botName)
+	if err != nil {
+		r.warnf("list auto-issued keys for bot %q: %v", botName, err)
+		return
+	}
+	for _, k := range keys {
+		if err := km.DeleteBotApiKey(ctx, botName, k.ID); err != nil {
+			r.warnf("revoke auto-issued key for bot %q: %v", botName, err)
+		}
+	}
 }
 
 func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Report) error {
@@ -167,6 +217,23 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 			r.warnf("list versions for %q: %v", a.Name, err)
 			continue
 		}
+
+		// Read the source's scopes BEFORE uploading any versions. If the read
+		// fails we skip the asset entirely rather than leaving stranded versions
+		// on the destination (and, on Sleuth, an auto-applied org-wide install
+		// with no way to know it should have been narrowed).
+		var (
+			scopes  []manifest.Scope
+			present bool
+		)
+		if canReadScopes {
+			scopes, present, err = scopeReader.AssetInstallScopes(ctx, a.Name)
+			if err != nil {
+				r.warnf("read scopes for %q: %v; skipping asset", a.Name, err)
+				continue
+			}
+		}
+
 		r.Assets++
 		for _, v := range version.Sort(versions) {
 			if opts.DryRun {
@@ -191,12 +258,7 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 			r.Versions++
 		}
 		if canReadScopes {
-			scopes, present, err := scopeReader.AssetInstallScopes(ctx, a.Name)
-			if err != nil {
-				r.warnf("read scopes for %q: %v", a.Name, err)
-			} else {
-				copyAssetScopes(ctx, dst, a.Name, scopes, present, opts.DryRun, r)
-			}
+			copyAssetScopes(ctx, dst, a.Name, scopes, present, opts.DryRun, r)
 		}
 	}
 	return nil
@@ -219,18 +281,22 @@ type bulkInstaller interface {
 	SetAssetInstallations(ctx context.Context, name string, targets []vault.InstallTarget) (unresolved []vault.InstallTarget, err error)
 }
 
+// clearAutoInstall undoes any install a destination auto-applies on upload
+// (skills.new publishes uploaded assets org-wide by default), so an asset that
+// should end up with no — or no resolvable — scopes isn't silently widened.
+// No-op on backends that don't auto-install.
+func clearAutoInstall(ctx context.Context, dst scopeInstaller, name string, r *Report) {
+	if err := dst.ClearAssetInstallations(ctx, name); err != nil {
+		r.warnf("clear auto-applied install on %q: %v", name, err)
+	}
+}
+
 func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scopes []manifest.Scope, present, dryRun bool, r *Report) {
 	if !present {
 		// The asset has no installation in the source, so it should have none in
-		// the destination. Some backends auto-install on upload (skills.new
-		// publishes uploaded assets org-wide by default), so explicitly clear to
-		// match the source's uninstalled state. No-op on backends that don't
-		// auto-install (file-backed vaults leave an uploaded-but-unregistered
-		// asset alone).
+		// the destination. Clear the auto-applied install to match.
 		if !dryRun {
-			if err := dst.ClearAssetInstallations(ctx, name); err != nil {
-				r.warnf("clear auto-applied install on %q: %v", name, err)
-			}
+			clearAutoInstall(ctx, dst, name, r)
 		}
 		return
 	}
@@ -265,13 +331,25 @@ func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scope
 	if bulk, ok := dst.(bulkInstaller); ok {
 		unresolved, err := bulk.SetAssetInstallations(ctx, name, targets)
 		if err != nil {
+			// The set failed, so the asset still carries any auto-applied install
+			// (org-wide on skills.new). Clear it so a failed scope-set doesn't
+			// leave the asset more permissive than the source intended.
 			r.warnf("set scopes on %q: %v", name, err)
+			clearAutoInstall(ctx, dst, name, r)
 			return
 		}
 		for _, u := range unresolved {
 			r.warnf("scope %s on %q skipped (not found in destination)", u.Describe(), name)
 		}
-		r.Scopes += len(targets) - len(unresolved)
+		applied := len(targets) - len(unresolved)
+		if applied == 0 {
+			// Nothing resolved (every target absent from the destination). The
+			// asset would otherwise keep its auto-applied org-wide install, which
+			// is more permissive than the source — clear it instead.
+			clearAutoInstall(ctx, dst, name, r)
+			return
+		}
+		r.Scopes += applied
 		return
 	}
 	// Append-on-set backends (file-backed): each target is independent, so a

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -150,7 +150,7 @@ func copyBots(ctx context.Context, src, dst vault.Vault, opts Options, r *Report
 	// HasMore, so surface a heuristic warning when we hit it rather than only
 	// emitting a structured log the operator won't see.
 	if len(bots) >= sleuthBotListSoftCap {
-		r.warnf("source returned %d bots (the server's list cap); any beyond that were not copied", len(bots))
+		r.warnf("source returned %d bots, the most the server lists in one call; if the org has more, they were not copied", len(bots))
 	}
 	for _, b := range bots {
 		r.Bots++
@@ -317,6 +317,12 @@ func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scope
 		}
 	}
 	if len(targets) == 0 {
+		// The asset had scopes but none mapped to a target (e.g. an unsupported
+		// kind). Don't leave the destination's auto-applied install in place —
+		// clear it, mirroring the all-unresolved path below.
+		if !dryRun {
+			clearAutoInstall(ctx, dst, name, r)
+		}
 		return
 	}
 	if dryRun {

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -64,33 +64,30 @@ type assetScopeReader interface {
 
 const assetListLimit = 10000
 
-// Copy migrates the selected categories from src into dst. It returns a Report
-// even on error so the caller can show partial progress.
+// Copy migrates the selected categories from src into dst. Each category is
+// independent: a category-level failure is recorded as a warning and the copy
+// moves on to the next, so one broken category (e.g. audit) never costs the
+// others (e.g. usage). Always returns a Report for partial-progress reporting.
 func Copy(ctx context.Context, src, dst vault.Vault, opts Options) (*Report, error) {
 	r := &Report{}
-	if opts.Teams {
-		if err := copyTeams(ctx, src, dst, opts, r); err != nil {
-			return r, fmt.Errorf("copy teams: %w", err)
-		}
+	// Run in a fixed order (teams/bots before assets so scope targets exist).
+	stages := []struct {
+		name string
+		on   bool
+		fn   func(context.Context, vault.Vault, vault.Vault, Options, *Report) error
+	}{
+		{"teams", opts.Teams, copyTeams},
+		{"bots", opts.Bots, copyBots},
+		{"assets", opts.Assets, copyAssets},
+		{"audit", opts.Audit, copyAudit},
+		{"usage", opts.Usage, copyUsage},
 	}
-	if opts.Bots {
-		if err := copyBots(ctx, src, dst, opts, r); err != nil {
-			return r, fmt.Errorf("copy bots: %w", err)
+	for _, s := range stages {
+		if !s.on {
+			continue
 		}
-	}
-	if opts.Assets {
-		if err := copyAssets(ctx, src, dst, opts, r); err != nil {
-			return r, fmt.Errorf("copy assets: %w", err)
-		}
-	}
-	if opts.Audit {
-		if err := copyAudit(ctx, src, dst, opts, r); err != nil {
-			return r, fmt.Errorf("copy audit: %w", err)
-		}
-	}
-	if opts.Usage {
-		if err := copyUsage(ctx, src, dst, opts, r); err != nil {
-			return r, fmt.Errorf("copy usage: %w", err)
+		if err := s.fn(ctx, src, dst, opts, r); err != nil {
+			r.warnf("copy %s failed: %v", s.name, err)
 		}
 	}
 	return r, nil

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -59,7 +59,7 @@ func (r *Report) warnf(format string, args ...any) {
 // (skills.new) sources don't implement it, so scope copy is skipped with a
 // warning when the source is server-backed.
 type manifestScopeReader interface {
-	ManifestAssetScopes(name string) []manifest.Scope
+	ManifestAssetScopes(name string) (scopes []manifest.Scope, present bool)
 }
 
 const assetListLimit = 10000
@@ -100,6 +100,9 @@ func copyTeams(ctx context.Context, src, dst vault.Vault, opts Options, r *Repor
 	res, err := src.ListTeams(ctx, vault.ListTeamsOptions{Limit: vault.DefaultTeamsLimit})
 	if err != nil {
 		return err
+	}
+	if res.HasMore {
+		r.warnf("source has more than %d teams; only the first %d were copied", vault.DefaultTeamsLimit, vault.DefaultTeamsLimit)
 	}
 	for _, summary := range res.Teams {
 		full, err := src.GetTeam(ctx, summary.Name)
@@ -169,36 +172,53 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 		}
 		r.Assets++
 		for _, v := range version.Sort(versions) {
-			r.Versions++
 			if opts.DryRun {
+				r.Versions++
 				continue
 			}
 			data, err := src.GetAssetByVersion(ctx, a.Name, v)
 			if err != nil {
 				r.warnf("download %q@%s: %v", a.Name, v, err)
-				r.Versions--
 				continue
 			}
 			la := &lockfile.Asset{Name: a.Name, Version: v, Type: a.Type}
 			if err := dst.AddAsset(ctx, la, data); err != nil {
 				var exists *vault.ErrVersionExists
 				if errors.As(err, &exists) {
-					r.Versions--
 					r.SkippedVersions++
 					continue
 				}
 				r.warnf("upload %q@%s: %v", a.Name, v, err)
-				r.Versions--
+				continue
 			}
+			r.Versions++
 		}
-		if !opts.DryRun && canReadScopes {
-			copyAssetScopes(ctx, dst, a.Name, scopeReader.ManifestAssetScopes(a.Name), r)
+		if canReadScopes {
+			scopes, present := scopeReader.ManifestAssetScopes(a.Name)
+			copyAssetScopes(ctx, dst, a.Name, scopes, present, opts.DryRun, r)
 		}
 	}
 	return nil
 }
 
-func copyAssetScopes(ctx context.Context, dst vault.Vault, name string, scopes []manifest.Scope, r *Report) {
+func copyAssetScopes(ctx context.Context, dst vault.Vault, name string, scopes []manifest.Scope, present, dryRun bool, r *Report) {
+	if !present {
+		// Asset exists only as uploaded files (never installed) — nothing to
+		// register on the destination beyond the version content already copied.
+		return
+	}
+	if len(scopes) == 0 {
+		// Registered with no scopes == org-wide. Register it so the destination
+		// records the global install rather than leaving an orphan file set.
+		if !dryRun {
+			if err := dst.SetAssetInstallation(ctx, name, vault.InstallTarget{Kind: vault.InstallKindOrg}); err != nil {
+				r.warnf("set org-wide install on %q: %v", name, err)
+				return
+			}
+		}
+		r.Scopes++
+		return
+	}
 	if len(scopes) > 1 {
 		// SetAssetInstallation appends on file-backed vaults but replaces on
 		// skills.new, where each call supersedes the previous one. Flag it so a
@@ -211,9 +231,11 @@ func copyAssetScopes(ctx context.Context, dst vault.Vault, name string, scopes [
 			r.warnf("asset %q: unsupported scope kind %q; skipped", name, sc.Kind)
 			continue
 		}
-		if err := dst.SetAssetInstallation(ctx, name, target); err != nil {
-			r.warnf("set scope %s on %q: %v", target.Describe(), name, err)
-			continue
+		if !dryRun {
+			if err := dst.SetAssetInstallation(ctx, name, target); err != nil {
+				r.warnf("set scope %s on %q: %v", target.Describe(), name, err)
+				continue
+			}
 		}
 		r.Scopes++
 	}

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -1,0 +1,262 @@
+// Package vaultcopy implements a backend-agnostic copy of a vault's contents
+// (teams, bots, assets and their versions, installation scopes, audit history,
+// and usage history) from one vault into another. It is the engine behind
+// `sx vault copy`.
+//
+// Everything is read through the vault.Vault interface (plus a couple of
+// optional capability interfaces), so any source/destination combination of
+// path, git, and skills.new vaults works. The copy is best-effort at the item
+// level: a failure copying one team/asset/etc. is recorded as a warning and the
+// copy continues, so a single bad item never aborts a whole migration.
+package vaultcopy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/mgmt"
+	"github.com/sleuth-io/sx/internal/vault"
+	"github.com/sleuth-io/sx/internal/version"
+)
+
+// Options selects which categories to copy and whether to run read-only.
+type Options struct {
+	Teams  bool
+	Bots   bool
+	Assets bool
+	Audit  bool
+	Usage  bool
+	DryRun bool
+}
+
+// DefaultOptions copies everything.
+func DefaultOptions() Options {
+	return Options{Teams: true, Bots: true, Assets: true, Audit: true, Usage: true}
+}
+
+// Report summarizes what a copy did (or would do, for a dry run).
+type Report struct {
+	Teams           int
+	Bots            int
+	Assets          int
+	Versions        int
+	SkippedVersions int
+	Scopes          int
+	AuditEvents     int
+	UsageEvents     int
+	Warnings        []string
+}
+
+func (r *Report) warnf(format string, args ...any) {
+	r.Warnings = append(r.Warnings, fmt.Sprintf(format, args...))
+}
+
+// manifestScopeReader is implemented by file-backed vaults (path, git); it
+// exposes an asset's complete authoring scopes from the manifest. Server-backed
+// (skills.new) sources don't implement it, so scope copy is skipped with a
+// warning when the source is server-backed.
+type manifestScopeReader interface {
+	ManifestAssetScopes(name string) []manifest.Scope
+}
+
+const assetListLimit = 10000
+
+// Copy migrates the selected categories from src into dst. It returns a Report
+// even on error so the caller can show partial progress.
+func Copy(ctx context.Context, src, dst vault.Vault, opts Options) (*Report, error) {
+	r := &Report{}
+	if opts.Teams {
+		if err := copyTeams(ctx, src, dst, opts, r); err != nil {
+			return r, fmt.Errorf("copy teams: %w", err)
+		}
+	}
+	if opts.Bots {
+		if err := copyBots(ctx, src, dst, opts, r); err != nil {
+			return r, fmt.Errorf("copy bots: %w", err)
+		}
+	}
+	if opts.Assets {
+		if err := copyAssets(ctx, src, dst, opts, r); err != nil {
+			return r, fmt.Errorf("copy assets: %w", err)
+		}
+	}
+	if opts.Audit {
+		if err := copyAudit(ctx, src, dst, opts, r); err != nil {
+			return r, fmt.Errorf("copy audit: %w", err)
+		}
+	}
+	if opts.Usage {
+		if err := copyUsage(ctx, src, dst, opts, r); err != nil {
+			return r, fmt.Errorf("copy usage: %w", err)
+		}
+	}
+	return r, nil
+}
+
+func copyTeams(ctx context.Context, src, dst vault.Vault, opts Options, r *Report) error {
+	res, err := src.ListTeams(ctx, vault.ListTeamsOptions{Limit: vault.DefaultTeamsLimit})
+	if err != nil {
+		return err
+	}
+	for _, summary := range res.Teams {
+		full, err := src.GetTeam(ctx, summary.Name)
+		if err != nil {
+			r.warnf("read team %q: %v", summary.Name, err)
+			continue
+		}
+		r.Teams++
+		if opts.DryRun {
+			continue
+		}
+		team := mgmt.Team{
+			Name:        full.Name,
+			Description: full.Description,
+			Members:     full.Members,
+			Admins:      full.Admins,
+		}
+		if err := dst.CreateTeam(ctx, team); err != nil {
+			// May already exist on a re-run; record and still try to sync repos.
+			r.warnf("create team %q: %v", full.Name, err)
+		}
+		for _, repo := range full.Repositories {
+			if err := dst.AddTeamRepository(ctx, full.Name, repo); err != nil {
+				r.warnf("add repo %q to team %q: %v", repo, full.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func copyBots(ctx context.Context, src, dst vault.Vault, opts Options, r *Report) error {
+	bots, err := src.ListBots(ctx)
+	if err != nil {
+		return err
+	}
+	for _, b := range bots {
+		r.Bots++
+		if opts.DryRun {
+			continue
+		}
+		// CreateBot may auto-issue a token (Sleuth) — it can't be copied, so we
+		// drop it and note that bot keys must be regenerated.
+		if _, err := dst.CreateBot(ctx, mgmt.Bot{Name: b.Name, Description: b.Description, Teams: b.Teams}); err != nil {
+			r.warnf("create bot %q: %v", b.Name, err)
+		}
+	}
+	if len(bots) > 0 && !opts.DryRun {
+		r.warnf("bot API keys are not copyable; regenerate them on the destination")
+	}
+	return nil
+}
+
+func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Report) error {
+	res, err := src.ListAssets(ctx, vault.ListAssetsOptions{Limit: assetListLimit})
+	if err != nil {
+		return err
+	}
+	scopeReader, canReadScopes := src.(manifestScopeReader)
+	if !canReadScopes && len(res.Assets) > 0 {
+		r.warnf("source does not expose asset installation scopes; assets copied without scopes")
+	}
+	for _, a := range res.Assets {
+		versions, err := src.GetVersionList(ctx, a.Name)
+		if err != nil {
+			r.warnf("list versions for %q: %v", a.Name, err)
+			continue
+		}
+		r.Assets++
+		for _, v := range version.Sort(versions) {
+			r.Versions++
+			if opts.DryRun {
+				continue
+			}
+			data, err := src.GetAssetByVersion(ctx, a.Name, v)
+			if err != nil {
+				r.warnf("download %q@%s: %v", a.Name, v, err)
+				r.Versions--
+				continue
+			}
+			la := &lockfile.Asset{Name: a.Name, Version: v, Type: a.Type}
+			if err := dst.AddAsset(ctx, la, data); err != nil {
+				var exists *vault.ErrVersionExists
+				if errors.As(err, &exists) {
+					r.Versions--
+					r.SkippedVersions++
+					continue
+				}
+				r.warnf("upload %q@%s: %v", a.Name, v, err)
+				r.Versions--
+			}
+		}
+		if !opts.DryRun && canReadScopes {
+			copyAssetScopes(ctx, dst, a.Name, scopeReader.ManifestAssetScopes(a.Name), r)
+		}
+	}
+	return nil
+}
+
+func copyAssetScopes(ctx context.Context, dst vault.Vault, name string, scopes []manifest.Scope, r *Report) {
+	if len(scopes) > 1 {
+		// SetAssetInstallation appends on file-backed vaults but replaces on
+		// skills.new, where each call supersedes the previous one. Flag it so a
+		// multi-scope asset's installs can be verified on a server destination.
+		r.warnf("asset %q has %d scopes; verify all applied on the destination (server vaults replace per call)", name, len(scopes))
+	}
+	for _, sc := range scopes {
+		target, ok := scopeToTarget(sc)
+		if !ok {
+			r.warnf("asset %q: unsupported scope kind %q; skipped", name, sc.Kind)
+			continue
+		}
+		if err := dst.SetAssetInstallation(ctx, name, target); err != nil {
+			r.warnf("set scope %s on %q: %v", target.Describe(), name, err)
+			continue
+		}
+		r.Scopes++
+	}
+}
+
+func scopeToTarget(sc manifest.Scope) (vault.InstallTarget, bool) {
+	switch sc.Kind {
+	case manifest.ScopeKindOrg:
+		return vault.InstallTarget{Kind: vault.InstallKindOrg}, true
+	case manifest.ScopeKindRepo:
+		return vault.InstallTarget{Kind: vault.InstallKindRepo, Repo: sc.Repo}, true
+	case manifest.ScopeKindPath:
+		return vault.InstallTarget{Kind: vault.InstallKindPath, Repo: sc.Repo, Paths: sc.Paths}, true
+	case manifest.ScopeKindTeam:
+		return vault.InstallTarget{Kind: vault.InstallKindTeam, Team: sc.Team}, true
+	case manifest.ScopeKindUser:
+		return vault.InstallTarget{Kind: vault.InstallKindUser, User: sc.User}, true
+	case manifest.ScopeKindBot:
+		return vault.InstallTarget{Kind: vault.InstallKindBot, Bot: sc.Bot}, true
+	}
+	return vault.InstallTarget{}, false
+}
+
+func copyAudit(ctx context.Context, src, dst vault.Vault, opts Options, r *Report) error {
+	events, err := src.QueryAuditEvents(ctx, mgmt.AuditFilter{})
+	if err != nil {
+		return err
+	}
+	r.AuditEvents = len(events)
+	if opts.DryRun || len(events) == 0 {
+		return nil
+	}
+	return dst.ImportAuditEvents(ctx, events)
+}
+
+func copyUsage(ctx context.Context, src, dst vault.Vault, opts Options, r *Report) error {
+	events, err := src.ReadUsageEvents(ctx, mgmt.UsageFilter{})
+	if err != nil {
+		return err
+	}
+	r.UsageEvents = len(events)
+	if opts.DryRun || len(events) == 0 {
+		return nil
+	}
+	return dst.RecordUsageEvents(ctx, events)
+}

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -202,41 +202,68 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 	return nil
 }
 
-func copyAssetScopes(ctx context.Context, dst vault.Vault, name string, scopes []manifest.Scope, present, dryRun bool, r *Report) {
+// scopeInstaller is the slice of a vault the scope-copy step needs: set one
+// installation target at a time. Narrowed from vault.Vault so the dispatch
+// logic is unit-testable with a fake.
+type scopeInstaller interface {
+	SetAssetInstallation(ctx context.Context, name string, target vault.InstallTarget) error
+}
+
+// bulkInstaller is implemented by vaults that can set an asset's whole
+// installation set in one call (the Sleuth vault). It matters because that
+// backend replaces-on-set: setting scopes one at a time would let each call
+// clobber the last, so a multi-scope asset would keep only its final scope.
+type bulkInstaller interface {
+	SetAssetInstallations(ctx context.Context, name string, targets []vault.InstallTarget) error
+}
+
+func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scopes []manifest.Scope, present, dryRun bool, r *Report) {
 	if !present {
 		// Asset exists only as uploaded files (never installed) — nothing to
 		// register on the destination beyond the version content already copied.
 		return
 	}
+
+	var targets []vault.InstallTarget
 	if len(scopes) == 0 {
 		// Registered with no scopes == org-wide. Register it so the destination
 		// records the global install rather than leaving an orphan file set.
-		if !dryRun {
-			if err := dst.SetAssetInstallation(ctx, name, vault.InstallTarget{Kind: vault.InstallKindOrg}); err != nil {
-				r.warnf("set org-wide install on %q: %v", name, err)
-				return
-			}
-		}
-		r.Scopes++
-		return
-	}
-	if len(scopes) > 1 {
-		// SetAssetInstallation appends on file-backed vaults but replaces on
-		// skills.new, where each call supersedes the previous one. Flag it so a
-		// multi-scope asset's installs can be verified on a server destination.
-		r.warnf("asset %q has %d scopes; verify all applied on the destination (server vaults replace per call)", name, len(scopes))
-	}
-	for _, sc := range scopes {
-		target, ok := scopeToTarget(sc)
-		if !ok {
-			r.warnf("asset %q: unsupported scope kind %q; skipped", name, sc.Kind)
-			continue
-		}
-		if !dryRun {
-			if err := dst.SetAssetInstallation(ctx, name, target); err != nil {
-				r.warnf("set scope %s on %q: %v", target.Describe(), name, err)
+		targets = []vault.InstallTarget{{Kind: vault.InstallKindOrg}}
+	} else {
+		for _, sc := range scopes {
+			target, ok := scopeToTarget(sc)
+			if !ok {
+				r.warnf("asset %q: unsupported scope kind %q; skipped", name, sc.Kind)
 				continue
 			}
+			targets = append(targets, target)
+		}
+	}
+	if len(targets) == 0 {
+		return
+	}
+	if dryRun {
+		r.Scopes += len(targets)
+		return
+	}
+
+	// Prefer one bulk call when the destination supports it (skills.new), so a
+	// multi-scope asset lands atomically rather than each call replacing the
+	// last. Fall back to per-target on any bulk error so one unresolvable
+	// target (e.g. a repo absent from the destination org) doesn't drop the
+	// rest — matching the engine's best-effort behavior.
+	if bulk, ok := dst.(bulkInstaller); ok && len(targets) > 1 {
+		if err := bulk.SetAssetInstallations(ctx, name, targets); err == nil {
+			r.Scopes += len(targets)
+			return
+		} else {
+			r.warnf("bulk-set scopes on %q failed (%v); retrying per-scope", name, err)
+		}
+	}
+	for _, target := range targets {
+		if err := dst.SetAssetInstallation(ctx, name, target); err != nil {
+			r.warnf("set scope %s on %q: %v", target.Describe(), name, err)
+			continue
 		}
 		r.Scopes++
 	}

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -54,12 +54,12 @@ func (r *Report) warnf(format string, args ...any) {
 	r.Warnings = append(r.Warnings, fmt.Sprintf(format, args...))
 }
 
-// manifestScopeReader is implemented by file-backed vaults (path, git); it
-// exposes an asset's complete authoring scopes from the manifest. Server-backed
-// (skills.new) sources don't implement it, so scope copy is skipped with a
-// warning when the source is server-backed.
-type manifestScopeReader interface {
-	ManifestAssetScopes(name string) (scopes []manifest.Scope, present bool)
+// assetScopeReader reads an asset's installation scopes from a vault. All three
+// backends implement it: file-backed vaults read sx.toml; the Sleuth vault reads
+// the server's installation rows. `present` reports whether the asset is
+// registered (an org-wide asset is present with no scopes).
+type assetScopeReader interface {
+	AssetInstallScopes(ctx context.Context, name string) (scopes []manifest.Scope, present bool, err error)
 }
 
 const assetListLimit = 10000
@@ -160,7 +160,7 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 	if err != nil {
 		return err
 	}
-	scopeReader, canReadScopes := src.(manifestScopeReader)
+	scopeReader, canReadScopes := src.(assetScopeReader)
 	if !canReadScopes && len(res.Assets) > 0 {
 		r.warnf("source does not expose asset installation scopes; assets copied without scopes")
 	}
@@ -194,8 +194,12 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 			r.Versions++
 		}
 		if canReadScopes {
-			scopes, present := scopeReader.ManifestAssetScopes(a.Name)
-			copyAssetScopes(ctx, dst, a.Name, scopes, present, opts.DryRun, r)
+			scopes, present, err := scopeReader.AssetInstallScopes(ctx, a.Name)
+			if err != nil {
+				r.warnf("read scopes for %q: %v", a.Name, err)
+			} else {
+				copyAssetScopes(ctx, dst, a.Name, scopes, present, opts.DryRun, r)
+			}
 		}
 	}
 	return nil

--- a/internal/vaultcopy/vaultcopy_roundtrip_test.go
+++ b/internal/vaultcopy/vaultcopy_roundtrip_test.go
@@ -101,16 +101,16 @@ func TestCopy_PathToPathRoundTrip(t *testing.T) {
 	}
 
 	scopeReader := dst.(interface {
-		ManifestAssetScopes(string) ([]manifest.Scope, bool)
+		AssetInstallScopes(context.Context, string) ([]manifest.Scope, bool, error)
 	})
-	scopes, present := scopeReader.ManifestAssetScopes("my-skill")
-	if !present || len(scopes) != 1 || scopes[0].Kind != manifest.ScopeKindRepo {
-		t.Fatalf("dst my-skill scopes = %+v present=%v, want one repo scope", scopes, present)
+	scopes, present, err := scopeReader.AssetInstallScopes(ctx, "my-skill")
+	if err != nil || !present || len(scopes) != 1 || scopes[0].Kind != manifest.ScopeKindRepo {
+		t.Fatalf("dst my-skill scopes = %+v present=%v err=%v, want one repo scope", scopes, present, err)
 	}
 	// The org-wide asset must be registered (present) with no scopes on dst.
-	orgScopes, orgPresent := scopeReader.ManifestAssetScopes("global-skill")
-	if !orgPresent || len(orgScopes) != 0 {
-		t.Fatalf("dst global-skill scopes = %+v present=%v, want registered org-wide", orgScopes, orgPresent)
+	orgScopes, orgPresent, err := scopeReader.AssetInstallScopes(ctx, "global-skill")
+	if err != nil || !orgPresent || len(orgScopes) != 0 {
+		t.Fatalf("dst global-skill scopes = %+v present=%v err=%v, want registered org-wide", orgScopes, orgPresent, err)
 	}
 
 	// dst holds the imported source events PLUS the copy's own mutation audit

--- a/internal/vaultcopy/vaultcopy_roundtrip_test.go
+++ b/internal/vaultcopy/vaultcopy_roundtrip_test.go
@@ -1,0 +1,188 @@
+package vaultcopy_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/metadata"
+	"github.com/sleuth-io/sx/internal/mgmt"
+	"github.com/sleuth-io/sx/internal/vault"
+	"github.com/sleuth-io/sx/internal/vaultcopy"
+)
+
+// TestCopy_PathToPathRoundTrip seeds a source path vault with a team, a
+// two-version asset (with a repo scope), audit events, and usage events, copies
+// it into an empty destination path vault, and asserts everything landed.
+func TestCopy_PathToPathRoundTrip(t *testing.T) {
+	mgmt.ResetActorCache()
+	ctx := context.Background()
+
+	src := newSeededVault(t)
+	dst := newEmptyVault(t)
+
+	// Seed source.
+	if err := src.CreateTeam(ctx, mgmt.Team{
+		Name:    "platform",
+		Members: []string{"alice@example.com", "bob@example.com"},
+		Admins:  []string{"alice@example.com"},
+	}); err != nil {
+		t.Fatalf("seed team: %v", err)
+	}
+	for _, v := range []string{"1.0.0", "1.1.0"} {
+		a := &lockfile.Asset{Name: "my-skill", Version: v, Type: asset.TypeSkill}
+		if err := src.AddAsset(ctx, a, skillZip(t, "my-skill", v)); err != nil {
+			t.Fatalf("seed asset %s: %v", v, err)
+		}
+	}
+	if err := src.SetAssetInstallation(ctx, "my-skill", vault.InstallTarget{
+		Kind: vault.InstallKindRepo, Repo: "github.com/acme/repo",
+	}); err != nil {
+		t.Fatalf("seed scope: %v", err)
+	}
+	ts := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	if err := src.ImportAuditEvents(ctx, []mgmt.AuditEvent{
+		{Timestamp: ts, Actor: "alice@example.com", Event: "asset.created", TargetType: "asset", Target: "my-skill"},
+	}); err != nil {
+		t.Fatalf("seed audit: %v", err)
+	}
+	if err := src.RecordUsageEvents(ctx, []mgmt.UsageEvent{
+		{Timestamp: ts, Actor: "bob@example.com", AssetName: "my-skill", AssetVersion: "1.1.0", AssetType: "skill"},
+	}); err != nil {
+		t.Fatalf("seed usage: %v", err)
+	}
+
+	// The management ops above (CreateTeam, AddAsset, SetAssetInstallation) each
+	// emit their own audit events, so the source audit log holds more than the
+	// one event we imported. A lossless copy carries all of them — capture the
+	// source count to compare against.
+	srcAudit, err := src.QueryAuditEvents(ctx, mgmt.AuditFilter{})
+	if err != nil {
+		t.Fatalf("read src audit: %v", err)
+	}
+
+	// Copy.
+	report, err := vaultcopy.Copy(ctx, src, dst, vaultcopy.DefaultOptions())
+	if err != nil {
+		t.Fatalf("Copy: %v (warnings: %v)", err, report.Warnings)
+	}
+	if report.Teams != 1 || report.Assets != 1 || report.Versions != 2 || report.Scopes != 1 ||
+		report.AuditEvents != len(srcAudit) || report.UsageEvents != 1 {
+		t.Fatalf("report = %+v, want 1 team / 1 asset / 2 versions / 1 scope / %d audit / 1 usage", report, len(srcAudit))
+	}
+
+	// Assert destination.
+	teams, err := dst.ListTeams(ctx, vault.ListTeamsOptions{Limit: 50})
+	if err != nil || len(teams.Teams) != 1 || teams.Teams[0].Name != "platform" {
+		t.Fatalf("dst teams = %+v err=%v, want platform", teams, err)
+	}
+	team, err := dst.GetTeam(ctx, "platform")
+	if err != nil || len(team.Members) != 2 || len(team.Admins) != 1 {
+		t.Fatalf("dst team = %+v err=%v", team, err)
+	}
+
+	versions, err := dst.GetVersionList(ctx, "my-skill")
+	if err != nil || len(versions) != 2 {
+		t.Fatalf("dst versions = %v err=%v, want 2", versions, err)
+	}
+
+	scopes := dst.(interface {
+		ManifestAssetScopes(string) []manifest.Scope
+	}).ManifestAssetScopes("my-skill")
+	if len(scopes) != 1 || scopes[0].Kind != manifest.ScopeKindRepo {
+		t.Fatalf("dst scopes = %+v, want one repo scope", scopes)
+	}
+
+	// dst holds the imported source events PLUS the copy's own mutation audit
+	// (CreateTeam/AddAsset/SetAssetInstallation on dst each emit one), so it's a
+	// superset. What matters: the imported history is preserved verbatim.
+	audit, err := dst.QueryAuditEvents(ctx, mgmt.AuditFilter{})
+	if err != nil || len(audit) < len(srcAudit) {
+		t.Fatalf("dst audit count = %d err=%v, want >= %d", len(audit), err, len(srcAudit))
+	}
+	// The imported event kept its original (older) timestamp, so it sorts last.
+	if got := audit[len(audit)-1]; !got.Timestamp.Equal(ts) || got.Actor != "alice@example.com" {
+		t.Fatalf("oldest dst audit = %+v, want imported event at %v by alice", got, ts)
+	}
+
+	usage, err := dst.ReadUsageEvents(ctx, mgmt.UsageFilter{})
+	if err != nil || len(usage) != 1 || usage[0].Actor != "bob@example.com" {
+		t.Fatalf("dst usage = %+v err=%v", usage, err)
+	}
+
+	// Re-copying assets is idempotent: a path vault overwrites identical
+	// versions in place (Sleuth signals ErrVersionExists instead), so neither
+	// path duplicates versions.
+	if _, err := vaultcopy.Copy(ctx, src, dst, vaultcopy.Options{Assets: true}); err != nil {
+		t.Fatalf("re-copy: %v", err)
+	}
+	if versions, err := dst.GetVersionList(ctx, "my-skill"); err != nil || len(versions) != 2 {
+		t.Fatalf("after re-copy dst versions = %v err=%v, want 2 (no duplication)", versions, err)
+	}
+}
+
+func newEmptyVault(t *testing.T) vault.Vault {
+	t.Helper()
+	dir := t.TempDir()
+	gitInit(t, dir)
+	if err := manifest.Save(dir, &manifest.Manifest{SchemaVersion: manifest.CurrentSchemaVersion}); err != nil {
+		t.Fatalf("manifest.Save: %v", err)
+	}
+	v, err := vault.NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	return v
+}
+
+func newSeededVault(t *testing.T) vault.Vault { return newEmptyVault(t) }
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "admin@example.com"},
+		{"config", "user.name", "Admin"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func skillZip(t *testing.T, name, ver string) []byte {
+	t.Helper()
+	meta, err := metadata.Marshal(&metadata.Metadata{
+		MetadataVersion: metadata.CurrentMetadataVersion,
+		Asset:           metadata.Asset{Name: name, Version: ver, Type: asset.TypeSkill},
+		Skill:           &metadata.SkillConfig{},
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	write := func(fname string, data []byte) {
+		w, err := zw.Create(fname)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", fname, err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("zip write %s: %v", fname, err)
+		}
+	}
+	write("metadata.toml", meta)
+	write("SKILL.md", []byte("# "+name+"\nversion "+ver+"\n"))
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/vaultcopy/vaultcopy_roundtrip_test.go
+++ b/internal/vaultcopy/vaultcopy_roundtrip_test.go
@@ -46,6 +46,14 @@ func TestCopy_PathToPathRoundTrip(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed scope: %v", err)
 	}
+	// An org-wide asset: uploaded then registered globally (empty scopes).
+	if err := src.AddAsset(ctx, &lockfile.Asset{Name: "global-skill", Version: "1.0.0", Type: asset.TypeSkill},
+		skillZip(t, "global-skill", "1.0.0")); err != nil {
+		t.Fatalf("seed global asset: %v", err)
+	}
+	if err := src.SetAssetInstallation(ctx, "global-skill", vault.InstallTarget{Kind: vault.InstallKindOrg}); err != nil {
+		t.Fatalf("seed org scope: %v", err)
+	}
 	ts := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
 	if err := src.ImportAuditEvents(ctx, []mgmt.AuditEvent{
 		{Timestamp: ts, Actor: "alice@example.com", Event: "asset.created", TargetType: "asset", Target: "my-skill"},
@@ -72,9 +80,9 @@ func TestCopy_PathToPathRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Copy: %v (warnings: %v)", err, report.Warnings)
 	}
-	if report.Teams != 1 || report.Assets != 1 || report.Versions != 2 || report.Scopes != 1 ||
+	if report.Teams != 1 || report.Assets != 2 || report.Versions != 3 || report.Scopes != 2 ||
 		report.AuditEvents != len(srcAudit) || report.UsageEvents != 1 {
-		t.Fatalf("report = %+v, want 1 team / 1 asset / 2 versions / 1 scope / %d audit / 1 usage", report, len(srcAudit))
+		t.Fatalf("report = %+v, want 1 team / 2 assets / 3 versions / 2 scopes / %d audit / 1 usage", report, len(srcAudit))
 	}
 
 	// Assert destination.
@@ -92,11 +100,17 @@ func TestCopy_PathToPathRoundTrip(t *testing.T) {
 		t.Fatalf("dst versions = %v err=%v, want 2", versions, err)
 	}
 
-	scopes := dst.(interface {
-		ManifestAssetScopes(string) []manifest.Scope
-	}).ManifestAssetScopes("my-skill")
-	if len(scopes) != 1 || scopes[0].Kind != manifest.ScopeKindRepo {
-		t.Fatalf("dst scopes = %+v, want one repo scope", scopes)
+	scopeReader := dst.(interface {
+		ManifestAssetScopes(string) ([]manifest.Scope, bool)
+	})
+	scopes, present := scopeReader.ManifestAssetScopes("my-skill")
+	if !present || len(scopes) != 1 || scopes[0].Kind != manifest.ScopeKindRepo {
+		t.Fatalf("dst my-skill scopes = %+v present=%v, want one repo scope", scopes, present)
+	}
+	// The org-wide asset must be registered (present) with no scopes on dst.
+	orgScopes, orgPresent := scopeReader.ManifestAssetScopes("global-skill")
+	if !orgPresent || len(orgScopes) != 0 {
+		t.Fatalf("dst global-skill scopes = %+v present=%v, want registered org-wide", orgScopes, orgPresent)
 	}
 
 	// dst holds the imported source events PLUS the copy's own mutation audit


### PR DESCRIPTION
## Summary
Adds `sx vault copy --from <profile> --to <profile>` — copy a whole vault (teams, bots, assets + all versions, installation scopes, audit history, usage history) between any backends (skills.new, git, path). Wires the Sleuth vault to the new GraphQL surface from sleuth-io/pulse#3954 and adds a backend-agnostic copy engine.

- Sleuth vault wiring: team/user-scoped installs via the new `installations` input; team-repository management via `updateTeam` + repo-GID resolution; `GetUsageStats`/`ReadUsageEvents` via the new `assetUsageEvents` export; `RecordUsageEvents` sends actor; `ImportAuditEvents`; reads asset scopes from skills.new via the `installations` query.
- `internal/vaultcopy` engine: teams → bots → assets(+versions+scopes) → audit → usage. Best-effort (item failures become warnings); always previews, requires `--yes` to apply.
- Paginates `assetAuditLog` at the server's 50-cap (was a single `first=1000` call); chunks audit-import and usage POSTs for large vaults.

**Depends on:** sleuth-io/pulse#3954 (the GraphQL operations this calls). Already deployed to app.skills.new.

## Testing
Exercised both directions against deployed skills.new with two real orgs (Docker): skills.new → git vault, then git vault → fresh org. Validated assets+versions, teams, bots, scopes, audit (15,885 events round-tripped), and usage (chunked). Round-trip unit test (path→path) covers losslessness + idempotency + org-wide assets.

## Known limitations (candidate follow-ups)
- Multi-scope asset → skills.new destination currently keeps only the last scope (being addressed).
- Cross-org copy requires referenced users/repos to exist in the destination org (warns otherwise).
- Bot API keys are not copyable (regenerate on the destination).

**Security implications of changes have been considered**