### PR TITLE
SD-10150: Add RBAC rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ make build && ./dist/sx <command>
 - [Manifest Spec](docs/manifest-spec.md) - sx.toml format (source of truth)
 - [Lock Spec](docs/lock-spec.md) - Per-user resolved lock file format
 - [Scoping](docs/scoping.md) - Overview of every install scope (org/repo/path/team/user/bot), links to per-scope docs
+- [Permissions / RBAC](docs/rbac.md) - github vault: who can set scope (org-admins) and who can edit a skill (team-scope membership)
 - [Vault copy](docs/copy.md) - `sx vault copy` cross-vault migration (assets, teams, bots, scopes, audit, usage)
 - [Orgs](docs/orgs.md) - Org-scoped (global) installs
 - [Repos](docs/repos.md) - Repo and path-scoped installs (monorepo patterns)

--- a/cmd/sx/main.go
+++ b/cmd/sx/main.go
@@ -228,6 +228,7 @@ Use "{{muted (printf "%s [command] --help" .CommandPath)}}" for more information
 	rootCmd.AddCommand(commands.NewRoleCommand())
 	rootCmd.AddCommand(commands.NewTeamCommand())
 	rootCmd.AddCommand(commands.NewBotCommand())
+	rootCmd.AddCommand(commands.NewOrgCommand())
 	rootCmd.AddCommand(commands.NewStatsCommand())
 	rootCmd.AddCommand(commands.NewAuditCommand())
 	rootCmd.AddCommand(commands.NewCloudCommand())

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -164,6 +164,20 @@ resolution rules. File-based vaults (path/git) treat bots as
 identity-only — there are no API keys stored in the manifest. Sleuth
 vaults issue real OAuth tokens via `sx bot key create`.
 
+## `[org]` — vault governance
+
+Optional. Holds the **org-admins** list — the file-vault stand-in for an org
+admin. When non-empty, the vault is "governed": only org-admins may set broad
+scopes (org/repo/path/bot) and change this list. Empty/absent = ungoverned
+(anyone can set any scope). See [rbac.md](rbac.md).
+
+```toml
+[org]
+admins = ["alice@acme.com", "bob@acme.com"]
+```
+
+Manage it with `sx org admin add|list|remove`.
+
 ## Mutation semantics
 
 * Every CLI that mutates the manifest reads the file, applies the change,

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -6,16 +6,18 @@ This controls **who can set a skill's scope** (where it installs) and **who can 
 
 Scope rules depend on a single thing: **does the vault have org-admins?**
 
+**One scope is always gated, regardless of state:** locking a skill to **team X** always requires being an **admin of team X** (or an org-admin) — teams own skills, so claiming a skill for a team is a team-management decision even in an ungoverned vault. Everything below is about the *other* scopes.
+
 ### State 1 — No org-admins (ungoverned, the default)
 
-**Anyone can set any scope.** A fresh vault starts here. Setting the first org-admin flips it to State 2 — and while the list is empty, *anyone* can do that, so the command warns you first.
+**Anyone can set any non-team scope.** A fresh vault starts here. Setting the first org-admin flips it to State 2 — and while the list is empty, *anyone* can do that, so the command warns you first.
 
 ### State 2 — Org-admins exist (governed)
 
 | Scope                   | Who can set or remove it                |
 |-------------------------|-----------------------------------------|
 | org / repo / path / bot | **org-admins** only                     |
-| team X                  | an **admin of team X**, or an org-admin |
+| team X                  | an **admin of team X**, or an org-admin (always, even ungoverned) |
 | just-me (your own user) | **anyone**                              |
 
 Org-admins can always act; they never take away a team admin's control over their own team's scope.
@@ -40,7 +42,7 @@ A skill scoped to several teams is editable by a member of any of them. Org-admi
 Remove every org-admin with `sx org admin remove <email>`. Only a current org-admin can do this. Once the list is empty, the vault is ungoverned again — anyone can set any scope.
 
 **Who can scope a skill to team X?**
-An admin of team X, or an org-admin. (If the vault has no org-admins, anyone can.)
+An admin of team X, or an org-admin — **always**, even in an ungoverned vault. Locking a skill to a team is a team-management action (teams own skills), so a non-admin can never do it.
 
 **If I scope a skill to a team, who actually gets it installed, and where?**
 Every **member** of the team — but *where* depends on the team's repositories. If the team owns repos, members get it **in those repos** (so a member only sees it when working in one of them). If the team owns **no** repositories, members get it **globally** (everywhere). Non-members never get it. So a team scope is "these people, in these repos" — or, with no repos, just "these people, everywhere."

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,49 @@
+# Permissions — github vault
+
+This controls **who can set a skill's scope** (where it installs) and **who can edit it**. Scope is governed by the vault's **org-admins**; editing is governed by a skill's **team scope**. Org-admins can always do both.
+
+## Setting scope — the two states
+
+Scope rules depend on a single thing: **does the vault have org-admins?**
+
+### State 1 — No org-admins (ungoverned, the default)
+
+**Anyone can set any scope.** A fresh vault starts here. Setting the first org-admin flips it to State 2 — and while the list is empty, *anyone* can do that, so the command warns you first.
+
+### State 2 — Org-admins exist (governed)
+
+| Scope                   | Who can set or remove it                |
+|-------------------------|-----------------------------------------|
+| org / repo / path / bot | **org-admins** only                     |
+| team X                  | an **admin of team X**, or an org-admin |
+| just-me (your own user) | **anyone**                              |
+
+Org-admins can always act; they never take away a team admin's control over their own team's scope.
+
+## Editing a skill
+
+Who can edit/publish a skill depends only on whether it is scoped to a team — not on the org-admins state:
+
+| Skill                | Who can edit / publish it                  |
+|----------------------|--------------------------------------------|
+| scoped to a team     | a **member** of that team, or an org-admin |
+| not scoped to a team | **anyone**                                 |
+
+A skill scoped to several teams is editable by a member of any of them. Org-admins can always edit anything.
+
+## Q & A — common flows
+
+**How do I turn on governance?**
+`sx org admin add a@x.com b@y.com` — add one or more org-admins. While the list is empty anyone can do this; it locks scope control to those people, so you're asked to confirm.
+
+**How do I unset all org-admins (go back to ungoverned)?**
+Remove every org-admin with `sx org admin remove <email>`. Only a current org-admin can do this. Once the list is empty, the vault is ungoverned again — anyone can set any scope.
+
+**Who can scope a skill to team X?**
+An admin of team X, or an org-admin. (If the vault has no org-admins, anyone can.)
+
+**Why can't I set an org-wide / repo scope?**
+The vault has org-admins and you're not one. Ask an org-admin to do it, or to add you.
+
+**Who can edit a skill?**
+If it's scoped to a team, only members of that team (plus org-admins, who can always edit anything). If it isn't scoped to any team, anyone can.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -42,8 +42,14 @@ Remove every org-admin with `sx org admin remove <email>`. Only a current org-ad
 **Who can scope a skill to team X?**
 An admin of team X, or an org-admin. (If the vault has no org-admins, anyone can.)
 
+**If I scope a skill to a team, who actually gets it installed, and where?**
+Every **member** of the team — but *where* depends on the team's repositories. If the team owns repos, members get it **in those repos** (so a member only sees it when working in one of them). If the team owns **no** repositories, members get it **globally** (everywhere). Non-members never get it. So a team scope is "these people, in these repos" — or, with no repos, just "these people, everywhere."
+
 **Why can't I set an org-wide / repo scope?**
 The vault has org-admins and you're not one. Ask an org-admin to do it, or to add you.
 
 **Who can edit a skill?**
 If it's scoped to a team, only members of that team (plus org-admins, who can always edit anything). If it isn't scoped to any team, anyone can.
+
+**A skill is scoped to a team *and* to specific users — who can edit it?**
+The team scope still rules: only a member of (one of) those teams, or an org-admin. Being named in the user scope does **not** grant edit rights — any team scope means team members only.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,6 +1,6 @@
 # Permissions — github vault
 
-This controls **who can set a skill's scope** (where it installs) and **who can edit it**. Scope is governed by the vault's **org-admins**; editing is governed by a skill's **team scope**. Org-admins can always do both.
+This controls **who can set a skill's scope** (where it installs) and **who can edit it**. Scope is governed by the vault's **org-admins**; editing is governed by a skill's **team scope**. Org-admins can always do both. This is the model for the **github (git/path) vault**, enforced client-side; the Sleuth (skills.new) vault enforces the same model server-side.
 
 ## Setting scope — the two states
 
@@ -32,6 +32,8 @@ Who can edit/publish a skill depends only on whether it is scoped to a team — 
 | not scoped to a team | **anyone**                                 |
 
 A skill scoped to several teams is editable by a member of any of them. Org-admins can always edit anything.
+
+These edit rules hold **regardless of governance state** — even in an ungoverned vault (no org-admins), a team-scoped skill is editable only by that team's members, and with no org-admins there is no one to override it. That's safe because scoping a skill to a team is itself always team-admin gated (above), so a skill can't be locked away from you by someone who doesn't run the team.
 
 ## Q & A — common flows
 

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -9,7 +9,7 @@ Assets don't have to be everywhere. You can choose where each one is installed, 
 | `org` (global) | every caller in the vault         | always — installs to `~/.claude/`                                               |
 | `repo`         | one git repository                | running in a clone of that repo — installs to `myapp/.claude/`                  |
 | `path`         | specific paths within a repo      | running under one of those paths — installs to `myapp/services/api/.claude/`    |
-| `team`         | every member of a named team      | caller is a team member; expands to the team's repositories                     |
+| `team`         | every member of a named team      | caller is a team member; expands to the team's repositories, or global if the team owns none |
 | `user`         | a single user (email)             | caller's git identity matches the email; the asset becomes global for that user |
 | `bot`          | a bot identity (CI runner, agent) | `SX_BOT=<name>` is set in the runtime — see [bots.md](bots.md)                  |
 
@@ -94,11 +94,28 @@ Already added an asset and want to change its scope? Run `sx install
 <name>` with one or more scope flags, or re-run `sx add <name>` for an
 interactive prompt.
 
+## Removing a scope
+
+There is no `--remove` flag. To drop a scope, either:
+
+- **Interactive editor** — re-run `sx add <name>` (or `sx install <name>`
+  without scope flags) and pick *Edit scopes*, then deselect the scope.
+  This applies a precise diff, touching only the scope you remove.
+- **`--replace-scope`** — `sx install <name> --replace-scope <scopes to
+  keep>` sets the complete scope set, dropping anything unnamed. Note it
+  *re-asserts* the scopes you keep, so you need permission for those too —
+  use the interactive editor when you only control the one scope you're
+  removing.
+
+Removing a scope needs the **same authority as setting it** (e.g.
+removing a `team X` scope requires being an admin of team X, or an
+org-admin).
+
 ## Who can set scope (permissions)
 
 Who may set a skill's scope is specified in [rbac.md](rbac.md). In short: with no org-admins the vault is ungoverned (anyone can set any scope); once org-admins exist, broad scopes (org/repo/path/bot) are org-admins-only, a team scope needs an admin of that team, and "just-me" is always open.
 
-> **Status:** design — not yet enforced on the github (git/path) vault. The Sleuth (skills.new) vault already enforces its own server-side permissions.
+> **Note:** Enforced client-side on the github (git/path) vault — a file vault can't stop a raw `git push`, so it steers correct usage rather than guaranteeing it. The Sleuth (skills.new) vault enforces server-side.
 
 ## How `sx install` uses scopes
 

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -4,22 +4,16 @@ Assets don't have to be everywhere. You can choose where each one is installed, 
 
 ## Scopes
 
-| Scope | Target | Available when |
-|-------|--------|----------------|
-| `org` (global) | every caller in the vault | always — installs to `~/.claude/` |
-| `repo` | one git repository | running in a clone of that repo — installs to `myapp/.claude/` |
-| `path` | specific paths within a repo | running under one of those paths — installs to `myapp/services/api/.claude/` |
-| `team` | every member of a named team | caller is a team member; expands to the team's repositories |
-| `user` | a single user (email) | caller's git identity matches the email; the asset becomes global for that user |
-| `bot` | a bot identity (CI runner, agent) | `SX_BOT=<name>` is set in the runtime — see [bots.md](bots.md) |
+| Scope          | Target                            | Available when                                                                  |
+|----------------|-----------------------------------|---------------------------------------------------------------------------------|
+| `org` (global) | every caller in the vault         | always — installs to `~/.claude/`                                               |
+| `repo`         | one git repository                | running in a clone of that repo — installs to `myapp/.claude/`                  |
+| `path`         | specific paths within a repo      | running under one of those paths — installs to `myapp/services/api/.claude/`    |
+| `team`         | every member of a named team      | caller is a team member; expands to the team's repositories                     |
+| `user`         | a single user (email)             | caller's git identity matches the email; the asset becomes global for that user |
+| `bot`          | a bot identity (CI runner, agent) | `SX_BOT=<name>` is set in the runtime — see [bots.md](bots.md)                  |
 
-The first three are structural and apply to every caller. `team`,
-`user`, and `bot` are identity-dependent and resolved at install time:
-human callers go through `git config user.email`, bots through
-`SX_BOT`. The Sleuth-only **"personal"** scope offered in the
-interactive `sx add` TUI is the same as `--user <your-email>` —
-included as a convenience so users don't have to type their own
-address.
+The first three are structural and apply to every caller. `team`, `user`, and `bot` are identity-dependent and resolved at install time: human callers go through `git config user.email`, bots through `SX_BOT`. The Sleuth-only **"personal"** scope offered in the interactive `sx add` TUI is the same as `--user <your-email>` — included as a convenience so users don't have to type their own address.
 
 ### Per-scope deep dives
 
@@ -99,6 +93,12 @@ unnamed). The change is previewed and you're asked to confirm — pass
 Already added an asset and want to change its scope? Run `sx install
 <name>` with one or more scope flags, or re-run `sx add <name>` for an
 interactive prompt.
+
+## Who can set scope (permissions)
+
+Who may set a skill's scope is specified in [rbac.md](rbac.md). In short: with no org-admins the vault is ungoverned (anyone can set any scope); once org-admins exist, broad scopes (org/repo/path/bot) are org-admins-only, a team scope needs an admin of that team, and "just-me" is always open.
+
+> **Status:** design — not yet enforced on the github (git/path) vault. The Sleuth (skills.new) vault already enforces its own server-side permissions.
 
 ## How `sx install` uses scopes
 

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -113,7 +113,7 @@ org-admin).
 
 ## Who can set scope (permissions)
 
-Who may set a skill's scope is specified in [rbac.md](rbac.md). In short: with no org-admins the vault is ungoverned (anyone can set any scope); once org-admins exist, broad scopes (org/repo/path/bot) are org-admins-only, a team scope needs an admin of that team, and "just-me" is always open.
+Who may set a skill's scope is specified in [rbac.md](rbac.md). In short: locking a skill to **team X** always requires being an admin of team X (or an org-admin), even in an ungoverned vault — teams own skills. For the other scopes: with no org-admins anyone can set them; once org-admins exist, broad scopes (org/repo/path/bot) are org-admins-only and "just-me" is always open.
 
 > **Note:** Enforced client-side on the github (git/path) vault — a file vault can't stop a raw `git push`, so it steers correct usage rather than guaranteeing it. The Sleuth (skills.new) vault enforces server-side.
 

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -110,13 +110,15 @@ one of the team's repositories" — so the asset reaches the right
 people in the right codebases without you listing every repo
 separately.
 
