### PR TITLE
SD-10191: Fix vault show scope display

### DIFF
--- a/internal/commands/add_already_installed_test.go
+++ b/internal/commands/add_already_installed_test.go
@@ -333,7 +333,7 @@ func TestAddAlreadyInstalled(t *testing.T) {
 	// interactive prompt must still reflect the existing installation —
 	// not "Not installed". `--yes` mode bypasses the prompt itself, so we
 	// assert against resolveCurrentScopes directly: this is the exact data
-	// that displayCurrentInstallation would render, and the bug the user
+	// that displayCurrentTargets would render, and the bug the user
 	// reported (`✓ Successfully added check-sx@3` followed by "Not installed
 	// (available in vault only)") is precisely a regression where this
 	// helper returns nil when it shouldn't.

--- a/internal/commands/add_scopes.go
+++ b/internal/commands/add_scopes.go
@@ -74,7 +74,7 @@ func existingAssetScopes(vault vaultpkg.Vault, name string) []lockfile.Scope {
 // local install tracker when the vault can't answer — e.g. the sleuth vault,
 // where user-scope installs live server-side and aren't surfaced to the
 // client. A returned empty slice means "installed globally" (no repo/path
-// scope). Callers downstream (promptForRepositories / displayCurrentInstallation)
+// scope). Callers downstream (promptForRepositories / displayCurrentTargets)
 // already treat nil vs. empty distinctly, so the tristate matters.
 func resolveCurrentScopes(vault vaultpkg.Vault, name string) []lockfile.Scope {
 	if s := existingAssetScopes(vault, name); s != nil {

--- a/internal/commands/scope_selection_display.go
+++ b/internal/commands/scope_selection_display.go
@@ -10,14 +10,6 @@ import (
 	"github.com/sleuth-io/sx/internal/vault"
 )
 
-// formatRepository formats a repository entry for display
-func formatRepository(repo lockfile.Scope) string {
-	if len(repo.Paths) == 0 {
-		return repo.Repo + " (entire repository)"
-	}
-	return fmt.Sprintf("%s → %s", repo.Repo, strings.Join(repo.Paths, ", "))
-}
-
 // formatTarget formats a kind-aware install target for display in the scope
 // editor.
 func formatTarget(t vault.InstallTarget) string {
@@ -119,31 +111,6 @@ func displayCurrentTargets(targets []vault.InstallTarget, installed bool, styled
 	items := make([]string, len(targets))
 	for i, t := range targets {
 		items[i] = formatTarget(t)
-	}
-	styledOut.List(items)
-}
-
-// displayCurrentInstallation shows the current installation state of an asset
-func displayCurrentInstallation(currentRepos []lockfile.Scope, styledOut *ui.Output) {
-	styledOut.Newline()
-	styledOut.Println("Current installation:")
-
-	if currentRepos == nil {
-		styledOut.Println("  Not installed (available in vault only)")
-		return
-	}
-
-	if len(currentRepos) == 0 {
-		// Global installation
-		styledOut.Println("  → Global (available in all projects)")
-		return
-	}
-
-	// Repository-specific installations
-	styledOut.Println("  → Repository-specific")
-	items := make([]string, len(currentRepos))
-	for i, repo := range currentRepos {
-		items[i] = formatRepository(repo)
 	}
 	styledOut.List(items)
 }

--- a/internal/commands/vault.go
+++ b/internal/commands/vault.go
@@ -211,15 +211,14 @@ func runVaultShow(cmd *cobra.Command, assetName string, jsonOutput bool) error {
 
 	out := newOutputHelper(cmd)
 
-	// Load config and create vault
-	cfg, err := config.Load()
+	// Build the vault the same way sx add does (createVault), which applies the
+	// active profile's identity override before any vault op. Without it, a
+	// --profile <git vault> resolves "me"/user scopes against the system git
+	// config instead of the profile's email, so a user-scoped install reads as
+	// "Global" here while sx add shows it correctly (SD-10170).
+	vault, err := createVault()
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w\nRun 'sx init' to configure", err)
-	}
-
-	vault, err := vaultpkg.NewFromConfig(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to create vault: %w", err)
+		return err
 	}
 
 	// Only show status for text output (not JSON)
@@ -239,26 +238,15 @@ func runVaultShow(cmd *cobra.Command, assetName string, jsonOutput bool) error {
 		return fmt.Errorf("failed to get asset details: %w", err)
 	}
 
-	// Check if asset is installed by looking in lock file
-	var currentScopes []lockfile.Scope
-	var scopesFound bool
-	lockFileData, _, _, err := vault.GetLockFile(ctx, "")
-	if err == nil {
-		if lockFile, err := lockfile.Parse(lockFileData); err == nil {
-			for i := range lockFile.Assets {
-				if lockFile.Assets[i].Name == assetName {
-					currentScopes = lockFile.Assets[i].Scopes
-					scopesFound = true
-					break
-				}
-			}
-		}
-	}
+	// Resolve the asset's real, kind-aware installation set (repo/path/team/
+	// user/bot/org) using the same path sx add uses, so user/team/bot installs
+	// show up instead of only the repo/path subset the lockfile carries.
+	currentTargets, installed := resolveCurrentTargets(ctx, vault, assetName)
 
 	if jsonOutput {
-		return printVaultShowJSON(out, details, scopesFound, currentScopes)
+		return printVaultShowJSON(out, details, installed, currentTargets)
 	}
-	return printVaultShowText(out, details, scopesFound, currentScopes)
+	return printVaultShowText(out, details, installed, currentTargets)
 }
 
 // getTypeLabel returns a display label for an asset type, with fallback for unknown types
@@ -576,28 +564,21 @@ func printInstalledListJSON(out *outputHelper, assets []lockfile.Asset, typeFilt
 	return nil
 }
 
-func printVaultShowText(out *outputHelper, details *vaultpkg.AssetDetails, scopesFound bool, currentScopes []lockfile.Scope) error {
+func printVaultShowText(out *outputHelper, details *vaultpkg.AssetDetails, installed bool, currentTargets []vaultpkg.InstallTarget) error {
 	ui := ui.NewOutput(out.cmd.OutOrStdout(), out.cmd.ErrOrStderr())
 
-	ui.Newline()
 	ui.Header(details.Name)
 	ui.Muted(details.Type.Label)
 	ui.Newline()
 
 	if details.Description != "" {
 		ui.Println(details.Description)
-		ui.Newline()
 	}
 
-	// Show installation status
-	if scopesFound {
-		displayCurrentInstallation(currentScopes, ui)
-	} else {
-		ui.Newline()
-		ui.Info("Installation Status:")
-		ui.Println("  Not installed (available in vault only)")
-		ui.Newline()
-	}
+	// Show installation status using the same kind-aware display sx add uses.
+	// displayCurrentTargets emits its own leading newline as the separator.
+	displayCurrentTargets(currentTargets, installed, ui)
+	ui.Newline()
 
 	if len(details.Versions) > 0 {
 		// Versions are in ascending order (oldest first), so last element is latest
@@ -638,7 +619,7 @@ func printVaultShowText(out *outputHelper, details *vaultpkg.AssetDetails, scope
 	return nil
 }
 
-func printVaultShowJSON(out *outputHelper, details *vaultpkg.AssetDetails, scopesFound bool, currentScopes []lockfile.Scope) error {
+func printVaultShowJSON(out *outputHelper, details *vaultpkg.AssetDetails, installed bool, currentTargets []vaultpkg.InstallTarget) error {
 	// Create JSON-friendly output
 	versions := make([]map[string]any, 0, len(details.Versions))
 	for _, v := range details.Versions {
@@ -656,11 +637,15 @@ func printVaultShowJSON(out *outputHelper, details *vaultpkg.AssetDetails, scope
 		"versions":    versions,
 		"createdAt":   details.CreatedAt,
 		"updatedAt":   details.UpdatedAt,
-		"installed":   scopesFound,
+		"installed":   installed,
 	}
 
-	if scopesFound {
-		output["installationScopes"] = currentScopes
+	if installed {
+		scopes := make([]map[string]any, 0, len(currentTargets))
+		for _, t := range currentTargets {
+			scopes = append(scopes, t.AuditData())
+		}
+		output["installationScopes"] = scopes
 	}
 
 	if details.Metadata != nil {


### PR DESCRIPTION
Use sx add's scope resolution so user/team/bot installs show correctly instead of collapsing to Global.

Scenario: 
1. sx vault show
2. sx add changes shope
3. sx vault shows the new scope
<img width="599" height="939" alt="image" src="https://github.com/user-attachments/assets/9af70880-c2dd-4b7a-b52f-83e14a7657e3" />