-`--team <name>` only requires the named team to **exist** in the vault
-(re-checked inside the transaction) plus write access to the vault —
-**not** team-admin. Scoping an asset to a team is distribution, not team
-management: anyone who can write to the vault may target a team with an
-asset. Admin is reserved for modifying the team itself (`sx team
-member/admin/repo …`). A `--team` naming an unknown team is skipped with
-a "team not found" warning rather than created implicitly.
+`--team <name>` requires you to be an **admin of that team** (or an
+org-admin) — **always**, in every vault, governed or not. Scoping a
+skill to a team **locks it to that team**: teams own skills, so once a
+skill is team-scoped only that team's members may edit it (see
+[rbac.md](rbac.md)). Claiming a skill for a team is therefore a
+team-management decision, not open distribution, so only a team admin
+may do it. The named team must also **exist** (re-checked inside the
+transaction); a `--team` naming an unknown team is skipped with a "team
+not found" warning rather than created implicitly.
 
 ## Where state lives
 

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -120,13 +120,13 @@ a "team not found" warning rather than created implicitly.
 
 ## Where state lives
 
-| State | Location | Who writes |
-|-------|----------|-----------|
-| Manifest (assets, scopes, teams) | `<vault>/sx.toml` | Vault admins via `sx team *`, `sx add`, `sx install --team` |
-| Audit events | `<vault>/.sx/audit/YYYY-MM.jsonl` | Every mutation (see [audit.md](audit.md)) |
-| Usage events | `<vault>/.sx/usage/YYYY-MM.jsonl` | Every `sx install` (see [stats.md](stats.md)) |
-| Per-user resolved lock | `~/<cache>/sx/lockfiles/<vault-id>.lock` | `sx install` |
-| Rotated lock history | `~/<cache>/sx/lockfiles/<vault-id>-<ts>.lock` | Every install whose resolved content differs from the previous |
+| State                            | Location                                      | Who writes                                                     |
+|----------------------------------|-----------------------------------------------|----------------------------------------------------------------|
+| Manifest (assets, scopes, teams) | `<vault>/sx.toml`                             | Vault admins via `sx team *`, `sx add`, `sx install --team`    |
+| Audit events                     | `<vault>/.sx/audit/YYYY-MM.jsonl`             | Every mutation (see [audit.md](audit.md))                      |
+| Usage events                     | `<vault>/.sx/usage/YYYY-MM.jsonl`             | Every `sx install` (see [stats.md](stats.md))                  |
+| Per-user resolved lock           | `~/<cache>/sx/lockfiles/<vault-id>.lock`      | `sx install`                                                   |
+| Rotated lock history             | `~/<cache>/sx/lockfiles/<vault-id>-<ts>.lock` | Every install whose resolved content differs from the previous |
 
 ## Sleuth vault
 

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -4,7 +4,9 @@
 Teams are first-class objects in the vault — they have members,
 admins, and a list of repositories the team owns. Team-scoped installs
 flatten to the team's repositories at resolve time, so a team install
-both targets the people in the team and the codebases they work on.
+both targets the people in the team and the codebases they work on. If
+the team owns **no** repositories, the asset installs globally for every
+member instead.
 
 This document covers the team CRUD surface and team-scoped installs.
 For the manifest schema, see
@@ -62,7 +64,9 @@ not rewrite the manifest or emit an audit event.
 
 Team repositories drive scope resolution: if an asset is installed with
 `--team platform`, every member gets it flattened to the team's
-repositories at install time.
+repositories at install time. **If the team has no repositories, the
+asset installs globally for every member** (so a team scope is never a
+no-op just because the team owns no repos).
 
 ```bash
 sx team repo add platform github.com/acme/billing

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -53,8 +53,14 @@ Every destructive mutation re-checks admin membership inside the
 transaction, after acquiring the vault flock, so a concurrent
 demotion can't race past the pre-check.
 
+**You can always remove *yourself* from a team** (leaving), admin or
+not — `sx team member remove <team> <your-email>` succeeds even if you
+are only a plain member. Removing *anyone else* still requires being a
+team admin.
+
 A mutation that would leave the team with zero admins is rejected; you
-must promote another admin before removing or demoting the last one.
+must promote another admin before removing or demoting the last one
+(so the sole admin can't leave a team and orphan it).
 
 Repeating an idempotent mutation (adding an existing member, granting
 admin to someone who already has it, etc.) is a silent no-op that does

--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -541,6 +541,13 @@ func handleIdenticalAsset(ctx context.Context, out *outputHelper, status *compon
 
 // addNewAsset adds a new or updated asset to the vault
 func addNewAsset(ctx context.Context, out *outputHelper, status *components.Status, vault vaultpkg.Vault, name string, assetType asset.Type, version, zipFile string, zipData []byte, metadataExists bool, opts addOptions) error {
+	// RBAC edit gate: a skill scoped to a team may only be re-published by a
+	// member of that team (or an org-admin); a non-team-scoped or brand-new
+	// skill is open to anyone. See docs/rbac.md.
+	if err := enforceAssetEditPermission(ctx, vault, name); err != nil {
+		return err
+	}
+
 	// Prompt user for version (skip if --yes)
 	if !opts.Yes {
 		var err error

--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -101,7 +101,7 @@ func resolveSelfUserScopes(ctx context.Context, repo vault.Vault, targets []vaul
 // installSetter is implemented by vaults that can persist a full set of
 // kind-aware install targets — team/user/bot in addition to repo/path — in one
 // atomic call. appendMode merges with the asset's existing installations
-// instead of replacing them. The Sleuth/skills.io vault implements it against
+// instead of replacing them. The Sleuth/skills.new vault implements it against
 // the server; file-backed vaults (git/path) implement it too via
 // commonSetAssetInstallations, resolving identity targets against the manifest.
 type installSetter interface {
@@ -109,7 +109,7 @@ type installSetter interface {
 }
 
 // targetUninstaller is implemented by vaults that can remove specific
-// installations by server GID in one best-effort call (the Sleuth/skills.io
+// installations by server GID in one best-effort call (the Sleuth/skills.new
 // vault). It returns how many installs were removed and a per-target failure
 // message for any the server couldn't remove.
 type targetUninstaller interface {

--- a/internal/commands/add_scope_rbac_repro_test.go
+++ b/internal/commands/add_scope_rbac_repro_test.go
@@ -1,0 +1,179 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/mgmt"
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+// TestRepro_NonAdminCannotAddTeamScope reproduces the user report: re-scoping a
+// skill in the editor (Edited diff) must NOT let a non-team-admin ADD a team
+// scope. This drives the real command apply path (updateLockFile ->
+// applyScopeEdit -> bulkSetInstallTargets) against a path vault whose git
+// identity is a non-admin.
+func TestRepro_NonAdminCannotAddTeamScope(t *testing.T) {
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	reproGit(t, dir, "init")
+	reproGit(t, dir, "config", "user.email", "mallory@example.com")
+	reproGit(t, dir, "config", "user.name", "Mallory")
+
+	// platform is admined by alice; mallory is not a member or admin.
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{{
+			Name: "my-skill", Version: "1.0.0", Type: asset.TypeSkill,
+			SourceHTTP: &manifest.SourceHTTP{URL: "https://example.com/s.zip"},
+			Scopes:     []manifest.Scope{{Kind: manifest.ScopeKindUser, User: "mallory@example.com"}},
+		}},
+		Teams: []manifest.Team{{Name: "platform", Members: []string{"alice@example.com"}, Admins: []string{"alice@example.com"}}},
+		Org:   &manifest.Org{Admins: []string{"boss@example.com"}},
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	v, err := vaultpkg.NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	out := newOutputHelper(cmd)
+
+	lockAsset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0", Type: asset.TypeSkill}
+	// This is exactly what the file-backed editor returns when the user picks
+	// "Add a team scope" for platform (Edited diff: add team, remove nothing).
+	result := &scopeResult{
+		Edited: true,
+		Added:  []vaultpkg.InstallTarget{{Kind: vaultpkg.InstallKindTeam, Team: "platform"}},
+	}
+
+	applyErr := updateLockFile(context.Background(), out, v, lockAsset, result)
+	t.Logf("updateLockFile err = %v\noutput:\n%s", applyErr, buf.String())
+
+	// The team scope must NOT have been written.
+	loaded, ok, lerr := manifest.Load(dir)
+	if lerr != nil || !ok {
+		t.Fatalf("load manifest: ok=%v err=%v", ok, lerr)
+	}
+	a := loaded.FindAsset("my-skill")
+	for _, s := range a.Scopes {
+		if s.Kind == manifest.ScopeKindTeam && s.Team == "platform" {
+			t.Fatalf("BUG REPRODUCED: non-admin added team scope; scopes=%+v", a.Scopes)
+		}
+	}
+}
+
+// TestRepro_NonAdminCannotAddTeamScope_GitVault is the git-vault counterpart —
+// the actual setup in the report: a cached clone + runInVaultTx. The seed scopes
+// my-skill to user:mallory; mallory (non-admin) then tries to add team platform.
+func TestRepro_NonAdminCannotAddTeamScope_GitVault(t *testing.T) {
+	mgmt.ResetActorCache()
+	base := t.TempDir()
+	t.Setenv("HOME", base)
+	t.Setenv("XDG_CONFIG_HOME", base+"/.config")
+	t.Setenv("XDG_CACHE_HOME", base+"/.cache")
+	t.Setenv("SX_CONFIG_DIR", base+"/.config/sx")
+	t.Setenv("SX_CACHE_DIR", base+"/.cache/sx")
+
+	bare := base + "/remote.git"
+	if err := mkdirAllRepro(bare); err != nil {
+		t.Fatal(err)
+	}
+	reproGit(t, "", "init", "--bare", "-b", "main", bare)
+	seed := base + "/seed"
+	if err := mkdirAllRepro(seed); err != nil {
+		t.Fatal(err)
+	}
+	reproGit(t, "", "init", "-b", "main", seed)
+	reproGit(t, seed, "config", "user.email", "mallory@example.com")
+	reproGit(t, seed, "config", "user.name", "Mallory")
+	if err := manifest.Save(seed, &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{{
+			Name: "my-skill", Version: "1.0.0", Type: asset.TypeSkill,
+			SourcePath: &manifest.SourcePath{Path: "./assets/my-skill/1.0.0"},
+			Scopes:     []manifest.Scope{{Kind: manifest.ScopeKindUser, User: "mallory@example.com"}},
+		}},
+		Teams: []manifest.Team{{Name: "platform", Members: []string{"alice@example.com"}, Admins: []string{"alice@example.com"}}},
+		Org:   &manifest.Org{Admins: []string{"boss@example.com"}},
+	}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	reproGit(t, seed, "add", ".")
+	reproGit(t, seed, "commit", "-m", "seed")
+	reproGit(t, seed, "remote", "add", "origin", bare)
+	reproGit(t, seed, "push", "origin", "main")
+
+	// Global git identity for the clone the vault makes (no per-clone config set).
+	reproGit(t, "", "config", "--global", "user.email", "mallory@example.com")
+	reproGit(t, "", "config", "--global", "user.name", "Mallory")
+
+	v, err := vaultpkg.NewGitVault("file://" + bare)
+	if err != nil {
+		t.Fatalf("NewGitVault: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	out := newOutputHelper(cmd)
+
+	lockAsset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0", Type: asset.TypeSkill}
+	result := &scopeResult{
+		Edited: true,
+		Added:  []vaultpkg.InstallTarget{{Kind: vaultpkg.InstallKindTeam, Team: "platform"}},
+	}
+
+	applyErr := updateLockFile(context.Background(), out, v, lockAsset, result)
+	t.Logf("updateLockFile err = %v\noutput:\n%s", applyErr, buf.String())
+
+	remoteToml := gitOutRepro(t, bare, "show", "main:sx.toml")
+	if bytes.Contains([]byte(remoteToml), []byte("platform")) &&
+		bytes.Contains([]byte(remoteToml), []byte(`kind = "team"`)) {
+		t.Fatalf("BUG REPRODUCED: non-admin added team scope on git vault; remote sx.toml:\n%s", remoteToml)
+	}
+}
+
+func mkdirAllRepro(dir string) error {
+	return execMkdir(dir)
+}
+
+func execMkdir(dir string) error {
+	c := exec.Command("mkdir", "-p", dir)
+	return c.Run()
+}
+
+func gitOutRepro(t *testing.T, bare string, args ...string) string {
+	t.Helper()
+	full := append([]string{"--git-dir", bare}, args...)
+	c := exec.Command("git", full...)
+	outBytes, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", full, err, outBytes)
+	}
+	return string(outBytes)
+}
+
+func reproGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	if outBytes, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, outBytes)
+	}
+}

--- a/internal/commands/add_scope_rbac_repro_test.go
+++ b/internal/commands/add_scope_rbac_repro_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -143,8 +144,8 @@ func TestRepro_NonAdminCannotAddTeamScope_GitVault(t *testing.T) {
 	t.Logf("updateLockFile err = %v\noutput:\n%s", applyErr, buf.String())
 
 	remoteToml := gitOutRepro(t, bare, "show", "main:sx.toml")
-	if bytes.Contains([]byte(remoteToml), []byte("platform")) &&
-		bytes.Contains([]byte(remoteToml), []byte(`kind = "team"`)) {
+	if strings.Contains(remoteToml, "platform") &&
+		strings.Contains(remoteToml, `kind = "team"`) {
 		t.Fatalf("BUG REPRODUCED: non-admin added team scope on git vault; remote sx.toml:\n%s", remoteToml)
 	}
 }

--- a/internal/commands/add_scopes.go
+++ b/internal/commands/add_scopes.go
@@ -11,6 +11,22 @@ import (
 	vaultpkg "github.com/sleuth-io/sx/internal/vault"
 )
 
+// assetEditChecker is the capability a file-backed vault exposes to gate
+// publishing a new version on the skill's team scope (see docs/rbac.md). The
+// Sleuth vault enforces edit permission server-side and does not implement it.
+type assetEditChecker interface {
+	CheckAssetEditPermission(ctx context.Context, name string) error
+}
+
+// enforceAssetEditPermission returns the vault's edit-permission error for the
+// named asset, or nil when the vault doesn't gate edits client-side.
+func enforceAssetEditPermission(ctx context.Context, v vaultpkg.Vault, name string) error {
+	if c, ok := v.(assetEditChecker); ok {
+		return c.CheckAssetEditPermission(ctx, name)
+	}
+	return nil
+}
+
 // currentInstallReader is implemented by vaults that can report an asset's
 // complete, kind-aware installation set (repo/path/team/user/bot/org) including
 // the server entity GIDs. The Sleuth/skills.io vault answers this from the

--- a/internal/commands/add_scopes.go
+++ b/internal/commands/add_scopes.go
@@ -29,7 +29,7 @@ func enforceAssetEditPermission(ctx context.Context, v vaultpkg.Vault, name stri
 
 // currentInstallReader is implemented by vaults that can report an asset's
 // complete, kind-aware installation set (repo/path/team/user/bot/org) including
-// the server entity GIDs. The Sleuth/skills.io vault answers this from the
+// the server entity GIDs. The Sleuth/skills.new vault answers this from the
 // server, the only authoritative source for identity-scoped installs the
 // stripped lockfile view and the local tracker never see. The GIDs let a later
 // removal target the exact installation without re-resolving by name/email.

--- a/internal/commands/org.go
+++ b/internal/commands/org.go
@@ -47,7 +47,7 @@ func newOrgAdminAddCommand() *cobra.Command {
 		Short: "Add org-admins (turns on scope governance)",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 			out := newOutputHelper(cmd)
 
@@ -91,7 +91,7 @@ func newOrgAdminListCommand() *cobra.Command {
 		Short: "List org-admins",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 			out := newOutputHelper(cmd)
 
@@ -121,7 +121,7 @@ func newOrgAdminRemoveCommand() *cobra.Command {
 		Short: "Remove an org-admin",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 			out := newOutputHelper(cmd)
 

--- a/internal/commands/org.go
+++ b/internal/commands/org.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/sleuth-io/sx/internal/ui"
 	"github.com/sleuth-io/sx/internal/ui/components"
 )
 
@@ -60,8 +61,8 @@ func newOrgAdminAddCommand() *cobra.Command {
 			}
 			// Bootstrap: seeding the first org-admin locks scope governance.
 			if len(current) == 0 && !yes {
-				out.println("⚠ This vault has no org-admins yet. Setting them turns on scope governance:")
-				out.println("  from now on only these people can set broad scopes and change this list.")
+				styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+				styledOut.Warning("This vault has no org-admins yet. Setting them turns on scope governance:\n  from now on only these people can set broad scopes and change this list.")
 				confirmed, err := components.ConfirmWithIO("Continue?", false, cmd.InOrStdin(), cmd.OutOrStdout())
 				if err != nil {
 					return err

--- a/internal/commands/org.go
+++ b/internal/commands/org.go
@@ -1,0 +1,138 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/internal/ui/components"
+)
+
+// orgAdminManager is implemented by file-backed vaults that store the
+// vault-level org-admin list. The Sleuth vault manages roles server-side.
+type orgAdminManager interface {
+	AddOrgAdmins(ctx context.Context, emails []string) (int, error)
+	RemoveOrgAdmin(ctx context.Context, email string) error
+	ListOrgAdmins(ctx context.Context) ([]string, error)
+}
+
+func orgAdminVault() (orgAdminManager, error) {
+	vault, err := createVault()
+	if err != nil {
+		return nil, err
+	}
+	mgr, ok := vault.(orgAdminManager)
+	if !ok {
+		return nil, errors.New("org-admins are managed on the server for this vault; this command is only for git/path vaults")
+	}
+	return mgr, nil
+}
+
+// NewOrgCommand returns `sx org` (vault-level governance).
+func NewOrgCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "org", Short: "Manage vault-level governance"}
+	admin := &cobra.Command{Use: "admin", Short: "Manage org-admins (who controls scope)"}
+	admin.AddCommand(newOrgAdminAddCommand(), newOrgAdminListCommand(), newOrgAdminRemoveCommand())
+	cmd.AddCommand(admin)
+	return cmd
+}
+
+func newOrgAdminAddCommand() *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "add <email...>",
+		Short: "Add org-admins (turns on scope governance)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			out := newOutputHelper(cmd)
+
+			mgr, err := orgAdminVault()
+			if err != nil {
+				return err
+			}
+			current, err := mgr.ListOrgAdmins(ctx)
+			if err != nil {
+				return err
+			}
+			// Bootstrap: seeding the first org-admin locks scope governance.
+			if len(current) == 0 && !yes {
+				out.println("⚠ This vault has no org-admins yet. Setting them turns on scope governance:")
+				out.println("  from now on only these people can set broad scopes and change this list.")
+				confirmed, err := components.ConfirmWithIO("Continue?", false, cmd.InOrStdin(), cmd.OutOrStdout())
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					out.println("Cancelled.")
+					return nil
+				}
+			}
+
+			added, err := mgr.AddOrgAdmins(ctx, args)
+			if err != nil {
+				return err
+			}
+			out.printf("✓ Added %d org-admin(s)\n", added)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip the governance-lock confirmation")
+	return cmd
+}
+
+func newOrgAdminListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List org-admins",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			out := newOutputHelper(cmd)
+
+			mgr, err := orgAdminVault()
+			if err != nil {
+				return err
+			}
+			admins, err := mgr.ListOrgAdmins(ctx)
+			if err != nil {
+				return err
+			}
+			if len(admins) == 0 {
+				out.println("No org-admins — this vault is ungoverned (anyone can set any scope).")
+				return nil
+			}
+			for _, a := range admins {
+				out.printf("  %s\n", a)
+			}
+			return nil
+		},
+	}
+}
+
+func newOrgAdminRemoveCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <email>",
+		Short: "Remove an org-admin",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			out := newOutputHelper(cmd)
+
+			mgr, err := orgAdminVault()
+			if err != nil {
+				return err
+			}
+			if err := mgr.RemoveOrgAdmin(ctx, args[0]); err != nil {
+				return err
+			}
+			out.printf("✓ Removed org-admin %s\n", args[0])
+			return nil
+		},
+	}
+}

--- a/internal/commands/scope_e2e_test.go
+++ b/internal/commands/scope_e2e_test.go
@@ -133,10 +133,11 @@ func TestScopeE2E_UserScopedAssetInstallsForCaller(t *testing.T) {
 	env.AssertFileExists(env.GlobalClaudeDir() + "/skills/my-skill")
 }
 
-// TestScopeE2E_TeamScopeByNonAdminWritesToManifest: scoping an asset to a team
-// you are NOT an admin of succeeds and records the team scope (SD-10170: scoping
-// is distribution, not team management).
-func TestScopeE2E_TeamScopeByNonAdminWritesToManifest(t *testing.T) {
+// TestScopeE2E_TeamScopeByNonAdminDenied: in a governed vault (org-admins set),
+// scoping to a team you are NOT an admin of is denied and writes nothing
+// (SD-10190 RBAC). This deliberately reverses SD-10170's earlier "scoping is
+// distribution, not team management" stance — see docs/scoping.md.
+func TestScopeE2E_TeamScopeByNonAdminDenied(t *testing.T) {
 	_, vaultDir := seedScopeVault(t)
 
 	// Create a team admined by someone else, directly via the vault API.
@@ -152,15 +153,27 @@ func TestScopeE2E_TeamScopeByNonAdminWritesToManifest(t *testing.T) {
 		t.Fatalf("CreateTeam: %v", err)
 	}
 
-	// The caller (test@example.com) is not an admin, but scoping must still work.
-	cmd := NewInstallCommand()
-	cmd.SetArgs([]string{"my-skill", "--team", "platform", "--yes"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("install --team platform by non-admin should succeed: %v", err)
+	// Switch governance on: an org-admin exists. The caller (test@example.com)
+	// is neither an org-admin nor a platform admin.
+	mm, _, err := manifest.Load(vaultDir)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	mm.AddOrgAdmins("boss@example.com")
+	if err := manifest.Save(vaultDir, mm); err != nil {
+		t.Fatalf("save manifest: %v", err)
 	}
 
-	if scopes := manifestScopes(t, vaultDir, "my-skill"); !hasScope(scopes, manifest.ScopeKindTeam, "platform") {
-		t.Fatalf("expected a team scope for platform, got %+v", scopes)
+	// The caller (test@example.com) is not an admin of platform, so it's denied.
+	cmd := NewInstallCommand()
+	cmd.SetArgs([]string{"my-skill", "--team", "platform", "--yes"})
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "admin of team") {
+		t.Fatalf("non-admin team scope should be denied, got err=%v", err)
+	}
+
+	if scopes := manifestScopes(t, vaultDir, "my-skill"); hasScope(scopes, manifest.ScopeKindTeam, "platform") {
+		t.Fatalf("denied team scope must not be recorded, got %+v", scopes)
 	}
 }
 
@@ -246,7 +259,7 @@ func TestScopeE2E_AddFlagsApplyScopeWithYes(t *testing.T) {
 		t.Fatalf("NewPathVault: %v", err)
 	}
 	if err := v.CreateTeam(context.Background(), mgmt.Team{
-		Name: "platform", Members: []string{"other@example.com"}, Admins: []string{"other@example.com"},
+		Name: "platform", Members: []string{"test@example.com"}, Admins: []string{"test@example.com"},
 	}); err != nil {
 		t.Fatalf("CreateTeam: %v", err)
 	}
@@ -300,7 +313,7 @@ func TestScopeE2E_InstallMultiScope(t *testing.T) {
 		t.Fatalf("NewPathVault: %v", err)
 	}
 	if err := v.CreateTeam(context.Background(), mgmt.Team{
-		Name: "platform", Members: []string{"other@example.com"}, Admins: []string{"other@example.com"},
+		Name: "platform", Members: []string{"test@example.com"}, Admins: []string{"test@example.com"},
 	}); err != nil {
 		t.Fatalf("CreateTeam: %v", err)
 	}
@@ -330,7 +343,7 @@ func TestScopeE2E_InstallAppendsByDefault(t *testing.T) {
 		t.Fatalf("NewPathVault: %v", err)
 	}
 	if err := v.CreateTeam(context.Background(), mgmt.Team{
-		Name: "platform", Members: []string{"other@example.com"}, Admins: []string{"other@example.com"},
+		Name: "platform", Members: []string{"test@example.com"}, Admins: []string{"test@example.com"},
 	}); err != nil {
 		t.Fatalf("CreateTeam: %v", err)
 	}
@@ -368,7 +381,7 @@ func TestScopeE2E_InstallReplaceScopeDropsExisting(t *testing.T) {
 		t.Fatalf("NewPathVault: %v", err)
 	}
 	if err := v.CreateTeam(context.Background(), mgmt.Team{
-		Name: "platform", Members: []string{"other@example.com"}, Admins: []string{"other@example.com"},
+		Name: "platform", Members: []string{"test@example.com"}, Admins: []string{"test@example.com"},
 	}); err != nil {
 		t.Fatalf("CreateTeam: %v", err)
 	}
@@ -405,7 +418,7 @@ func seedScopeTeam(t *testing.T, vaultDir string) {
 		t.Fatalf("NewPathVault: %v", err)
 	}
 	if err := v.CreateTeam(context.Background(), mgmt.Team{
-		Name: "platform", Members: []string{"other@example.com"}, Admins: []string{"other@example.com"},
+		Name: "platform", Members: []string{"test@example.com"}, Admins: []string{"test@example.com"},
 	}); err != nil {
 		t.Fatalf("CreateTeam: %v", err)
 	}

--- a/internal/commands/scope_selection.go
+++ b/internal/commands/scope_selection.go
@@ -150,7 +150,7 @@ func promptForRepositoriesWithUI(assetName, version string, current []vault.Inst
 	case "modify": // Add/modify scopes
 		// Identity scopes (team/user/bot) are only offered when the vault can
 		// persist them — i.e. it implements the bulk SetAssetInstallations
-		// setter (the Sleuth/skills.io vault). File-backed vaults stay
+		// setter (the Sleuth/skills.new vault). File-backed vaults stay
 		// repo/path-only.
 		_, allowIdentity := v.(installSetter)
 		working, added, removed, err := modifyScopes(current, allowIdentity, styledOut, ioc)

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -235,11 +235,33 @@ func newTeamMemberCommand() *cobra.Command {
 		Short: "Remove a member from a team",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTeamMutation(cmd, args[0], func(ctx context.Context, v vault.Vault) error {
-				return v.RemoveTeamMember(ctx, args[0], args[1])
-			},
-				fmt.Sprintf("Removing %s from team %s", args[1], args[0]),
-				fmt.Sprintf("Removed %s from team %s", args[1], args[0]))
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			v, err := loadVault()
+			if err != nil {
+				return err
+			}
+			// You can always remove yourself from a team (leave); removing
+			// someone else requires being a team admin.
+			actor, err := v.CurrentActor(ctx)
+			if err != nil {
+				return err
+			}
+			if !strings.EqualFold(strings.TrimSpace(args[1]), actor.Email) {
+				if err := requireTeamAdmin(ctx, v, args[0]); err != nil {
+					return err
+				}
+			}
+
+			status := components.NewStatus(cmd.OutOrStdout())
+			status.Start(fmt.Sprintf("Removing %s from team %s", args[1], args[0]))
+			if err := v.RemoveTeamMember(ctx, args[0], args[1]); err != nil {
+				status.Fail(err.Error())
+				return err
+			}
+			status.Done(fmt.Sprintf("Removed %s from team %s", args[1], args[0]))
+			return nil
 		},
 	}
 
@@ -434,11 +456,11 @@ func printTeamDetails(cmd *cobra.Command, team *mgmt.Team) error {
 	}
 	out.Bold(fmt.Sprintf("Members (%d)", memberCount))
 	for _, m := range team.Members {
-		marker := " "
+		line := "  " + m
 		if team.IsAdmin(m) {
-			marker = "*"
+			line += " (admin)"
 		}
-		out.Println(fmt.Sprintf("  %s %s", marker, m))
+		out.Println(line)
 	}
 	if memberCount > len(team.Members) {
 		out.Muted(fmt.Sprintf("  … and %d more", memberCount-len(team.Members)))

--- a/internal/commands/team.go
+++ b/internal/commands/team.go
@@ -248,7 +248,7 @@ func newTeamMemberCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if !strings.EqualFold(strings.TrimSpace(args[1]), actor.Email) {
+			if mgmt.NormalizeEmail(args[1]) != mgmt.NormalizeEmail(actor.Email) {
 				if err := requireTeamAdmin(ctx, v, args[0]); err != nil {
 					return err
 				}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -98,7 +98,7 @@ type Manifest struct {
 // Org is vault-level governance configuration.
 type Org struct {
 	// Admins is the set of org-admin emails — the file-vault stand-in for
-	// skills.io's org admin / asset-manager role. Empty = ungoverned.
+	// skills.new's org admin / asset-manager role. Empty = ungoverned.
 	Admins []string `toml:"admins,omitempty"`
 }
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -88,6 +88,18 @@ type Manifest struct {
 	// member does) and can also be a direct install target via
 	// ScopeKindBot.
 	Bots []Bot `toml:"bots,omitempty"`
+
+	// Org holds vault-level governance. When Org.Admins is non-empty the
+	// vault is "governed": only org-admins may set broad scopes and change
+	// the admin list. Nil/empty = ungoverned. See docs/rbac.md.
+	Org *Org `toml:"org,omitempty"`
+}
+
+// Org is vault-level governance configuration.
+type Org struct {
+	// Admins is the set of org-admin emails — the file-vault stand-in for
+	// skills.io's org admin / asset-manager role. Empty = ungoverned.
+	Admins []string `toml:"admins,omitempty"`
 }
 
 // Asset is one managed asset: its identity, source, and install scopes.
@@ -389,6 +401,63 @@ func (m *Manifest) RemoveAsset(name, version string) int {
 // NormalizeEmail lowercases and trims an email for comparison and storage.
 func NormalizeEmail(email string) string {
 	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// OrgAdmins returns the configured org-admin emails (nil-safe).
+func (m *Manifest) OrgAdmins() []string {
+	if m.Org == nil {
+		return nil
+	}
+	return m.Org.Admins
+}
+
+// HasOrgAdmins reports whether the vault is governed (has any org-admin).
+func (m *Manifest) HasOrgAdmins() bool {
+	return len(m.OrgAdmins()) > 0
+}
+
+// IsOrgAdmin reports whether email is an org-admin.
+func (m *Manifest) IsOrgAdmin(email string) bool {
+	needle := NormalizeEmail(email)
+	if needle == "" {
+		return false
+	}
+	return slices.Contains(m.OrgAdmins(), needle)
+}
+
+// AddOrgAdmins adds the given emails to the org-admin list (normalized,
+// deduped, sorted). Returns how many were newly added.
+func (m *Manifest) AddOrgAdmins(emails ...string) int {
+	if m.Org == nil {
+		m.Org = &Org{}
+	}
+	before := len(m.Org.Admins)
+	m.Org.Admins = dedupeSorted(append(m.Org.Admins, normalizeEmails(emails)...))
+	return len(m.Org.Admins) - before
+}
+
+// RemoveOrgAdmin removes email from the org-admin list. Returns true if it
+// was present. Clears the Org table entirely once the last admin is removed,
+// returning the vault to ungoverned.
+func (m *Manifest) RemoveOrgAdmin(email string) bool {
+	if m.Org == nil {
+		return false
+	}
+	needle := NormalizeEmail(email)
+	kept := m.Org.Admins[:0]
+	removed := false
+	for _, a := range m.Org.Admins {
+		if a == needle {
+			removed = true
+			continue
+		}
+		kept = append(kept, a)
+	}
+	m.Org.Admins = kept
+	if len(m.Org.Admins) == 0 {
+		m.Org = nil
+	}
+	return removed
 }
 
 // normalizeTeamInPlace trims and deduplicates a team's string slices. The

--- a/internal/manifest/resolve.go
+++ b/internal/manifest/resolve.go
@@ -203,6 +203,13 @@ func resolveScopes(in []Scope, m *Manifest, actorEmail string) (_ []lockfile.Sco
 			if actorEmail == "" || !team.IsMember(actorEmail) {
 				continue
 			}
+			if len(team.Repositories) == 0 {
+				// A team with no repositories installs globally for its members
+				// (matches skills.new). Expanding to zero repos would otherwise
+				// drop the asset, so a team-scoped skill would never install.
+				becameGlobal = true
+				continue
+			}
 			for _, repoURL := range team.Repositories {
 				accumulated = append(accumulated, lockfile.Scope{Repo: repoURL})
 			}

--- a/internal/manifest/resolve_test.go
+++ b/internal/manifest/resolve_test.go
@@ -127,3 +127,52 @@ func TestResolve_HumanIgnoresBotScopes(t *testing.T) {
 		}
 	}
 }
+
+// TestResolve_TeamWithNoReposIsGlobal: a skill scoped to a team the caller is a
+// member of installs globally when the team has no repositories (matches
+// skills.new), and scopes to the team's repos when it has them. A non-member
+// gets neither.
+func TestResolve_TeamWithNoReposIsGlobal(t *testing.T) {
+	m := &Manifest{
+		SchemaVersion: CurrentSchemaVersion,
+		Teams: []Team{
+			{Name: "my-team", Members: []string{"ines@acme.com"}, Admins: []string{"ines@acme.com"}},
+			{Name: "with-repos", Members: []string{"ines@acme.com"}, Repositories: []string{"github.com/acme/app"}},
+		},
+		Assets: []Asset{
+			{Name: "team-no-repos", Version: "1.0", Type: asset.TypeSkill,
+				Scopes: []Scope{{Kind: ScopeKindTeam, Team: "my-team"}}},
+			{Name: "team-with-repos", Version: "1.0", Type: asset.TypeSkill,
+				Scopes: []Scope{{Kind: ScopeKindTeam, Team: "with-repos"}}},
+		},
+	}
+
+	// Member of both teams.
+	lf := Resolve(m, mgmt.Actor{Email: "ines@acme.com"})
+	got := map[string][]Scope{}
+	for _, a := range lf.Assets {
+		// a.Scopes is []lockfile.Scope; capture presence + whether global (no scopes).
+		got[a.Name] = nil
+		if len(a.Scopes) > 0 {
+			got[a.Name] = []Scope{{Repo: a.Scopes[0].Repo}}
+		}
+	}
+
+	if _, ok := got["team-no-repos"]; !ok {
+		t.Fatalf("team with no repos should install for member (global), got assets %+v", got)
+	}
+	if s := got["team-no-repos"]; s != nil {
+		t.Fatalf("team with no repos should be global (no scopes), got %+v", s)
+	}
+	if s := got["team-with-repos"]; len(s) != 1 || s[0].Repo != "github.com/acme/app" {
+		t.Fatalf("team with repos should scope to its repo, got %+v", s)
+	}
+
+	// A non-member gets neither.
+	lf2 := Resolve(m, mgmt.Actor{Email: "stranger@acme.com"})
+	for _, a := range lf2.Assets {
+		if a.Name == "team-no-repos" || a.Name == "team-with-repos" {
+			t.Fatalf("non-member should not receive team-scoped asset %q", a.Name)
+		}
+	}
+}

--- a/internal/mgmt/audit.go
+++ b/internal/mgmt/audit.go
@@ -47,6 +47,9 @@ const (
 	EventInstallSet     = "install.set"
 	EventInstallCleared = "install.cleared"
 	EventInstallRemoved = "install.removed"
+
+	EventOrgAdminAdded   = "org.admin_added"
+	EventOrgAdminRemoved = "org.admin_removed"
 )
 
 // Audit target type constants.
@@ -55,6 +58,7 @@ const (
 	TargetTypeBot          = "bot"
 	TargetTypeAsset        = "asset"
 	TargetTypeInstallation = "installation"
+	TargetTypeOrg          = "org"
 )
 
 // AuditEvent is a single row in .sx/audit/YYYY-MM.jsonl.

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -789,7 +789,10 @@ func (g *GitVault) PostUsageStats(ctx context.Context, jsonlData string) error {
 	return g.RecordUsageEvents(ctx, events)
 }
 
-// SetInstallations upserts the asset into the vault's manifest and pushes.
+// SetInstallations upserts the asset into the vault's manifest and pushes. The
+// incoming asset's scopes replace the stored set, except for existing scopes the
+// actor isn't allowed to remove (e.g. a team they don't admin), which are
+// carried through — see commonSetInstallations and docs/rbac.md.
 func (g *GitVault) SetInstallations(ctx context.Context, asset *lockfile.Asset, scopeEntity string) error {
 	fileLock, err := g.acquireFileLock(ctx)
 	if err != nil {
@@ -801,7 +804,11 @@ func (g *GitVault) SetInstallations(ctx context.Context, asset *lockfile.Asset, 
 		return fmt.Errorf("failed to clone/update repository: %w", err)
 	}
 
-	if err := upsertAssetInManifest(g.repoPath, asset); err != nil {
+	actor, err := g.CurrentActor(ctx)
+	if err != nil {
+		return err
+	}
+	if err := commonSetInstallations(g.repoPath, actor, asset); err != nil {
 		return fmt.Errorf("failed to update manifest: %w", err)
 	}
 

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -352,7 +352,7 @@ func (g *GitVault) SetAssetInstallations(ctx context.Context, assetName string, 
 	}
 	msg := verb + assetName
 	err = g.runInVaultTx(ctx, msg, func(root string, actor mgmt.Actor) error {
-		skipped, err = commonSetAssetInstallations(root, actor, assetName, targets, appendMode)
+		skipped, err = commonSetAssetInstallations(ctx, root, actor, assetName, targets, appendMode)
 		return err
 	})
 	return skipped, err
@@ -364,7 +364,7 @@ func (g *GitVault) SetAssetInstallations(ctx context.Context, assetName string, 
 func (g *GitVault) UninstallAssetTargets(ctx context.Context, assetName string, targets []InstallTarget) (removed int, failures []string, err error) {
 	msg := "Remove installations for " + assetName
 	err = g.runInVaultTx(ctx, msg, func(root string, actor mgmt.Actor) error {
-		removed, failures, err = commonUninstallAssetTargets(root, actor, assetName, targets)
+		removed, failures, err = commonUninstallAssetTargets(ctx, root, actor, assetName, targets)
 		return err
 	})
 	return removed, failures, err

--- a/internal/vault/mgmt_e2e_test.go
+++ b/internal/vault/mgmt_e2e_test.go
@@ -430,62 +430,6 @@ func TestPathVault_RemoveOrgInstall_Rejected(t *testing.T) {
 	}
 }
 
-// TestPathVault_TeamScopeDoesNotRequireAdmin pins SD-10170: scoping an asset TO
-// a team (and unscoping it) only requires the team to EXIST plus vault write
-// access — NOT team-admin. Team *management* still requires admin (see
-// TestPathVault_TeamMutationsRequireAdmin). Scoping to a team that doesn't
-// exist still errors.
-func TestPathVault_TeamScopeDoesNotRequireAdmin(t *testing.T) {
-	mgmt.ResetActorCache()
-	dir := t.TempDir()
-
-	runGit(t, dir, "init")
-	runGit(t, dir, "config", "user.email", "alice@example.com")
-	runGit(t, dir, "config", "user.name", "Alice")
-
-	if err := manifest.Save(dir, &manifest.Manifest{
-		SchemaVersion: manifest.CurrentSchemaVersion,
-		Assets: []manifest.Asset{
-			{
-				Name:       "my-skill",
-				Version:    "1.0.0",
-				Type:       asset.TypeSkill,
-				SourceHTTP: &manifest.SourceHTTP{URL: "https://example.com/my-skill.zip"},
-			},
-		},
-	}); err != nil {
-		t.Fatalf("seed manifest: %v", err)
-	}
-	v, err := NewPathVault("file://" + dir)
-	if err != nil {
-		t.Fatalf("NewPathVault: %v", err)
-	}
-	ctx := context.Background()
-
-	// Team whose only admin is bob — the caller (alice) is NOT an admin.
-	if err := v.CreateTeam(ctx, mgmt.Team{
-		Name:    "platform",
-		Members: []string{"bob@example.com"},
-		Admins:  []string{"bob@example.com"},
-	}); err != nil {
-		t.Fatalf("CreateTeam: %v", err)
-	}
-
-	// Non-admin alice may scope the asset to the team...
-	if err := v.SetAssetInstallation(ctx, "my-skill", InstallTarget{Kind: InstallKindTeam, Team: "platform"}); err != nil {
-		t.Fatalf("non-admin should be able to scope an asset to a team: %v", err)
-	}
-	// ...and unscope it.
-	if err := v.RemoveAssetInstallation(ctx, "my-skill", InstallTarget{Kind: InstallKindTeam, Team: "platform"}); err != nil {
-		t.Fatalf("non-admin should be able to unscope an asset from a team: %v", err)
-	}
-
-	// But scoping to a team that doesn't exist still fails.
-	if err := v.SetAssetInstallation(ctx, "my-skill", InstallTarget{Kind: InstallKindTeam, Team: "ghost"}); err == nil {
-		t.Fatal("scoping to a nonexistent team should fail with team-not-found")
-	}
-}
-
 func countPathScopes(a *manifest.Asset) int {
 	if a == nil {
 		return 0

--- a/internal/vault/mgmt_e2e_test.go
+++ b/internal/vault/mgmt_e2e_test.go
@@ -1226,3 +1226,48 @@ func TestPathVault_CreateTeam_ExplicitAdminNotCaller(t *testing.T) {
 		t.Errorf("admin should be auto-added as member, got members=%v", team.Members)
 	}
 }
+
+// TestRemoveTeamMember_SelfRemoval: a plain member can always remove themselves
+// (leave) without being a team admin; removing someone else still needs admin.
+func TestRemoveTeamMember_SelfRemoval(t *testing.T) {
+	ctx := context.Background()
+	seed := func(actorEmail string) *PathVault {
+		mgmt.ResetActorCache()
+		dir := t.TempDir()
+		runGit(t, dir, "init")
+		runGit(t, dir, "config", "user.email", actorEmail)
+		runGit(t, dir, "config", "user.name", "U")
+		m := &manifest.Manifest{
+			SchemaVersion: manifest.CurrentSchemaVersion,
+			Teams: []manifest.Team{{
+				Name:    "my-team",
+				Members: []string{"alice@example.com", "bob@example.com"},
+				Admins:  []string{"alice@example.com"},
+			}},
+		}
+		if err := manifest.Save(dir, m); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		v, err := NewPathVault("file://" + dir)
+		if err != nil {
+			t.Fatalf("NewPathVault: %v", err)
+		}
+		return v
+	}
+
+	// bob (a non-admin member) removes himself — allowed.
+	v := seed("bob@example.com")
+	if err := v.RemoveTeamMember(ctx, "my-team", "bob@example.com"); err != nil {
+		t.Fatalf("self-removal by a non-admin should succeed: %v", err)
+	}
+	if team, _ := v.GetTeam(ctx, "my-team"); team != nil && team.IsMember("bob@example.com") {
+		t.Fatalf("bob should no longer be a member")
+	}
+
+	// bob (a non-admin) tries to remove alice — denied.
+	v = seed("bob@example.com")
+	if err := v.RemoveTeamMember(ctx, "my-team", "alice@example.com"); err == nil ||
+		!strings.Contains(err.Error(), "not an admin") {
+		t.Fatalf("non-admin removing another member should be denied, got %v", err)
+	}
+}

--- a/internal/vault/mgmt_edit.go
+++ b/internal/vault/mgmt_edit.go
@@ -1,0 +1,82 @@
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/mgmt"
+)
+
+// assetEditReason returns "" if actor may edit/publish the named asset, or a
+// human-readable denial reason. Per docs/rbac.md, editing is governed by the
+// skill's team scope (not the org-admins state):
+//
+//   - A brand-new asset (absent from the manifest) → anyone may create it.
+//   - Org-admins → may always edit anything.
+//   - A skill scoped to a team → only a member of that team may edit it.
+//     Scoped to several teams → a member of any of them.
+//   - A skill not scoped to any team → anyone may edit it.
+func assetEditReason(m *manifest.Manifest, name string, actor mgmt.Actor) string {
+	a := m.FindAsset(name)
+	if a == nil {
+		return "" // new asset → anyone may create it
+	}
+	if m.IsOrgAdmin(actor.Email) {
+		return "" // org-admins may always edit
+	}
+	var teamScopes []string
+	for _, s := range a.Scopes {
+		if s.Kind == manifest.ScopeKindTeam {
+			teamScopes = append(teamScopes, s.Team)
+		}
+	}
+	if len(teamScopes) == 0 {
+		return "" // not team-scoped → anyone may edit
+	}
+	for _, tn := range teamScopes {
+		if team, err := m.FindTeam(tn); err == nil &&
+			(team.IsMember(actor.Email) || team.IsAdmin(actor.Email)) {
+			return ""
+		}
+	}
+	return fmt.Sprintf("permission denied: %q is scoped to team %s — only a member of that team (or an org-admin) may edit it",
+		name, strings.Join(teamScopes, ", "))
+}
+
+// commonAssetEditPermission is the file-backed (git/path) edit gate. It reads
+// the manifest and returns an error when actor may not publish a new version of
+// the named asset.
+func commonAssetEditPermission(vaultRoot string, actor mgmt.Actor, name string) error {
+	m, err := loadManifest(vaultRoot)
+	if err != nil {
+		return err
+	}
+	if reason := assetEditReason(m, name, actor); reason != "" {
+		return errors.New(reason)
+	}
+	return nil
+}
+
+// CheckAssetEditPermission enforces the file-backed edit gate for a path vault.
+func (p *PathVault) CheckAssetEditPermission(ctx context.Context, name string) error {
+	actor, err := p.CurrentActor(ctx)
+	if err != nil {
+		return err
+	}
+	return commonAssetEditPermission(p.repoPath, actor, name)
+}
+
+// CheckAssetEditPermission enforces the file-backed edit gate for a git vault.
+func (g *GitVault) CheckAssetEditPermission(ctx context.Context, name string) error {
+	if err := g.cloneOrUpdate(ctx); err != nil {
+		return err
+	}
+	actor, err := g.CurrentActor(ctx)
+	if err != nil {
+		return err
+	}
+	return commonAssetEditPermission(g.repoPath, actor, name)
+}

--- a/internal/vault/mgmt_edit.go
+++ b/internal/vault/mgmt_edit.go
@@ -37,8 +37,9 @@ func assetEditReason(m *manifest.Manifest, name string, actor mgmt.Actor) string
 		return "" // not team-scoped → anyone may edit
 	}
 	for _, tn := range teamScopes {
-		if team, err := m.FindTeam(tn); err == nil &&
-			(team.IsMember(actor.Email) || team.IsAdmin(actor.Email)) {
+		// Editing is member-level: team admins are auto-added as members, so a
+		// membership check alone suffices (admin status gates *scoping*, not edits).
+		if team, err := m.FindTeam(tn); err == nil && team.IsMember(actor.Email) {
 			return ""
 		}
 	}

--- a/internal/vault/mgmt_edit_test.go
+++ b/internal/vault/mgmt_edit_test.go
@@ -1,0 +1,73 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/mgmt"
+)
+
+// TestAssetEditPermission_Matrix exercises the edit gate (assetEditReason):
+// team-scoped skills are editable only by members of that team (or an
+// org-admin); non-team-scoped and brand-new skills are open to anyone.
+func TestAssetEditPermission_Matrix(t *testing.T) {
+	platform := manifest.Team{Name: "platform", Members: []string{"alice@x.com", "carol@x.com"}, Admins: []string{"alice@x.com"}}
+	backend := manifest.Team{Name: "backend", Members: []string{"dave@x.com"}, Admins: []string{"dave@x.com"}}
+
+	mk := func(scopes []manifest.Scope, orgAdmins []string) *manifest.Manifest {
+		m := &manifest.Manifest{
+			Teams:  []manifest.Team{platform, backend},
+			Assets: []manifest.Asset{{Name: "skill", Scopes: scopes}},
+		}
+		if len(orgAdmins) > 0 {
+			m.Org = &manifest.Org{Admins: orgAdmins}
+		}
+		return m
+	}
+	team := func(n string) manifest.Scope { return manifest.Scope{Kind: manifest.ScopeKindTeam, Team: n} }
+	repo := manifest.Scope{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/r"}
+	a := func(e string) mgmt.Actor { return mgmt.Actor{Email: e} }
+
+	cases := []struct {
+		name    string
+		m       *manifest.Manifest
+		actor   mgmt.Actor
+		allowed bool
+	}{
+		// Not team-scoped → anyone.
+		{"no-scopes/anyone", mk(nil, nil), a("nobody@x.com"), true},
+		{"repo-scoped/anyone", mk([]manifest.Scope{repo}, nil), a("nobody@x.com"), true},
+
+		// Team-scoped → members only.
+		{"team-scoped/admin-member", mk([]manifest.Scope{team("platform")}, nil), a("alice@x.com"), true},
+		{"team-scoped/plain-member", mk([]manifest.Scope{team("platform")}, nil), a("carol@x.com"), true},
+		{"team-scoped/non-member-denied", mk([]manifest.Scope{team("platform")}, nil), a("nobody@x.com"), false},
+		{"team-scoped/other-team-member-denied", mk([]manifest.Scope{team("platform")}, nil), a("dave@x.com"), false},
+
+		// Org-admin always.
+		{"team-scoped/org-admin", mk([]manifest.Scope{team("platform")}, []string{"boss@x.com"}), a("boss@x.com"), true},
+
+		// Multiple team scopes → member of any.
+		{"multi-team/member-of-one", mk([]manifest.Scope{team("platform"), team("backend")}, nil), a("dave@x.com"), true},
+		{"multi-team/non-member-denied", mk([]manifest.Scope{team("platform"), team("backend")}, nil), a("nobody@x.com"), false},
+
+		// Team + repo scopes → team scope still restricts editing to members.
+		{"team+repo/member", mk([]manifest.Scope{team("platform"), repo}, nil), a("carol@x.com"), true},
+		{"team+repo/non-member-denied", mk([]manifest.Scope{team("platform"), repo}, nil), a("nobody@x.com"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			reason := assetEditReason(c.m, "skill", c.actor)
+			if (reason == "") != c.allowed {
+				t.Fatalf("allowed=%v want=%v (reason=%q)", reason == "", c.allowed, reason)
+			}
+		})
+	}
+
+	// A brand-new asset (absent from the manifest) is editable by anyone.
+	t.Run("new-asset/anyone", func(t *testing.T) {
+		if r := assetEditReason(mk(nil, nil), "does-not-exist", a("nobody@x.com")); r != "" {
+			t.Fatalf("new asset should be editable, got %q", r)
+		}
+	})
+}

--- a/internal/vault/mgmt_edit_test.go
+++ b/internal/vault/mgmt_edit_test.go
@@ -26,6 +26,7 @@ func TestAssetEditPermission_Matrix(t *testing.T) {
 	}
 	team := func(n string) manifest.Scope { return manifest.Scope{Kind: manifest.ScopeKindTeam, Team: n} }
 	repo := manifest.Scope{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/r"}
+	user := func(e string) manifest.Scope { return manifest.Scope{Kind: manifest.ScopeKindUser, User: e} }
 	a := func(e string) mgmt.Actor { return mgmt.Actor{Email: e} }
 
 	cases := []struct {
@@ -54,6 +55,11 @@ func TestAssetEditPermission_Matrix(t *testing.T) {
 		// Team + repo scopes → team scope still restricts editing to members.
 		{"team+repo/member", mk([]manifest.Scope{team("platform"), repo}, nil), a("carol@x.com"), true},
 		{"team+repo/non-member-denied", mk([]manifest.Scope{team("platform"), repo}, nil), a("nobody@x.com"), false},
+
+		// Team + user scopes → the team scope still rules; being the scoped user
+		// does not grant edit rights (must be a team member).
+		{"team+user/scoped-user-non-member-denied", mk([]manifest.Scope{team("platform"), user("bob@x.com")}, nil), a("bob@x.com"), false},
+		{"team+user/team-member-allowed", mk([]manifest.Scope{team("platform"), user("bob@x.com")}, nil), a("carol@x.com"), true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -962,10 +963,14 @@ func commonClearAssetInstallations(vaultRoot string, actor mgmt.Actor, assetName
 // caller to surface — it never aborts the whole batch on one bad target. If
 // NOTHING resolves, the asset is left untouched rather than cleared, so a
 // REPLACE whose targets all fail can't silently globalize the asset.
-func commonSetAssetInstallations(vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget, appendMode bool) ([]SkippedTarget, error) {
+func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget, appendMode bool) ([]SkippedTarget, error) {
 	if len(targets) == 0 {
 		return nil, nil
 	}
+
+	// Trusted bulk writers (vault copy faithfully replicating a source's scopes)
+	// opt out of the interactive RBAC; a normal user-driven scope change enforces.
+	enforce := !scopeRBACBypassed(ctx)
 
 	orgWide := false
 	for _, t := range targets {
@@ -976,6 +981,15 @@ func commonSetAssetInstallations(vaultRoot string, actor mgmt.Actor, assetName s
 
 	var skipped []SkippedTarget
 	err := withManifestEvents(vaultRoot, actor, func(m *manifest.Manifest) ([]mgmt.AuditEvent, error) {
+		// Org-wide is exclusive and bypasses the per-target resolve loop below,
+		// so gate its RBAC permission here. Denied → record it and leave the
+		// asset untouched (the caller turns an all-skipped set into a hard error).
+		if enforce && orgWide {
+			if reason := scopeSetPermissionReason(m, InstallTarget{Kind: InstallKindOrg}, actor); reason != "" {
+				skipped = append(skipped, SkippedTarget{Target: InstallTarget{Kind: InstallKindOrg}, Reason: reason})
+				return nil, nil
+			}
+		}
 		// Resolve each non-org target against the in-transaction manifest,
 		// skipping any that can't be set (with the reason why). Org is exclusive
 		// and needs no resolution (it clears the scope set).
@@ -987,6 +1001,10 @@ func commonSetAssetInstallations(vaultRoot string, actor mgmt.Actor, assetName s
 		if !orgWide {
 			for _, t := range targets {
 				s, reason := resolveSetTarget(m, t, actor)
+				// Existence/format settled; now the RBAC gate (who may set it).
+				if reason == "" && enforce {
+					reason = scopeSetPermissionReason(m, t, actor)
+				}
 				if reason != "" {
 					skipped = append(skipped, SkippedTarget{Target: t, Reason: reason})
 					continue
@@ -1102,6 +1120,63 @@ func resolveSetTarget(m *manifest.Manifest, t InstallTarget, actor mgmt.Actor) (
 	return s, ""
 }
 
+// scopeRBACBypassKey carries the trusted-write opt-out (see
+// ContextWithTrustedScopeWrite). Pointer-free empty struct = standard ctx key.
+type scopeRBACBypassKey struct{}
+
+// ContextWithTrustedScopeWrite marks ctx as a trusted bulk scope write that
+// skips the file-backed RBAC gate. Used by `sx vault copy`, which replicates a
+// source vault's existing scopes verbatim and must not be blocked just because
+// the operator isn't a team admin in the destination. User-driven scope changes
+// (sx add) never set this, so they stay governed by scopeSetPermissionReason.
+func ContextWithTrustedScopeWrite(ctx context.Context) context.Context {
+	return context.WithValue(ctx, scopeRBACBypassKey{}, true)
+}
+
+// scopeRBACBypassed reports whether ctx was marked trusted.
+func scopeRBACBypassed(ctx context.Context) bool {
+	v, _ := ctx.Value(scopeRBACBypassKey{}).(bool)
+	return v
+}
+
+// scopeSetPermissionReason is the file-backed (git/path) vault's RBAC gate for
+// setting (or removing) an install scope. It returns "" when actor may set the
+// target, or a human-readable reason when they may not. The org-admins list is
+// the single on/off switch — see docs/rbac.md:
+//
+//   - No org-admins configured → ungoverned: anyone may set any scope.
+//   - org-admin → may set any scope.
+//   - team scope → actor must be an admin of THAT team (or an org-admin).
+//   - user scope ("just for me") → always allowed; installTargetScope already
+//     forbids targeting anyone but the caller, so user is self-only.
+//   - org / repo / path / bot → org-admins only.
+//
+// This is a client-side gate — a file-backed vault can't stop a raw `git push`
+// — so it steers correct usage rather than guaranteeing it.
+func scopeSetPermissionReason(m *manifest.Manifest, t InstallTarget, actor mgmt.Actor) string {
+	if !m.HasOrgAdmins() {
+		return "" // ungoverned: no org-admins configured
+	}
+	if m.IsOrgAdmin(actor.Email) {
+		return "" // org-admins may set any scope
+	}
+	switch t.Kind {
+	case InstallKindTeam:
+		if team, err := m.FindTeam(t.Team); err == nil && team.IsAdmin(actor.Email) {
+			return ""
+		}
+		return fmt.Sprintf("permission denied: setting a team scope requires being an admin of team %q or an org-admin", t.Team)
+	case InstallKindUser:
+		if actor.Email != "" && manifest.NormalizeEmail(t.User) == manifest.NormalizeEmail(actor.Email) {
+			return "" // your own account
+		}
+		return "permission denied: a user scope may only target your own account"
+	case InstallKindOrg, InstallKindRepo, InstallKindPath, InstallKindBot:
+		return fmt.Sprintf("permission denied: setting a %s scope requires being an org-admin", t.Kind)
+	}
+	return fmt.Sprintf("permission denied: setting a %s scope requires being an org-admin", t.Kind)
+}
+
 // commonUninstallAssetTargets removes a batch of install targets from the named
 // asset in a single manifest transaction, returning how many scope rows were
 // removed and a per-target failure message for any that couldn't be resolved
@@ -1109,13 +1184,16 @@ func resolveSetTarget(m *manifest.Manifest, t InstallTarget, actor mgmt.Actor) (
 // counterpart to SleuthVault.UninstallAssetTargets and satisfies the
 // targetUninstaller interface. A row left with no scopes is dropped rather than
 // reinterpreted as global, matching commonRemoveAssetInstallation.
-func commonUninstallAssetTargets(vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget) (int, []string, error) {
+func commonUninstallAssetTargets(ctx context.Context, vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget) (int, []string, error) {
 	if len(targets) == 0 {
 		return 0, nil, nil
 	}
 
+	enforce := !scopeRBACBypassed(ctx)
+
 	var needles []manifest.Scope
 	var teamTargets []InstallTarget
+	var resolvedTargets []InstallTarget
 	var failures []string
 	for _, t := range targets {
 		needle, err := installTargetScope(t, actor)
@@ -1124,6 +1202,7 @@ func commonUninstallAssetTargets(vaultRoot string, actor mgmt.Actor, assetName s
 			continue
 		}
 		needles = append(needles, needle)
+		resolvedTargets = append(resolvedTargets, t)
 		if t.Kind == InstallKindTeam {
 			teamTargets = append(teamTargets, t)
 		}
@@ -1137,6 +1216,14 @@ func commonUninstallAssetTargets(vaultRoot string, actor mgmt.Actor, assetName s
 		for _, t := range teamTargets {
 			if err := teamExistsInTx(m, t.Team); err != nil {
 				return nil, err
+			}
+		}
+		// Removing a scope needs the same authority as setting it.
+		if enforce {
+			for _, t := range resolvedTargets {
+				if reason := scopeSetPermissionReason(m, t, actor); reason != "" {
+					return nil, errors.New(reason)
+				}
 			}
 		}
 		changed := false

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
 	"github.com/sleuth-io/sx/internal/scope"
@@ -1057,6 +1058,23 @@ func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mg
 		}
 
 		if orgWide || !appendMode {
+			// A replace/global clears the whole scope set — but removing a scope
+			// needs the same authority as setting it (docs/rbac.md). Before
+			// clearing, gather any existing scopes the actor isn't allowed to
+			// remove (chiefly team scopes they don't admin) so they survive; else
+			// a non-team-admin could strip a team just by re-scoping the skill to
+			// themselves or to global. Each kept scope is reported as skipped.
+			var preserved []manifest.Scope
+			if enforce {
+				desired := make([]manifest.Scope, 0, len(resolved))
+				for _, r := range resolved {
+					desired = append(desired, r.scope)
+				}
+				for _, d := range protectedScopesForActor(m, assetName, actor, desired) {
+					preserved = append(preserved, d.scope)
+					skipped = append(skipped, SkippedTarget{Target: d.target, Reason: d.reason + " (kept — not removed)"})
+				}
+			}
 			// Replace (and org-global) clear the whole picture: scopes inherit
 			// onto every same-name version row (see commonRemoveAssetInstallation),
 			// so clear them all before re-adding, or stale rows would keep the
@@ -1066,6 +1084,9 @@ func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mg
 					m.Assets[i].Scopes = nil
 				}
 			}
+			// Re-seed the protected scopes onto the canonical row; the resolved
+			// targets below append onto it (deduped).
+			asset.Scopes = append(asset.Scopes, preserved...)
 		}
 
 		events := make([]mgmt.AuditEvent, 0, len(resolved)+2)
@@ -1198,6 +1219,93 @@ func scopeSetPermissionReason(m *manifest.Manifest, t InstallTarget, actor mgmt.
 		// Handled above (always team-admin gated).
 	}
 	return fmt.Sprintf("permission denied: setting a %s scope requires being an org-admin", t.Kind)
+}
+
+// scopeDenial records an existing scope the actor is not permitted to remove,
+// with the reason and the equivalent install target for reporting.
+type scopeDenial struct {
+	scope  manifest.Scope
+	target InstallTarget
+	reason string
+}
+
+// protectedScopesForActor returns the named asset's existing scopes that actor
+// may NOT remove (per scopeSetPermissionReason) and that are absent from the
+// desired set — i.e. the scopes a wholesale replace or "go global" would
+// silently strip. Removing a scope needs the same authority as setting it
+// (docs/rbac.md), so callers carry these through and report them; without this
+// a non-team-admin could drop a team scope just by re-scoping a skill to
+// themselves or to global. Scopes are gathered across the asset's per-version
+// rows and deduped.
+func protectedScopesForActor(m *manifest.Manifest, assetName string, actor mgmt.Actor, desired []manifest.Scope) []scopeDenial {
+	seen := make(map[string]bool)
+	var denials []scopeDenial
+	for i := range m.Assets {
+		if m.Assets[i].Name != assetName {
+			continue
+		}
+		for _, s := range m.Assets[i].Scopes {
+			tgt, ok := manifestScopeToTarget(s)
+			if !ok {
+				continue // org rows aren't stored; nothing to protect
+			}
+			reason := scopeSetPermissionReason(m, tgt, actor)
+			if reason == "" {
+				continue // actor may remove it
+			}
+			if scopeExistsOnAsset(desired, s) {
+				continue // staying anyway — not a removal
+			}
+			key := scopeDedupKey(s)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			denials = append(denials, scopeDenial{scope: s, target: tgt, reason: reason})
+		}
+	}
+	return denials
+}
+
+// scopeDedupKey is a stable identity for a scope row, used to dedupe protected
+// scopes gathered across an asset's per-version rows.
+func scopeDedupKey(s manifest.Scope) string {
+	return strings.Join([]string{
+		string(s.Kind), s.Repo, strings.Join(canonicalPaths(s.Paths), ","), s.Team, s.User, s.Bot,
+	}, "\x00")
+}
+
+// commonSetInstallations upserts asset into the manifest like
+// upsertAssetInManifest, but first carries through any existing scopes actor is
+// not allowed to remove (docs/rbac.md) so a "go global" or repo/path replace
+// can't silently strip a team scope from someone who isn't that team's admin.
+// Kept scopes are reported to stderr — this singular path has no structured
+// output channel. It's the actor-aware counterpart used by the file-backed
+// SetInstallations methods.
+func commonSetInstallations(vaultRoot string, actor mgmt.Actor, asset *lockfile.Asset) error {
+	m, err := loadManifest(vaultRoot)
+	if err != nil {
+		return err
+	}
+	ma := lockfileAssetToManifest(*asset)
+	// Preserve Clients from any existing same name+version entry when the
+	// incoming asset declares none (mirrors upsertAssetInManifest).
+	if len(ma.Clients) == 0 {
+		for i := range m.Assets {
+			if m.Assets[i].Name == ma.Name && m.Assets[i].Version == ma.Version && len(m.Assets[i].Clients) > 0 {
+				ma.Clients = append([]string(nil), m.Assets[i].Clients...)
+				break
+			}
+		}
+	}
+	for _, d := range protectedScopesForActor(m, asset.Name, actor, ma.Scopes) {
+		if !scopeExistsOnAsset(ma.Scopes, d.scope) {
+			ma.Scopes = append(ma.Scopes, d.scope)
+		}
+		fmt.Fprintf(os.Stderr, "⚠ Kept %s scope: %s\n", d.target.Kind, d.reason)
+	}
+	m.UpsertAsset(ma)
+	return manifest.Save(vaultRoot, m)
 }
 
 // commonUninstallAssetTargets removes a batch of install targets from the named

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -349,11 +349,25 @@ func commonAddTeamMember(vaultRoot string, actor mgmt.Actor, teamName, email str
 // admin.
 func commonRemoveTeamMember(vaultRoot string, actor mgmt.Actor, teamName, email string) error {
 	return withManifest(vaultRoot, actor, func(m *manifest.Manifest) (*mgmt.AuditEvent, error) {
-		team, err := requireTeamAdminInTx(m, teamName, actor)
-		if err != nil {
-			return nil, err
-		}
 		normalized := manifest.NormalizeEmail(email)
+
+		// Anyone may remove themselves from a team (leave), admin or not.
+		// Removing someone else still requires being a team admin.
+		var team *manifest.Team
+		if normalized != "" && normalized == manifest.NormalizeEmail(actor.Email) {
+			t, err := m.FindTeam(teamName)
+			if err != nil {
+				return nil, err
+			}
+			team = t
+		} else {
+			t, err := requireTeamAdminInTx(m, teamName, actor)
+			if err != nil {
+				return nil, err
+			}
+			team = t
+		}
+
 		team.Members = removeString(team.Members, normalized)
 		team.Admins = removeString(team.Admins, normalized)
 		if len(team.Admins) == 0 {

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -1168,18 +1168,25 @@ func scopeRBACBypassed(ctx context.Context) bool {
 // This is a client-side gate — a file-backed vault can't stop a raw `git push`
 // — so it steers correct usage rather than guaranteeing it.
 func scopeSetPermissionReason(m *manifest.Manifest, t InstallTarget, actor mgmt.Actor) string {
-	if !m.HasOrgAdmins() {
-		return "" // ungoverned: no org-admins configured
-	}
+	// Org-admins may set any scope.
 	if m.IsOrgAdmin(actor.Email) {
-		return "" // org-admins may set any scope
+		return ""
 	}
-	switch t.Kind {
-	case InstallKindTeam:
+	// A team scope locks a skill to that team (teams own skills), so setting it
+	// ALWAYS requires being an admin of that team — in every vault, governed or
+	// ungoverned. This is the one scope the ungoverned free-for-all below never
+	// covers; only an org-admin (above) may otherwise act.
+	if t.Kind == InstallKindTeam {
 		if team, err := m.FindTeam(t.Team); err == nil && team.IsAdmin(actor.Email) {
 			return ""
 		}
-		return fmt.Sprintf("permission denied: setting a team scope requires being an admin of team %q or an org-admin", t.Team)
+		return fmt.Sprintf("permission denied: only an admin of team %q (or an org-admin) may scope a skill to it", t.Team)
+	}
+	// Without org-admins the vault is ungoverned: anyone may set any other scope.
+	if !m.HasOrgAdmins() {
+		return ""
+	}
+	switch t.Kind {
 	case InstallKindUser:
 		if actor.Email != "" && manifest.NormalizeEmail(t.User) == manifest.NormalizeEmail(actor.Email) {
 			return "" // your own account
@@ -1187,6 +1194,8 @@ func scopeSetPermissionReason(m *manifest.Manifest, t InstallTarget, actor mgmt.
 		return "permission denied: a user scope may only target your own account"
 	case InstallKindOrg, InstallKindRepo, InstallKindPath, InstallKindBot:
 		return fmt.Sprintf("permission denied: setting a %s scope requires being an org-admin", t.Kind)
+	case InstallKindTeam:
+		// Handled above (always team-admin gated).
 	}
 	return fmt.Sprintf("permission denied: setting a %s scope requires being an org-admin", t.Kind)
 }

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -1235,18 +1235,27 @@ func commonUninstallAssetTargets(ctx context.Context, vaultRoot string, actor mg
 	}
 
 	removed := 0
+	var rbacFailures []string
 	err := withManifest(vaultRoot, actor, func(m *manifest.Manifest) (*mgmt.AuditEvent, error) {
+		rbacFailures = nil // reset so a transaction retry doesn't double-count
 		for _, t := range teamTargets {
 			if err := teamExistsInTx(m, t.Team); err != nil {
 				return nil, err
 			}
 		}
-		// Removing a scope needs the same authority as setting it.
+		// Removing a scope needs the same authority as setting it. Deny
+		// per-target (like the set path) so the caller still removes what it
+		// is allowed to and reports the rest as failures, rather than aborting
+		// the whole batch on one denied target.
+		activeNeedles := needles
 		if enforce {
-			for _, t := range resolvedTargets {
+			activeNeedles = make([]manifest.Scope, 0, len(needles))
+			for i, t := range resolvedTargets {
 				if reason := scopeSetPermissionReason(m, t, actor); reason != "" {
-					return nil, errors.New(reason)
+					rbacFailures = append(rbacFailures, fmt.Sprintf("%s: %s", t.Kind, reason))
+					continue
 				}
+				activeNeedles = append(activeNeedles, needles[i])
 			}
 		}
 		changed := false
@@ -1259,7 +1268,7 @@ func commonUninstallAssetTargets(ctx context.Context, vaultRoot string, actor mg
 			nextScopes := a.Scopes[:0]
 			for _, s := range a.Scopes {
 				match := false
-				for _, needle := range needles {
+				for _, needle := range activeNeedles {
 					if installScopeMatches(s, needle) {
 						match = true
 						break
@@ -1291,6 +1300,7 @@ func commonUninstallAssetTargets(ctx context.Context, vaultRoot string, actor mg
 	if err != nil && !errors.Is(err, errUninstallNoMatch) {
 		return 0, failures, err
 	}
+	failures = append(failures, rbacFailures...)
 	return removed, failures, nil
 }
 

--- a/internal/vault/mgmt_org.go
+++ b/internal/vault/mgmt_org.go
@@ -1,0 +1,98 @@
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/mgmt"
+)
+
+// commonAddOrgAdmins adds emails to the org-admin list. While the list is empty
+// anyone may seed it (bootstrap); once set, only an org-admin may change it.
+func commonAddOrgAdmins(vaultRoot string, actor mgmt.Actor, emails []string) (int, error) {
+	added := 0
+	err := withManifest(vaultRoot, actor, func(m *manifest.Manifest) (*mgmt.AuditEvent, error) {
+		if m.HasOrgAdmins() && !m.IsOrgAdmin(actor.Email) {
+			return nil, errors.New("permission denied: only an org-admin may change the org-admin list")
+		}
+		added = m.AddOrgAdmins(emails...)
+		if added == 0 {
+			return nil, nil //nolint:nilnil // no-op: nothing added, no event, no error
+		}
+		return &mgmt.AuditEvent{
+			Event: mgmt.EventOrgAdminAdded, TargetType: mgmt.TargetTypeOrg, Target: "org",
+			Data: map[string]any{"added": emails},
+		}, nil
+	})
+	return added, err
+}
+
+// commonRemoveOrgAdmin removes an email from the org-admin list (org-admins only).
+func commonRemoveOrgAdmin(vaultRoot string, actor mgmt.Actor, email string) error {
+	return withManifest(vaultRoot, actor, func(m *manifest.Manifest) (*mgmt.AuditEvent, error) {
+		if !m.IsOrgAdmin(actor.Email) {
+			return nil, errors.New("permission denied: only an org-admin may change the org-admin list")
+		}
+		if !m.RemoveOrgAdmin(email) {
+			return nil, fmt.Errorf("%q is not an org-admin", email)
+		}
+		return &mgmt.AuditEvent{
+			Event: mgmt.EventOrgAdminRemoved, TargetType: mgmt.TargetTypeOrg, Target: "org",
+			Data: map[string]any{"removed": manifest.NormalizeEmail(email)},
+		}, nil
+	})
+}
+
+// commonListOrgAdmins returns the configured org-admin emails.
+func commonListOrgAdmins(vaultRoot string) ([]string, error) {
+	m, err := loadManifest(vaultRoot)
+	if err != nil {
+		return nil, err
+	}
+	return m.OrgAdmins(), nil
+}
+
+// ---- PathVault org methods ----
+
+func (p *PathVault) AddOrgAdmins(ctx context.Context, emails []string) (added int, err error) {
+	err = p.withLock(ctx, func(actor mgmt.Actor) error {
+		added, err = commonAddOrgAdmins(p.repoPath, actor, emails)
+		return err
+	})
+	return added, err
+}
+
+func (p *PathVault) RemoveOrgAdmin(ctx context.Context, email string) error {
+	return p.withLock(ctx, func(actor mgmt.Actor) error {
+		return commonRemoveOrgAdmin(p.repoPath, actor, email)
+	})
+}
+
+func (p *PathVault) ListOrgAdmins(ctx context.Context) ([]string, error) {
+	return commonListOrgAdmins(p.repoPath)
+}
+
+// ---- GitVault org methods ----
+
+func (g *GitVault) AddOrgAdmins(ctx context.Context, emails []string) (added int, err error) {
+	err = g.runInVaultTx(ctx, "Add org-admins", func(root string, actor mgmt.Actor) error {
+		added, err = commonAddOrgAdmins(root, actor, emails)
+		return err
+	})
+	return added, err
+}
+
+func (g *GitVault) RemoveOrgAdmin(ctx context.Context, email string) error {
+	return g.runInVaultTx(ctx, "Remove org-admin", func(root string, actor mgmt.Actor) error {
+		return commonRemoveOrgAdmin(root, actor, email)
+	})
+}
+
+func (g *GitVault) ListOrgAdmins(ctx context.Context) ([]string, error) {
+	if err := g.cloneOrUpdate(ctx); err != nil {
+		return nil, err
+	}
+	return commonListOrgAdmins(g.repoPath)
+}

--- a/internal/vault/mgmt_org_test.go
+++ b/internal/vault/mgmt_org_test.go
@@ -1,0 +1,78 @@
+package vault
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestOrgAdminBootstrap: while the list is empty anyone may seed the first
+// org-admin; once set, a non-admin may not change it.
+func TestOrgAdminBootstrap(t *testing.T) {
+	ctx := context.Background()
+	v := seedRBACVault(t, "mallory@example.com", nil, nil)
+
+	if n, err := v.AddOrgAdmins(ctx, []string{"boss@example.com"}); err != nil || n != 1 {
+		t.Fatalf("bootstrap add by anyone: n=%d err=%v", n, err)
+	}
+	admins, err := v.ListOrgAdmins(ctx)
+	if err != nil || len(admins) != 1 || admins[0] != "boss@example.com" {
+		t.Fatalf("list after bootstrap: %+v err=%v", admins, err)
+	}
+	// Now governed: mallory (not an admin) cannot change the list.
+	if _, err := v.AddOrgAdmins(ctx, []string{"mallory@example.com"}); err == nil ||
+		!strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("non-admin should not change org-admins, got %v", err)
+	}
+}
+
+// TestOrgAdminRemove: an org-admin can remove admins; removing the last one
+// returns the vault to ungoverned.
+func TestOrgAdminRemove(t *testing.T) {
+	ctx := context.Background()
+	v := seedRBACVault(t, "boss@example.com", nil, []string{"boss@example.com"})
+	if err := v.RemoveOrgAdmin(ctx, "boss@example.com"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	admins, err := v.ListOrgAdmins(ctx)
+	if err != nil || len(admins) != 0 {
+		t.Fatalf("expected ungoverned after removing last admin, got %+v err=%v", admins, err)
+	}
+}
+
+// TestOrgAdmin_Scenarios covers org-admin list management edge cases and gating.
+func TestOrgAdmin_Scenarios(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("add accepts and dedupes multiple emails", func(t *testing.T) {
+		v := seedRBACVault(t, "boss@example.com", nil, nil)
+		n, err := v.AddOrgAdmins(ctx, []string{"boss@example.com", "ann@example.com", "boss@example.com"})
+		if err != nil || n != 2 {
+			t.Fatalf("add multiple: n=%d err=%v", n, err)
+		}
+	})
+
+	t.Run("adding an existing admin is a no-op", func(t *testing.T) {
+		v := seedRBACVault(t, "boss@example.com", nil, []string{"boss@example.com"})
+		n, err := v.AddOrgAdmins(ctx, []string{"boss@example.com"})
+		if err != nil || n != 0 {
+			t.Fatalf("idempotent add: n=%d err=%v", n, err)
+		}
+	})
+
+	t.Run("non-admin cannot remove", func(t *testing.T) {
+		v := seedRBACVault(t, "mallory@example.com", nil, []string{"boss@example.com"})
+		if err := v.RemoveOrgAdmin(ctx, "boss@example.com"); err == nil ||
+			!strings.Contains(err.Error(), "permission denied") {
+			t.Fatalf("non-admin remove should be denied, got %v", err)
+		}
+	})
+
+	t.Run("removing a non-admin errors", func(t *testing.T) {
+		v := seedRBACVault(t, "boss@example.com", nil, []string{"boss@example.com"})
+		if err := v.RemoveOrgAdmin(ctx, "ghost@example.com"); err == nil ||
+			!strings.Contains(err.Error(), "not an org-admin") {
+			t.Fatalf("removing non-admin should error, got %v", err)
+		}
+	})
+}

--- a/internal/vault/mgmt_rbac_test.go
+++ b/internal/vault/mgmt_rbac_test.go
@@ -55,20 +55,44 @@ func platformTeam() manifest.Team {
 }
 
 // TestScopeRBAC_NoOrgAdminsIsUngoverned: with no org-admins, anyone may set any
-// scope — including a team scope they don't admin. Governance is off until
-// org-admins exist.
+// non-team scope. (Team scope is the exception — always team-admin gated; see
+// TestScopeRBAC_TeamScopeAlwaysRequiresAdmin.)
 func TestScopeRBAC_NoOrgAdminsIsUngoverned(t *testing.T) {
 	v := seedRBACVault(t, "mallory@example.com", []manifest.Team{platformTeam()}, nil)
 	skipped, err := v.SetAssetInstallations(context.Background(), "my-skill", []InstallTarget{
-		{Kind: InstallKindTeam, Team: "platform"},
 		{Kind: InstallKindRepo, Repo: "github.com/acme/x"},
-		{Kind: InstallKindOrg},
 	}, false)
 	if err != nil {
 		t.Fatalf("SetAssetInstallations: %v", err)
 	}
 	if len(skipped) != 0 {
-		t.Fatalf("no org-admins = ungoverned; expected nothing skipped, got %+v", skipped)
+		t.Fatalf("ungoverned: a non-admin should set a repo scope, got %+v", skipped)
+	}
+}
+
+// TestScopeRBAC_TeamScopeAlwaysRequiresAdmin: locking a skill to a team requires
+// being an admin of that team even in an ungoverned vault — a random user can't
+// scope someone's skill to a team they don't run.
+func TestScopeRBAC_TeamScopeAlwaysRequiresAdmin(t *testing.T) {
+	ctx := context.Background()
+	team := []manifest.Team{platformTeam()} // alice admins platform; mallory is nobody
+
+	// Ungoverned (no org-admins): non-admin denied.
+	v := seedRBACVault(t, "mallory@example.com", team, nil)
+	skipped, err := v.SetAssetInstallations(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}}, true)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0].Reason, "admin of team") {
+		t.Fatalf("ungoverned non-admin should be denied a team scope, got %+v", skipped)
+	}
+
+	// Ungoverned: the team's admin is allowed.
+	v = seedRBACVault(t, "alice@example.com", team, nil)
+	if skipped, err := v.SetAssetInstallations(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}}, true); err != nil || len(skipped) != 0 {
+		t.Fatalf("ungoverned team admin should set the team scope: skipped=%+v err=%v", skipped, err)
 	}
 }
 
@@ -188,12 +212,14 @@ func TestScopeSetPermission_Matrix(t *testing.T) {
 		actor   mgmt.Actor
 		allowed bool
 	}{
-		// Ungoverned: anyone may set anything.
+		// Ungoverned: anyone may set any scope EXCEPT a team scope, which always
+		// requires being an admin of that team (teams own skills).
 		{"ungoverned/random/org", ungoverned, org, a("nobody@x.com"), true},
 		{"ungoverned/random/repo", ungoverned, repo, a("nobody@x.com"), true},
-		{"ungoverned/random/team-not-admin", ungoverned, teamPlatform, a("nobody@x.com"), true},
-		{"ungoverned/member/team", ungoverned, teamPlatform, a("carol@x.com"), true},
-		{"ungoverned/empty-identity/team", ungoverned, teamPlatform, a(""), true},
+		{"ungoverned/team-admin/team", ungoverned, teamPlatform, a("alice@x.com"), true},
+		{"ungoverned/random/team-denied", ungoverned, teamPlatform, a("nobody@x.com"), false},
+		{"ungoverned/member/team-denied", ungoverned, teamPlatform, a("carol@x.com"), false},
+		{"ungoverned/empty-identity/team-denied", ungoverned, teamPlatform, a(""), false},
 
 		// Governed: broad scopes require org-admin.
 		{"governed/org-admin/org", governed, org, a("boss@x.com"), true},

--- a/internal/vault/mgmt_rbac_test.go
+++ b/internal/vault/mgmt_rbac_test.go
@@ -291,18 +291,66 @@ func TestUninstallScopeRBAC(t *testing.T) {
 		return v
 	}
 
+	// A denied removal is reported per-target (no hard error), mirroring set.
 	v := seed("mallory@example.com")
-	if _, _, err := v.UninstallAssetTargets(ctx, "my-skill",
-		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}}); err == nil ||
-		!strings.Contains(err.Error(), "admin of team") {
-		t.Fatalf("non-admin removing a team scope should be denied, got %v", err)
+	removed, failures, err := v.UninstallAssetTargets(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}})
+	if err != nil {
+		t.Fatalf("a denied removal should not hard-error: %v", err)
+	}
+	if removed != 0 || len(failures) != 1 || !strings.Contains(failures[0], "admin of team") {
+		t.Fatalf("non-admin team-scope removal should be a reported failure: removed=%d failures=%+v", removed, failures)
 	}
 
 	v = seed("alice@example.com")
-	removed, _, err := v.UninstallAssetTargets(ctx, "my-skill",
+	removed, _, err = v.UninstallAssetTargets(ctx, "my-skill",
 		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}})
 	if err != nil || removed != 1 {
 		t.Fatalf("team admin should remove the team scope: removed=%d err=%v", removed, err)
+	}
+}
+
+// TestUninstallScopeRBAC_PartialBatch: a removal batch removes what the actor is
+// allowed to and reports the rest as failures, instead of aborting everything on
+// one denied target.
+func TestUninstallScopeRBAC_PartialBatch(t *testing.T) {
+	ctx := context.Background()
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "mallory@example.com")
+	runGit(t, dir, "config", "user.name", "Mallory")
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{{
+			Name: "my-skill", Version: "1", Type: asset.TypeSkill,
+			SourceHTTP: &manifest.SourceHTTP{URL: "https://example.com/s.zip"},
+			Scopes: []manifest.Scope{
+				{Kind: manifest.ScopeKindTeam, Team: "platform"},
+				{Kind: manifest.ScopeKindUser, User: "mallory@example.com"},
+			},
+		}},
+		Teams: []manifest.Team{platformTeam()}, // mallory is not a platform admin
+		Org:   &manifest.Org{Admins: []string{"boss@example.com"}},
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+
+	// Mallory may remove her own user scope but not the team scope.
+	removed, failures, err := v.UninstallAssetTargets(ctx, "my-skill", []InstallTarget{
+		{Kind: InstallKindTeam, Team: "platform"},
+		{Kind: InstallKindUser, User: "mallory@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("partial batch should not hard-error: %v", err)
+	}
+	if removed != 1 || len(failures) != 1 || !strings.Contains(failures[0], "admin of team") {
+		t.Fatalf("expected the user scope removed and the team scope reported: removed=%d failures=%+v", removed, failures)
 	}
 }
 

--- a/internal/vault/mgmt_rbac_test.go
+++ b/internal/vault/mgmt_rbac_test.go
@@ -6,9 +6,137 @@ import (
 	"testing"
 
 	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
 )
+
+// seedScopedRBACVault is seedRBACVault plus a starting scope set on my-skill, so
+// removal-gating (replace/global) can be exercised. Returns the vault and its
+// on-disk root for reading the resulting manifest back.
+func seedScopedRBACVault(t *testing.T, actorEmail string, scopes []manifest.Scope, teams []manifest.Team, orgAdmins []string) (*PathVault, string) {
+	t.Helper()
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", actorEmail)
+	runGit(t, dir, "config", "user.name", "Test User")
+
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{{
+			Name:       "my-skill",
+			Version:    "1.0.0",
+			Type:       asset.TypeSkill,
+			SourceHTTP: &manifest.SourceHTTP{URL: "https://example.com/my-skill.zip"},
+			Scopes:     scopes,
+		}},
+		Teams: teams,
+	}
+	if len(orgAdmins) > 0 {
+		m.Org = &manifest.Org{Admins: orgAdmins}
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	return v, dir
+}
+
+// assetScopes reads my-skill's current scopes from the vault's manifest.
+func assetScopes(t *testing.T, dir string) []manifest.Scope {
+	t.Helper()
+	m, ok, err := manifest.Load(dir)
+	if err != nil || !ok {
+		t.Fatalf("load manifest: ok=%v err=%v", ok, err)
+	}
+	a := m.FindAsset("my-skill")
+	if a == nil {
+		t.Fatal("my-skill missing from manifest")
+	}
+	return a.Scopes
+}
+
+// TestScopeRBAC_ReplaceKeepsProtectedTeam reproduces the reported bug: a
+// non-admin re-scoping a team-scoped skill to "just for me" (a wholesale
+// replace) must NOT silently drop the team scope. The team is preserved and
+// reported as skipped, while the user's own scope still applies.
+func TestScopeRBAC_ReplaceKeepsProtectedTeam(t *testing.T) {
+	ctx := context.Background()
+	startScopes := []manifest.Scope{{Kind: manifest.ScopeKindTeam, Team: "platform"}}
+
+	// mallory is not a platform admin (governed vault, she's no org-admin either).
+	v, dir := seedScopedRBACVault(t, "mallory@example.com", startScopes,
+		[]manifest.Team{platformTeam()}, []string{"boss@example.com"})
+
+	skipped, err := v.SetAssetInstallations(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindUser, User: "mallory@example.com"}}, false)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != 1 || skipped[0].Target.Kind != InstallKindTeam ||
+		!strings.Contains(skipped[0].Reason, "admin of team") {
+		t.Fatalf("expected the team scope reported as kept, got %+v", skipped)
+	}
+
+	scopes := assetScopes(t, dir)
+	if !scopeExistsOnAsset(scopes, manifest.Scope{Kind: manifest.ScopeKindTeam, Team: "platform"}) {
+		t.Fatalf("team scope must be preserved through a non-admin replace, got %+v", scopes)
+	}
+	if !scopeExistsOnAsset(scopes, manifest.Scope{Kind: manifest.ScopeKindUser, User: "mallory@example.com"}) {
+		t.Fatalf("the actor's own user scope should have applied, got %+v", scopes)
+	}
+}
+
+// TestScopeRBAC_ReplaceTeamAdminCanRemove is the allowed counterpart: the team's
+// admin re-scoping to "just for me" DOES remove the team scope.
+func TestScopeRBAC_ReplaceTeamAdminCanRemove(t *testing.T) {
+	ctx := context.Background()
+	startScopes := []manifest.Scope{{Kind: manifest.ScopeKindTeam, Team: "platform"}}
+
+	v, dir := seedScopedRBACVault(t, "alice@example.com", startScopes,
+		[]manifest.Team{platformTeam()}, []string{"boss@example.com"})
+
+	skipped, err := v.SetAssetInstallations(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindUser, User: "alice@example.com"}}, false)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("team admin should replace freely, got skipped=%+v", skipped)
+	}
+	scopes := assetScopes(t, dir)
+	if scopeExistsOnAsset(scopes, manifest.Scope{Kind: manifest.ScopeKindTeam, Team: "platform"}) {
+		t.Fatalf("team admin's replace should drop the team scope, got %+v", scopes)
+	}
+}
+
+// TestScopeRBAC_GlobalKeepsProtectedTeam covers the singular SetInstallations
+// ("go global") path: a non-admin can't strip a team scope by globalizing the
+// skill — the team survives.
+func TestScopeRBAC_GlobalKeepsProtectedTeam(t *testing.T) {
+	ctx := context.Background()
+	startScopes := []manifest.Scope{{Kind: manifest.ScopeKindTeam, Team: "platform"}}
+
+	v, dir := seedScopedRBACVault(t, "mallory@example.com", startScopes,
+		[]manifest.Team{platformTeam()}, []string{"boss@example.com"})
+
+	// "Global" sends an asset with an empty scope set through SetInstallations.
+	if err := v.SetInstallations(ctx, &lockfile.Asset{
+		Name: "my-skill", Version: "1.0.0", Type: asset.TypeSkill,
+		SourceHTTP: &lockfile.SourceHTTP{URL: "https://example.com/my-skill.zip"},
+	}, ""); err != nil {
+		t.Fatalf("SetInstallations: %v", err)
+	}
+
+	scopes := assetScopes(t, dir)
+	if !scopeExistsOnAsset(scopes, manifest.Scope{Kind: manifest.ScopeKindTeam, Team: "platform"}) {
+		t.Fatalf("non-admin going global must not strip the team scope, got %+v", scopes)
+	}
+}
 
 // seedRBACVault creates a path vault holding one asset, git-identified as
 // actorEmail, with the given teams and org-admins. The org-admins list is the

--- a/internal/vault/mgmt_rbac_test.go
+++ b/internal/vault/mgmt_rbac_test.go
@@ -1,0 +1,293 @@
+package vault
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/manifest"
+	"github.com/sleuth-io/sx/internal/mgmt"
+)
+
+// seedRBACVault creates a path vault holding one asset, git-identified as
+// actorEmail, with the given teams and org-admins. The org-admins list is the
+// single on/off switch for scope governance (see docs/rbac.md), so tests set it
+// to exercise the gate.
+func seedRBACVault(t *testing.T, actorEmail string, teams []manifest.Team, orgAdmins []string) *PathVault {
+	t.Helper()
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", actorEmail)
+	runGit(t, dir, "config", "user.name", "Test User")
+
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{{
+			Name:       "my-skill",
+			Version:    "1.0.0",
+			Type:       asset.TypeSkill,
+			SourceHTTP: &manifest.SourceHTTP{URL: "https://example.com/my-skill.zip"},
+		}},
+		Teams: teams,
+	}
+	if len(orgAdmins) > 0 {
+		m.Org = &manifest.Org{Admins: orgAdmins}
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	return v
+}
+
+// platformTeam is admined (and membered) by alice; mallory is in neither.
+func platformTeam() manifest.Team {
+	return manifest.Team{
+		Name:    "platform",
+		Members: []string{"alice@example.com"},
+		Admins:  []string{"alice@example.com"},
+	}
+}
+
+// TestScopeRBAC_NoOrgAdminsIsUngoverned: with no org-admins, anyone may set any
+// scope — including a team scope they don't admin. Governance is off until
+// org-admins exist.
+func TestScopeRBAC_NoOrgAdminsIsUngoverned(t *testing.T) {
+	v := seedRBACVault(t, "mallory@example.com", []manifest.Team{platformTeam()}, nil)
+	skipped, err := v.SetAssetInstallations(context.Background(), "my-skill", []InstallTarget{
+		{Kind: InstallKindTeam, Team: "platform"},
+		{Kind: InstallKindRepo, Repo: "github.com/acme/x"},
+		{Kind: InstallKindOrg},
+	}, false)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("no org-admins = ungoverned; expected nothing skipped, got %+v", skipped)
+	}
+}
+
+// TestScopeRBAC_TeamScopeRequiresThatTeamsAdmin: once governed, a team scope is
+// allowed for an admin of that team and denied for everyone else.
+func TestScopeRBAC_TeamScopeRequiresThatTeamsAdmin(t *testing.T) {
+	ctx := context.Background()
+	team := []manifest.Team{platformTeam()}
+	admins := []string{"orgboss@example.com"}
+
+	// Admin of platform → allowed (even though not an org-admin).
+	v := seedRBACVault(t, "alice@example.com", team, admins)
+	if skipped, err := v.SetAssetInstallations(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}}, true); err != nil || len(skipped) != 0 {
+		t.Fatalf("team admin should set team scope: skipped=%+v err=%v", skipped, err)
+	}
+
+	// Non-admin, non-org-admin (mallory) → denied.
+	v = seedRBACVault(t, "mallory@example.com", team, admins)
+	skipped, err := v.SetAssetInstallations(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}}, true)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0].Reason, "admin of team") {
+		t.Fatalf("expected team-admin denial, got %+v", skipped)
+	}
+}
+
+// TestScopeRBAC_SelfUserAlwaysAllowed: any actor may scope an asset to their own
+// account, even under governance with no admin rights.
+func TestScopeRBAC_SelfUserAlwaysAllowed(t *testing.T) {
+	v := seedRBACVault(t, "mallory@example.com", []manifest.Team{platformTeam()}, []string{"orgboss@example.com"})
+	skipped, err := v.SetAssetInstallations(context.Background(), "my-skill",
+		[]InstallTarget{{Kind: InstallKindUser, User: "mallory@example.com"}}, true)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("self user scope should always be allowed, got %+v", skipped)
+	}
+}
+
+// TestScopeRBAC_BroadScopesRequireOrgAdmin: org/repo/path scopes require being an
+// org-admin — denied for a mere team admin, allowed for an org-admin.
+func TestScopeRBAC_BroadScopesRequireOrgAdmin(t *testing.T) {
+	ctx := context.Background()
+	team := []manifest.Team{platformTeam()}
+	admins := []string{"orgboss@example.com"}
+	broad := []InstallTarget{
+		{Kind: InstallKindRepo, Repo: "github.com/acme/x"},
+		{Kind: InstallKindPath, Repo: "github.com/acme/y", Paths: []string{"src"}},
+	}
+
+	// alice admins a team but is not an org-admin → every broad target denied.
+	v := seedRBACVault(t, "alice@example.com", team, admins)
+	skipped, err := v.SetAssetInstallations(ctx, "my-skill", broad, true)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != len(broad) {
+		t.Fatalf("team admin should be denied broad scopes, got %+v", skipped)
+	}
+	for _, s := range skipped {
+		if !strings.Contains(s.Reason, "org-admin") {
+			t.Errorf("expected org-admin reason, got %q", s.Reason)
+		}
+	}
+
+	// The org-admin → allowed.
+	v = seedRBACVault(t, "orgboss@example.com", team, admins)
+	if skipped, err := v.SetAssetInstallations(ctx, "my-skill", broad, true); err != nil || len(skipped) != 0 {
+		t.Fatalf("org-admin should set broad scopes: skipped=%+v err=%v", skipped, err)
+	}
+}
+
+// TestScopeRBAC_OrgWideGated: org-wide is exclusive and bypasses the per-target
+// resolve loop, so confirm it is gated too — denied for a non-org-admin.
+func TestScopeRBAC_OrgWideGated(t *testing.T) {
+	v := seedRBACVault(t, "alice@example.com", []manifest.Team{platformTeam()}, []string{"orgboss@example.com"})
+	skipped, err := v.SetAssetInstallations(context.Background(), "my-skill",
+		[]InstallTarget{{Kind: InstallKindOrg}}, false)
+	if err != nil {
+		t.Fatalf("SetAssetInstallations: %v", err)
+	}
+	if len(skipped) != 1 || skipped[0].Target.Kind != InstallKindOrg ||
+		!strings.Contains(skipped[0].Reason, "org-admin") {
+		t.Fatalf("expected org-wide denial for non-org-admin, got %+v", skipped)
+	}
+}
+
+// TestScopeSetPermission_Matrix exhaustively exercises the scope gate
+// (scopeSetPermissionReason) across governance states, actor roles, and target
+// kinds — the file-backed vault's full permission matrix.
+func TestScopeSetPermission_Matrix(t *testing.T) {
+	platform := manifest.Team{Name: "platform", Members: []string{"alice@x.com", "carol@x.com"}, Admins: []string{"alice@x.com"}}
+	backend := manifest.Team{Name: "backend", Members: []string{"dave@x.com"}, Admins: []string{"dave@x.com"}}
+	teams := []manifest.Team{platform, backend}
+
+	ungoverned := &manifest.Manifest{Teams: teams}
+	governed := &manifest.Manifest{Teams: teams, Org: &manifest.Org{Admins: []string{"boss@x.com"}}}
+
+	org := InstallTarget{Kind: InstallKindOrg}
+	repo := InstallTarget{Kind: InstallKindRepo, Repo: "github.com/acme/r"}
+	path := InstallTarget{Kind: InstallKindPath, Repo: "github.com/acme/r", Paths: []string{"svc"}}
+	botT := InstallTarget{Kind: InstallKindBot, Bot: "ci"}
+	teamPlatform := InstallTarget{Kind: InstallKindTeam, Team: "platform"}
+	teamBackend := InstallTarget{Kind: InstallKindTeam, Team: "backend"}
+	teamGhost := InstallTarget{Kind: InstallKindTeam, Team: "ghost"}
+	user := func(e string) InstallTarget { return InstallTarget{Kind: InstallKindUser, User: e} }
+	a := func(e string) mgmt.Actor { return mgmt.Actor{Email: e} }
+
+	cases := []struct {
+		name    string
+		m       *manifest.Manifest
+		target  InstallTarget
+		actor   mgmt.Actor
+		allowed bool
+	}{
+		// Ungoverned: anyone may set anything.
+		{"ungoverned/random/org", ungoverned, org, a("nobody@x.com"), true},
+		{"ungoverned/random/repo", ungoverned, repo, a("nobody@x.com"), true},
+		{"ungoverned/random/team-not-admin", ungoverned, teamPlatform, a("nobody@x.com"), true},
+		{"ungoverned/member/team", ungoverned, teamPlatform, a("carol@x.com"), true},
+		{"ungoverned/empty-identity/team", ungoverned, teamPlatform, a(""), true},
+
+		// Governed: broad scopes require org-admin.
+		{"governed/org-admin/org", governed, org, a("boss@x.com"), true},
+		{"governed/org-admin/repo", governed, repo, a("boss@x.com"), true},
+		{"governed/org-admin/path", governed, path, a("boss@x.com"), true},
+		{"governed/org-admin/bot", governed, botT, a("boss@x.com"), true},
+		{"governed/team-admin/repo-denied", governed, repo, a("alice@x.com"), false},
+		{"governed/team-admin/org-denied", governed, org, a("alice@x.com"), false},
+		{"governed/member/path-denied", governed, path, a("carol@x.com"), false},
+		{"governed/random/bot-denied", governed, botT, a("nobody@x.com"), false},
+		{"governed/empty-identity/repo-denied", governed, repo, a(""), false},
+
+		// Governed: team scope requires admin of THAT team (or org-admin).
+		{"governed/platform-admin/team-platform", governed, teamPlatform, a("alice@x.com"), true},
+		{"governed/org-admin/team-platform", governed, teamPlatform, a("boss@x.com"), true},
+		{"governed/platform-member/team-platform-denied", governed, teamPlatform, a("carol@x.com"), false},
+		{"governed/other-team-admin/team-platform-denied", governed, teamPlatform, a("dave@x.com"), false},
+		{"governed/random/team-platform-denied", governed, teamPlatform, a("nobody@x.com"), false},
+		{"governed/empty-identity/team-platform-denied", governed, teamPlatform, a(""), false},
+		{"governed/backend-admin/team-backend", governed, teamBackend, a("dave@x.com"), true},
+		{"governed/platform-admin/team-backend-denied", governed, teamBackend, a("alice@x.com"), false},
+		{"governed/team-admin/ghost-team-denied", governed, teamGhost, a("alice@x.com"), false},
+		{"governed/org-admin/ghost-team-allowed-by-role", governed, teamGhost, a("boss@x.com"), true},
+
+		// Governed: user scope is self-only; org-admins bypass.
+		{"governed/self-user", governed, user("carol@x.com"), a("carol@x.com"), true},
+		{"governed/self-user/random", governed, user("nobody@x.com"), a("nobody@x.com"), true},
+		{"governed/other-user-denied", governed, user("someone@x.com"), a("carol@x.com"), false},
+		{"governed/org-admin/other-user-allowed", governed, user("someone@x.com"), a("boss@x.com"), true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			reason := scopeSetPermissionReason(c.m, c.target, c.actor)
+			if (reason == "") != c.allowed {
+				t.Fatalf("allowed=%v want=%v (reason=%q)", reason == "", c.allowed, reason)
+			}
+		})
+	}
+}
+
+// TestUninstallScopeRBAC: removing a scope needs the same authority as setting
+// it — a non-admin can't remove a team scope, the team's admin can.
+func TestUninstallScopeRBAC(t *testing.T) {
+	ctx := context.Background()
+	seed := func(actorEmail string) *PathVault {
+		mgmt.ResetActorCache()
+		dir := t.TempDir()
+		runGit(t, dir, "init")
+		runGit(t, dir, "config", "user.email", actorEmail)
+		runGit(t, dir, "config", "user.name", "U")
+		m := &manifest.Manifest{
+			SchemaVersion: manifest.CurrentSchemaVersion,
+			Assets: []manifest.Asset{{
+				Name: "my-skill", Version: "1", Type: asset.TypeSkill,
+				SourceHTTP: &manifest.SourceHTTP{URL: "https://example.com/s.zip"},
+				Scopes:     []manifest.Scope{{Kind: manifest.ScopeKindTeam, Team: "platform"}},
+			}},
+			Teams: []manifest.Team{platformTeam()},
+			Org:   &manifest.Org{Admins: []string{"boss@example.com"}},
+		}
+		if err := manifest.Save(dir, m); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		v, err := NewPathVault("file://" + dir)
+		if err != nil {
+			t.Fatalf("NewPathVault: %v", err)
+		}
+		return v
+	}
+
+	v := seed("mallory@example.com")
+	if _, _, err := v.UninstallAssetTargets(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}}); err == nil ||
+		!strings.Contains(err.Error(), "admin of team") {
+		t.Fatalf("non-admin removing a team scope should be denied, got %v", err)
+	}
+
+	v = seed("alice@example.com")
+	removed, _, err := v.UninstallAssetTargets(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindTeam, Team: "platform"}})
+	if err != nil || removed != 1 {
+		t.Fatalf("team admin should remove the team scope: removed=%d err=%v", removed, err)
+	}
+}
+
+// TestScopeRBAC_TrustedWriteBypassesGate: a trusted bulk write (vault copy)
+// skips the gate even for a non-admin in a governed vault.
+func TestScopeRBAC_TrustedWriteBypassesGate(t *testing.T) {
+	v := seedRBACVault(t, "mallory@example.com", []manifest.Team{platformTeam()}, []string{"boss@example.com"})
+	ctx := ContextWithTrustedScopeWrite(context.Background())
+	skipped, err := v.SetAssetInstallations(ctx, "my-skill",
+		[]InstallTarget{{Kind: InstallKindRepo, Repo: "github.com/acme/x"}}, true)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("trusted write should bypass the gate: skipped=%+v err=%v", skipped, err)
+	}
+}

--- a/internal/vault/pathrepo.go
+++ b/internal/vault/pathrepo.go
@@ -224,10 +224,16 @@ func (p *PathVault) ManifestPath() string {
 	return filepath.Join(p.repoPath, manifest.FileName)
 }
 
-// SetInstallations upserts an asset into the vault's manifest. Scopes on
-// the incoming asset are preserved verbatim.
+// SetInstallations upserts an asset into the vault's manifest. The incoming
+// asset's scopes replace the stored set, except for existing scopes the actor
+// isn't allowed to remove (e.g. a team they don't admin), which are carried
+// through — see commonSetInstallations and docs/rbac.md.
 func (p *PathVault) SetInstallations(ctx context.Context, asset *lockfile.Asset, scopeEntity string) error {
-	return upsertAssetInManifest(p.repoPath, asset)
+	actor, err := p.CurrentActor(ctx)
+	if err != nil {
+		return err
+	}
+	return commonSetInstallations(p.repoPath, actor, asset)
 }
 
 // InheritInstallations copies scopes from any existing entry of this

--- a/internal/vault/pathrepo_mgmt.go
+++ b/internal/vault/pathrepo_mgmt.go
@@ -223,7 +223,7 @@ func (p *PathVault) ClearAssetInstallations(ctx context.Context, assetName strin
 // the unified scope flow works against path vaults, not just the Sleuth vault.
 func (p *PathVault) SetAssetInstallations(ctx context.Context, assetName string, targets []InstallTarget, appendMode bool) (skipped []SkippedTarget, err error) {
 	err = p.withLock(ctx, func(actor mgmt.Actor) error {
-		skipped, err = commonSetAssetInstallations(p.repoPath, actor, assetName, targets, appendMode)
+		skipped, err = commonSetAssetInstallations(ctx, p.repoPath, actor, assetName, targets, appendMode)
 		return err
 	})
 	return skipped, err
@@ -234,7 +234,7 @@ func (p *PathVault) SetAssetInstallations(ctx context.Context, assetName string,
 // remove individual scopes from a path vault.
 func (p *PathVault) UninstallAssetTargets(ctx context.Context, assetName string, targets []InstallTarget) (removed int, failures []string, err error) {
 	err = p.withLock(ctx, func(actor mgmt.Actor) error {
-		removed, failures, err = commonUninstallAssetTargets(p.repoPath, actor, assetName, targets)
+		removed, failures, err = commonUninstallAssetTargets(ctx, p.repoPath, actor, assetName, targets)
 		return err
 	})
 	return removed, failures, err

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -334,7 +334,10 @@ func copyAssetScopes(ctx context.Context, dst scopeInstaller, name string, scope
 	// best-effort: it applies all resolvable targets atomically and reports the
 	// rest as unresolved (so we never fall back to clobbering per-target calls).
 	if bulk, ok := dst.(bulkInstaller); ok {
-		skipped, err := bulk.SetAssetInstallations(ctx, name, targets, false)
+		// A copy replicates the source's existing scopes verbatim, so it bypasses
+		// the destination's file-backed RBAC gate — the operator needn't be a team
+		// admin there to migrate scopes that were already valid in the source.
+		skipped, err := bulk.SetAssetInstallations(vault.ContextWithTrustedScopeWrite(ctx), name, targets, false)
 		if err != nil {
 			// The set failed, so the asset still carries any auto-applied install
 			// (org-wide on skills.new). Clear it so a failed scope-set doesn't


### PR DESCRIPTION

I modify a skill, I try to push it to vault, but I can't, because I'm not a member of the team `frontend`. 
<img width="1297" height="593" alt="image" src="https://github.com/user-attachments/assets/c6a9663a-3c1f-4eb4-9225-bdbee99abd8d" />

The skill is scoped to my team, I modify it and push it successfully.
<img width="636" height="867" alt="image" src="https://github.com/user-attachments/assets/f2b73888-d9d0-4e67-8182-671a95d375e3" />

A remove myself from the team, while the team scope stays, I not don't have edit persmissions
<img width="1385" height="308" alt="image" src="https://github.com/user-attachments/assets/45b2be61-464d-4ebb-b2df-3e4d2b7154ae" />

Creating an org-admin:
<img width="884" height="104" alt="image" src="https://github.com/user-attachments/assets/7b3f1c54-59e8-40bf-931d-7a444b28b04e" />
Now I can edit the skill again:
<img width="801" height="533" alt="image" src="https://github.com/user-attachments/assets/0772548a-535f-42f9-af91-eb927d99a252" />


