### PR TITLE
SK-552 Add Codex sub-agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ See [docs/library.md](docs/library.md) for the full API guide.
 |-------------------------|----------------|-----------------------------------------------------------|
 | Claude Code             | ✅ Supported   | Full support for all asset types                          |
 | Cline                   | ✅ Supported   | Skills, rules, workflows as commands, MCP servers, hooks  |
-| Codex                   | ✅ Supported   | Skills, commands, MCP servers                             |
+| Codex                   | ✅ Supported   | Skills, commands, agents, MCP servers                     |
 | Cursor                  | ✅ Supported   | Skills, rules, commands, MCP servers, hooks               |
 | GitHub Copilot          | ✅ Supported   | Skills, rules, commands, agents, MCP servers, local hooks |
 | Gemini (CLI/VS Code)    | ✅ Supported   | Skills, rules, commands, MCP servers, hooks               |

--- a/internal/assets/detectors/single_file.go
+++ b/internal/assets/detectors/single_file.go
@@ -11,14 +11,9 @@ import (
 func DetectAssetTypeFromPath(path string, content []byte) *asset.Type {
 	lower := strings.ToLower(path)
 
-	if strings.HasSuffix(lower, ".toml") {
-		if strings.Contains(lower, "/agents/") || looksLikeCodexAgentTOML(content) {
-			return &asset.TypeAgent
-		}
-		return nil
-	}
-
-	// Only handle .md files after TOML-specific detection.
+	// Generic single-file detection only handles markdown prompt files.
+	// Client-specific formats, such as Codex agent TOML, are claimed by
+	// the owning client's RuleCapabilities.
 	if !strings.HasSuffix(lower, ".md") {
 		return nil
 	}
@@ -44,17 +39,6 @@ func DetectAssetTypeFromPath(path string, content []byte) *asset.Type {
 
 	// Default .md files to command
 	return &asset.TypeCommand
-}
-
-func looksLikeCodexAgentTOML(content []byte) bool {
-	if content == nil {
-		return false
-	}
-
-	contentStr := string(content)
-	return strings.Contains(contentStr, "developer_instructions") &&
-		strings.Contains(contentStr, "description") &&
-		strings.Contains(contentStr, "name")
 }
 
 // looksLikeAgent checks if content has YAML frontmatter with agent-specific fields

--- a/internal/assets/detectors/single_file.go
+++ b/internal/assets/detectors/single_file.go
@@ -11,7 +11,14 @@ import (
 func DetectAssetTypeFromPath(path string, content []byte) *asset.Type {
 	lower := strings.ToLower(path)
 
-	// Only handle .md files
+	if strings.HasSuffix(lower, ".toml") {
+		if strings.Contains(lower, "/agents/") || looksLikeCodexAgentTOML(content) {
+			return &asset.TypeAgent
+		}
+		return nil
+	}
+
+	// Only handle .md files after TOML-specific detection.
 	if !strings.HasSuffix(lower, ".md") {
 		return nil
 	}
@@ -37,6 +44,17 @@ func DetectAssetTypeFromPath(path string, content []byte) *asset.Type {
 
 	// Default .md files to command
 	return &asset.TypeCommand
+}
+
+func looksLikeCodexAgentTOML(content []byte) bool {
+	if content == nil {
+		return false
+	}
+
+	contentStr := string(content)
+	return strings.Contains(contentStr, "developer_instructions") &&
+		strings.Contains(contentStr, "description") &&
+		strings.Contains(contentStr, "name")
 }
 
 // looksLikeAgent checks if content has YAML frontmatter with agent-specific fields

--- a/internal/clients/codex/client.go
+++ b/internal/clients/codex/client.go
@@ -30,6 +30,7 @@ func NewClient() *Client {
 			[]asset.Type{
 				asset.TypeSkill,
 				asset.TypeCommand,
+				asset.TypeAgent,
 				asset.TypeMCP,
 			},
 		),
@@ -98,6 +99,9 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 		case asset.TypeCommand:
 			handler := handlers.NewCommandHandler(bundle.Metadata)
 			installErr = handler.Install(ctx, bundle.ZipData, targetBase)
+		case asset.TypeAgent:
+			handler := handlers.NewAgentHandler(bundle.Metadata)
+			installErr = handler.Install(ctx, bundle.ZipData, targetBase)
 		case asset.TypeMCP:
 			handler := handlers.NewMCPHandler(bundle.Metadata)
 			installErr = handler.Install(ctx, bundle.ZipData, targetBase)
@@ -156,6 +160,9 @@ func (c *Client) UninstallAssets(ctx context.Context, req clients.UninstallReque
 			uninstallErr = handler.Remove(ctx, targetBase)
 		case asset.TypeCommand:
 			handler := handlers.NewCommandHandler(meta)
+			uninstallErr = handler.Remove(ctx, targetBase)
+		case asset.TypeAgent:
+			handler := handlers.NewAgentHandler(meta)
 			uninstallErr = handler.Remove(ctx, targetBase)
 		case asset.TypeMCP:
 			handler := handlers.NewMCPHandler(meta)
@@ -475,6 +482,8 @@ func (c *Client) GetAssetPath(ctx context.Context, name string, assetType asset.
 		return filepath.Join(targetBase, handlers.DirSkills, name), nil
 	case asset.TypeCommand:
 		return filepath.Join(targetBase, handlers.DirCommands, name+".md"), nil
+	case asset.TypeAgent:
+		return filepath.Join(targetBase, handlers.DirAgents, name+".toml"), nil
 	case asset.TypeMCP:
 		return filepath.Join(targetBase, handlers.DirMCPServers, name), nil
 	default:

--- a/internal/clients/codex/client.go
+++ b/internal/clients/codex/client.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/bootstrap"
@@ -100,6 +101,12 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			handler := handlers.NewCommandHandler(bundle.Metadata)
 			installErr = handler.Install(ctx, bundle.ZipData, targetBase)
 		case asset.TypeAgent:
+			if !isCodexAgentMetadata(bundle.Metadata) {
+				result.Status = clients.StatusSkipped
+				result.Message = "Skipped non-Codex agent format"
+				resp.Results = append(resp.Results, result)
+				continue
+			}
 			handler := handlers.NewAgentHandler(bundle.Metadata)
 			installErr = handler.Install(ctx, bundle.ZipData, targetBase)
 		case asset.TypeMCP:
@@ -163,6 +170,19 @@ func (c *Client) UninstallAssets(ctx context.Context, req clients.UninstallReque
 			uninstallErr = handler.Remove(ctx, targetBase)
 		case asset.TypeAgent:
 			handler := handlers.NewAgentHandler(meta)
+			state, err := handler.InstalledCodexAgentState(targetBase)
+			if err != nil {
+				result.Status = clients.StatusFailed
+				result.Error = err
+				resp.Results = append(resp.Results, result)
+				continue
+			}
+			if state == "invalid" {
+				result.Status = clients.StatusSkipped
+				result.Message = "Skipped non-Codex agent format"
+				resp.Results = append(resp.Results, result)
+				continue
+			}
 			uninstallErr = handler.Remove(ctx, targetBase)
 		case asset.TypeMCP:
 			handler := handlers.NewMCPHandler(meta)
@@ -186,6 +206,13 @@ func (c *Client) UninstallAssets(ctx context.Context, req clients.UninstallReque
 	}
 
 	return resp, nil
+}
+
+func isCodexAgentMetadata(meta *metadata.Metadata) bool {
+	if meta == nil || meta.Agent == nil {
+		return false
+	}
+	return strings.EqualFold(filepath.Ext(meta.Agent.PromptFile), ".toml")
 }
 
 // determineTargetBase returns the installation directory based on scope and asset type.

--- a/internal/clients/codex/client_test.go
+++ b/internal/clients/codex/client_test.go
@@ -1,6 +1,8 @@
 package codex
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -10,6 +12,8 @@ import (
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/bootstrap"
 	"github.com/sleuth-io/sx/internal/clients"
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/metadata"
 )
 
 func TestCodexClient_ID(t *testing.T) {
@@ -332,8 +336,194 @@ func TestCodexClient_RuleCapabilities(t *testing.T) {
 	client := NewClient()
 
 	caps := client.RuleCapabilities()
-	if caps != nil {
-		t.Error("RuleCapabilities should be nil - Codex doesn't support rules")
+	if caps == nil {
+		t.Fatal("RuleCapabilities should be non-nil for Codex asset detection")
+	}
+	if caps.ClientName != clients.ClientIDCodex {
+		t.Errorf("ClientName = %q, want %q", caps.ClientName, clients.ClientIDCodex)
+	}
+	if caps.RulesDirectory != "" {
+		t.Errorf("RulesDirectory = %q, want empty", caps.RulesDirectory)
+	}
+	if caps.MatchesPath != nil {
+		t.Error("MatchesPath should be nil - Codex doesn't support rules")
+	}
+	if caps.DetectAssetType == nil {
+		t.Fatal("DetectAssetType should be set")
+	}
+	if got := caps.DetectAssetType("/home/user/.codex/agents/security-reviewer.toml", nil); got == nil || *got != asset.TypeAgent {
+		t.Fatalf("DetectAssetType(.codex/agents/*.toml) = %v, want agent", got)
+	}
+	if got := caps.DetectAssetType("/home/user/agents/security-reviewer.toml", nil); got != nil {
+		t.Fatalf("DetectAssetType(generic agents TOML) = %v, want nil", got)
+	}
+}
+
+func TestCodexClient_InstallAssets_SkipsNonCodexAgentFormats(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	client := NewClient()
+	resp, err := client.InstallAssets(context.Background(), clients.InstallRequest{
+		Scope: &clients.InstallScope{Type: clients.ScopeGlobal},
+		Assets: []*clients.AssetBundle{
+			{
+				Asset: &lockfile.Asset{Name: "markdown-reviewer", Type: asset.TypeAgent},
+				Metadata: &metadata.Metadata{
+					Asset: metadata.Asset{Name: "markdown-reviewer", Type: asset.TypeAgent},
+					Agent: &metadata.AgentConfig{PromptFile: "markdown-reviewer.md"},
+				},
+				ZipData: []byte("not read because install is skipped"),
+			},
+			{
+				Asset: &lockfile.Asset{Name: "missing-agent-config", Type: asset.TypeAgent},
+				Metadata: &metadata.Metadata{
+					Asset: metadata.Asset{Name: "missing-agent-config", Type: asset.TypeAgent},
+				},
+				ZipData: []byte("not read because install is skipped"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InstallAssets returned error: %v", err)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(resp.Results))
+	}
+	for _, result := range resp.Results {
+		if result.Status != clients.StatusSkipped {
+			t.Fatalf("status for %s = %v, want skipped", result.AssetName, result.Status)
+		}
+	}
+
+	for _, name := range []string{"markdown-reviewer.toml", "missing-agent-config.toml"} {
+		path := filepath.Join(tempDir, ".codex", "agents", name)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be absent, stat err = %v", path, err)
+		}
+	}
+}
+
+func TestCodexClient_InstallAssets_InstallsCodexAgentTOML(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	agentTOML := `name = "security_reviewer"
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+`
+	client := NewClient()
+	resp, err := client.InstallAssets(context.Background(), clients.InstallRequest{
+		Scope: &clients.InstallScope{Type: clients.ScopeGlobal},
+		Assets: []*clients.AssetBundle{
+			{
+				Asset: &lockfile.Asset{Name: "security_reviewer", Type: asset.TypeAgent},
+				Metadata: &metadata.Metadata{
+					Asset: metadata.Asset{Name: "security_reviewer", Type: asset.TypeAgent},
+					Agent: &metadata.AgentConfig{PromptFile: "security_reviewer.toml"},
+				},
+				ZipData: createZip(t, map[string]string{
+					"metadata.toml": `[asset]
+name = "security_reviewer"
+version = "1.0.0"
+type = "agent"
+
+[agent]
+prompt-file = "security_reviewer.toml"
+`,
+					"security_reviewer.toml": agentTOML,
+				}),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InstallAssets returned error: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(resp.Results))
+	}
+	if resp.Results[0].Status != clients.StatusSuccess {
+		t.Fatalf("status = %v, want success: %v", resp.Results[0].Status, resp.Results[0].Error)
+	}
+
+	installedPath := filepath.Join(tempDir, ".codex", "agents", "security_reviewer.toml")
+	got, err := os.ReadFile(installedPath)
+	if err != nil {
+		t.Fatalf("failed to read installed agent: %v", err)
+	}
+	if string(got) != agentTOML {
+		t.Fatalf("installed TOML = %q, want %q", string(got), agentTOML)
+	}
+}
+
+func TestCodexClient_UninstallAssets_SkipsNonCodexAgentFile(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	agentPath := filepath.Join(tempDir, ".codex", "agents", "markdown-reviewer.toml")
+	if err := os.MkdirAll(filepath.Dir(agentPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("# Markdown agent\n\nThis was not a Codex agent TOML file.")
+	if err := os.WriteFile(agentPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient()
+	resp, err := client.UninstallAssets(context.Background(), clients.UninstallRequest{
+		Scope:  &clients.InstallScope{Type: clients.ScopeGlobal},
+		Assets: []asset.Asset{{Name: "markdown-reviewer", Type: asset.TypeAgent}},
+	})
+	if err != nil {
+		t.Fatalf("UninstallAssets returned error: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(resp.Results))
+	}
+	if resp.Results[0].Status != clients.StatusSkipped {
+		t.Fatalf("status = %v, want skipped", resp.Results[0].Status)
+	}
+
+	got, err := os.ReadFile(agentPath)
+	if err != nil {
+		t.Fatalf("failed to read skipped file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("file was modified during skipped uninstall")
+	}
+}
+
+func TestCodexClient_UninstallAssets_RemovesCodexAgentTOML(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	agentPath := filepath.Join(tempDir, ".codex", "agents", "security_reviewer.toml")
+	if err := os.MkdirAll(filepath.Dir(agentPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agentPath, []byte(`name = "security_reviewer"
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient()
+	resp, err := client.UninstallAssets(context.Background(), clients.UninstallRequest{
+		Scope:  &clients.InstallScope{Type: clients.ScopeGlobal},
+		Assets: []asset.Asset{{Name: "security_reviewer", Type: asset.TypeAgent}},
+	})
+	if err != nil {
+		t.Fatalf("UninstallAssets returned error: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(resp.Results))
+	}
+	if resp.Results[0].Status != clients.StatusSuccess {
+		t.Fatalf("status = %v, want success", resp.Results[0].Status)
+	}
+	if _, err := os.Stat(agentPath); !os.IsNotExist(err) {
+		t.Fatalf("agent file still exists after uninstall, stat err = %v", err)
 	}
 }
 
@@ -419,4 +609,24 @@ command = "/usr/bin/test"
 	if strings.Contains(string(content), "test-server") {
 		t.Error("test-server should be removed from config.toml")
 	}
+}
+
+func createZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	writer := zip.NewWriter(buf)
+	for name, content := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %q: %v", name, err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatalf("failed to write zip entry %q: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	return buf.Bytes()
 }

--- a/internal/clients/codex/client_test.go
+++ b/internal/clients/codex/client_test.go
@@ -36,7 +36,7 @@ func TestCodexClient_SupportsAssetType(t *testing.T) {
 		{asset.TypeSkill, true},
 		{asset.TypeCommand, true},
 		{asset.TypeMCP, true},
-		{asset.TypeAgent, false},
+		{asset.TypeAgent, true},
 		{asset.TypeRule, false},
 		{asset.TypeHook, false},
 		{asset.TypeClaudeCodePlugin, false},
@@ -136,6 +136,15 @@ func TestCodexClient_DetermineTargetBase_RepoScope(t *testing.T) {
 	expected = filepath.Join(repoRoot, ".codex")
 	if target != expected {
 		t.Errorf("Repo command target = %q, want %q", target, expected)
+	}
+
+	// For agents - uses .codex/
+	target, err = client.determineTargetBase(scope, asset.TypeAgent)
+	if err != nil {
+		t.Fatalf("determineTargetBase error: %v", err)
+	}
+	if target != expected {
+		t.Errorf("Repo agent target = %q, want %q", target, expected)
 	}
 }
 
@@ -277,6 +286,24 @@ func TestCodexClient_GetAssetPath_Command(t *testing.T) {
 	}
 }
 
+func TestCodexClient_GetAssetPath_Agent(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	client := NewClient()
+	scope := &clients.InstallScope{Type: clients.ScopeGlobal}
+
+	path, err := client.GetAssetPath(context.Background(), "security_reviewer", asset.TypeAgent, scope)
+	if err != nil {
+		t.Fatalf("GetAssetPath error: %v", err)
+	}
+
+	expected := filepath.Join(tempDir, ".codex", "agents", "security_reviewer.toml")
+	if path != expected {
+		t.Errorf("GetAssetPath(agent) = %q, want %q", path, expected)
+	}
+}
+
 func TestCodexClient_GetAssetPath_UnsupportedType(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)
@@ -284,7 +311,7 @@ func TestCodexClient_GetAssetPath_UnsupportedType(t *testing.T) {
 	client := NewClient()
 	scope := &clients.InstallScope{Type: clients.ScopeGlobal}
 
-	_, err := client.GetAssetPath(context.Background(), "my-agent", asset.TypeAgent, scope)
+	_, err := client.GetAssetPath(context.Background(), "my-rule", asset.TypeRule, scope)
 	if err == nil {
 		t.Error("GetAssetPath should error for unsupported type")
 	}

--- a/internal/clients/codex/handlers/agent.go
+++ b/internal/clients/codex/handlers/agent.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/metadata"
+	"github.com/sleuth-io/sx/internal/utils"
+)
+
+// AgentHandler installs Codex custom agent definitions as standalone TOML files.
+type AgentHandler struct {
+	metadata *metadata.Metadata
+}
+
+// NewAgentHandler creates a new Codex agent handler.
+func NewAgentHandler(meta *metadata.Metadata) *AgentHandler {
+	return &AgentHandler{metadata: meta}
+}
+
+// Install writes the agent TOML file to {targetBase}/agents/{name}.toml.
+func (h *AgentHandler) Install(ctx context.Context, zipData []byte, targetBase string) error {
+	if err := metadata.ValidateZip(zipData, &asset.TypeAgent); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	promptFile := h.getPromptFile()
+	if promptFile == "" {
+		return errors.New("no agent TOML file specified in metadata")
+	}
+
+	content, err := utils.ReadZipFile(zipData, promptFile)
+	if err != nil {
+		return fmt.Errorf("failed to read agent TOML file: %w", err)
+	}
+
+	agentsDir := filepath.Join(targetBase, DirAgents)
+	if err := utils.EnsureDir(agentsDir); err != nil {
+		return fmt.Errorf("failed to create agent directory: %w", err)
+	}
+
+	if err := os.WriteFile(h.agentPath(targetBase), content, 0644); err != nil {
+		return fmt.Errorf("failed to write agent TOML file: %w", err)
+	}
+
+	return nil
+}
+
+// Remove deletes the Codex custom agent TOML file.
+func (h *AgentHandler) Remove(ctx context.Context, targetBase string) error {
+	if err := os.Remove(h.agentPath(targetBase)); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to remove agent TOML file: %w", err)
+	}
+	return nil
+}
+
+// VerifyInstalled returns whether the Codex custom agent TOML file exists.
+func (h *AgentHandler) VerifyInstalled(targetBase string) (bool, string) {
+	if !utils.FileExists(h.agentPath(targetBase)) {
+		return false, "agent TOML file not found"
+	}
+	return true, "installed"
+}
+
+func (h *AgentHandler) getPromptFile() string {
+	if h.metadata.Agent != nil && h.metadata.Agent.PromptFile != "" {
+		return h.metadata.Agent.PromptFile
+	}
+	return h.metadata.Asset.Name + ".toml"
+}
+
+func (h *AgentHandler) agentPath(targetBase string) string {
+	return filepath.Join(targetBase, DirAgents, h.metadata.Asset.Name+".toml")
+}

--- a/internal/clients/codex/handlers/agent.go
+++ b/internal/clients/codex/handlers/agent.go
@@ -6,11 +6,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/metadata"
 	"github.com/sleuth-io/sx/internal/utils"
 )
+
+type codexAgentDefinition struct {
+	Name                  string `toml:"name"`
+	Description           string `toml:"description"`
+	DeveloperInstructions string `toml:"developer_instructions"`
+}
 
 // AgentHandler installs Codex custom agent definitions as standalone TOML files.
 type AgentHandler struct {
@@ -36,6 +45,9 @@ func (h *AgentHandler) Install(ctx context.Context, zipData []byte, targetBase s
 	content, err := utils.ReadZipFile(zipData, promptFile)
 	if err != nil {
 		return fmt.Errorf("failed to read agent TOML file: %w", err)
+	}
+	if err := validateCodexAgentTOML(content); err != nil {
+		return fmt.Errorf("invalid agent TOML file: %w", err)
 	}
 
 	agentsDir := filepath.Join(targetBase, DirAgents)
@@ -69,6 +81,22 @@ func (h *AgentHandler) VerifyInstalled(targetBase string) (bool, string) {
 	return true, "installed"
 }
 
+// InstalledCodexAgentState reports whether the target file is missing, a valid
+// Codex agent TOML file, or a non-Codex file that should not be removed.
+func (h *AgentHandler) InstalledCodexAgentState(targetBase string) (string, error) {
+	content, err := os.ReadFile(h.agentPath(targetBase))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "missing", nil
+		}
+		return "", fmt.Errorf("failed to read agent TOML file: %w", err)
+	}
+	if err := validateCodexAgentTOML(content); err != nil {
+		return "invalid", nil
+	}
+	return "valid", nil
+}
+
 func (h *AgentHandler) getPromptFile() string {
 	if h.metadata.Agent != nil && h.metadata.Agent.PromptFile != "" {
 		return h.metadata.Agent.PromptFile
@@ -78,4 +106,26 @@ func (h *AgentHandler) getPromptFile() string {
 
 func (h *AgentHandler) agentPath(targetBase string) string {
 	return filepath.Join(targetBase, DirAgents, h.metadata.Asset.Name+".toml")
+}
+
+func validateCodexAgentTOML(content []byte) error {
+	var def codexAgentDefinition
+	if err := toml.Unmarshal(content, &def); err != nil {
+		return err
+	}
+
+	def.Name = strings.TrimSpace(def.Name)
+	def.Description = strings.TrimSpace(def.Description)
+	def.DeveloperInstructions = strings.TrimSpace(def.DeveloperInstructions)
+
+	if def.Name == "" {
+		return errors.New("missing required field: name")
+	}
+	if def.Description == "" {
+		return errors.New("missing required field: description")
+	}
+	if def.DeveloperInstructions == "" {
+		return errors.New("missing required field: developer_instructions")
+	}
+	return nil
 }

--- a/internal/clients/codex/handlers/agent_test.go
+++ b/internal/clients/codex/handlers/agent_test.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/metadata"
+)
+
+func TestCodexAgentHandler_InstallRemoveVerify(t *testing.T) {
+	targetBase := t.TempDir()
+
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{
+			Name:    "security_reviewer",
+			Version: "1.0.0",
+			Type:    asset.TypeAgent,
+		},
+		Agent: &metadata.AgentConfig{
+			PromptFile: "security_reviewer.toml",
+		},
+	}
+
+	agentTOML := `name = "security_reviewer"
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+`
+	zipData := createTestZip(t, map[string]string{
+		"metadata.toml": `[asset]
+name = "security_reviewer"
+version = "1.0.0"
+type = "agent"
+
+[agent]
+prompt-file = "security_reviewer.toml"
+`,
+		"security_reviewer.toml": agentTOML,
+	})
+
+	handler := NewAgentHandler(meta)
+	installed, msg := handler.VerifyInstalled(targetBase)
+	if installed {
+		t.Fatalf("VerifyInstalled before install = true, want false: %s", msg)
+	}
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	agentPath := filepath.Join(targetBase, DirAgents, "security_reviewer.toml")
+	got, err := os.ReadFile(agentPath)
+	if err != nil {
+		t.Fatalf("Failed to read installed agent file: %v", err)
+	}
+	if string(got) != agentTOML {
+		t.Errorf("Installed agent TOML = %q, want %q", string(got), agentTOML)
+	}
+
+	installed, msg = handler.VerifyInstalled(targetBase)
+	if !installed {
+		t.Fatalf("VerifyInstalled after install = false, want true: %s", msg)
+	}
+
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := os.Stat(agentPath); !os.IsNotExist(err) {
+		t.Fatalf("Agent file still exists after remove")
+	}
+}

--- a/internal/clients/codex/handlers/agent_test.go
+++ b/internal/clients/codex/handlers/agent_test.go
@@ -72,3 +72,78 @@ prompt-file = "security_reviewer.toml"
 		t.Fatalf("Agent file still exists after remove")
 	}
 }
+
+func TestCodexAgentHandler_InstallRejectsInvalidTOML(t *testing.T) {
+	targetBase := t.TempDir()
+
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{
+			Name:    "security_reviewer",
+			Version: "1.0.0",
+			Type:    asset.TypeAgent,
+		},
+		Agent: &metadata.AgentConfig{PromptFile: "security_reviewer.toml"},
+	}
+
+	zipData := createTestZip(t, map[string]string{
+		"metadata.toml": `[asset]
+name = "security_reviewer"
+version = "1.0.0"
+type = "agent"
+
+[agent]
+prompt-file = "security_reviewer.toml"
+`,
+		"security_reviewer.toml": "# Markdown agent\n",
+	})
+
+	handler := NewAgentHandler(meta)
+	if err := handler.Install(context.Background(), zipData, targetBase); err == nil {
+		t.Fatal("Install succeeded, want invalid TOML error")
+	}
+}
+
+func TestCodexAgentHandler_InstalledCodexAgentState(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "security_reviewer", Type: asset.TypeAgent},
+	}
+	handler := NewAgentHandler(meta)
+
+	state, err := handler.InstalledCodexAgentState(targetBase)
+	if err != nil {
+		t.Fatalf("InstalledCodexAgentState returned error: %v", err)
+	}
+	if state != "missing" {
+		t.Fatalf("state = %q, want missing", state)
+	}
+
+	agentPath := filepath.Join(targetBase, DirAgents, "security_reviewer.toml")
+	if err := os.MkdirAll(filepath.Dir(agentPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agentPath, []byte("# Markdown agent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	state, err = handler.InstalledCodexAgentState(targetBase)
+	if err != nil {
+		t.Fatalf("InstalledCodexAgentState returned error: %v", err)
+	}
+	if state != "invalid" {
+		t.Fatalf("state = %q, want invalid", state)
+	}
+
+	if err := os.WriteFile(agentPath, []byte(`name = "security_reviewer"
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	state, err = handler.InstalledCodexAgentState(targetBase)
+	if err != nil {
+		t.Fatalf("InstalledCodexAgentState returned error: %v", err)
+	}
+	if state != "valid" {
+		t.Fatalf("state = %q, want valid", state)
+	}
+}

--- a/internal/clients/codex/handlers/constants.go
+++ b/internal/clients/codex/handlers/constants.go
@@ -10,5 +10,6 @@ const (
 	// Asset subdirectories
 	DirSkills     = "skills"
 	DirCommands   = "commands"
+	DirAgents     = "agents"
 	DirMCPServers = "mcp-servers"
 )

--- a/internal/clients/codex/handlers/handler.go
+++ b/internal/clients/codex/handlers/handler.go
@@ -28,6 +28,8 @@ func NewHandler(assetType asset.Type, meta *metadata.Metadata) (Handler, error) 
 		return NewSkillHandler(meta), nil
 	case asset.TypeCommand:
 		return NewCommandHandler(meta), nil
+	case asset.TypeAgent:
+		return NewAgentHandler(meta), nil
 	case asset.TypeMCP:
 		return NewMCPHandler(meta), nil
 	default:

--- a/internal/clients/codex/rule_caps.go
+++ b/internal/clients/codex/rule_caps.go
@@ -1,0 +1,33 @@
+package codex
+
+import (
+	"strings"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/clients"
+	"github.com/sleuth-io/sx/internal/clients/codex/handlers"
+)
+
+// RuleCapabilities exposes Codex-owned single-file detection. Codex does
+// not support sx-managed rules, so only asset type detection is populated.
+func RuleCapabilities() *clients.RuleCapabilities {
+	return &clients.RuleCapabilities{
+		ClientName:      clients.ClientIDCodex,
+		DetectAssetType: detectAssetType,
+	}
+}
+
+// RuleCapabilities returns Codex's client-owned single-file detection hooks.
+func (c *Client) RuleCapabilities() *clients.RuleCapabilities {
+	return RuleCapabilities()
+}
+
+func detectAssetType(path string, _ []byte) *asset.Type {
+	lower := strings.ToLower(path)
+	agentDir := handlers.ConfigDir + "/" + handlers.DirAgents + "/"
+
+	if strings.Contains(lower, agentDir) && strings.HasSuffix(lower, ".toml") {
+		return &asset.TypeAgent
+	}
+	return nil
+}

--- a/internal/commands/add_input.go
+++ b/internal/commands/add_input.go
@@ -231,7 +231,12 @@ func downloadSingleFileFromGitHub(ctx context.Context, status *components.Status
 		}
 		tmpFile.Close()
 		return createZipFromRuleFile(tmpPath)
-	case asset.TypeAgent, asset.TypeCommand, asset.TypeSkill:
+	case asset.TypeAgent:
+		if strings.EqualFold(filepath.Ext(fileName), ".toml") {
+			return createZipFromCodexAgentContent(fileName, content)
+		}
+		return createZipFromPromptFile(fileName, *detectedType, content)
+	case asset.TypeCommand, asset.TypeSkill:
 		return createZipFromPromptFile(fileName, *detectedType, content)
 	default:
 		return nil, fmt.Errorf("unsupported asset type for single file: %s", detectedType.Label)

--- a/internal/commands/add_single_file.go
+++ b/internal/commands/add_single_file.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
+
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/clients"
 	"github.com/sleuth-io/sx/internal/metadata"
@@ -36,11 +38,72 @@ func createZipFromSingleFile(filePath string) ([]byte, error) {
 	switch *detectedType {
 	case asset.TypeRule:
 		return createZipFromRuleFile(filePath)
-	case asset.TypeAgent, asset.TypeCommand, asset.TypeSkill:
+	case asset.TypeAgent:
+		if strings.EqualFold(filepath.Ext(filePath), ".toml") {
+			return createZipFromCodexAgentFile(filePath, content)
+		}
+		return createZipFromPromptFile(filePath, *detectedType, content)
+	case asset.TypeCommand, asset.TypeSkill:
 		return createZipFromPromptFile(filePath, *detectedType, content)
 	default:
 		return nil, fmt.Errorf("unsupported asset type: %s", detectedType.Label)
 	}
+}
+
+type codexAgentDefinition struct {
+	Name                  string `toml:"name"`
+	Description           string `toml:"description"`
+	DeveloperInstructions string `toml:"developer_instructions"`
+}
+
+func createZipFromCodexAgentFile(filePath string, content []byte) ([]byte, error) {
+	return createZipFromCodexAgentContent(filePath, content)
+}
+
+func createZipFromCodexAgentContent(source string, content []byte) ([]byte, error) {
+	var def codexAgentDefinition
+	if err := toml.Unmarshal(content, &def); err != nil {
+		return nil, fmt.Errorf("failed to parse Codex agent TOML: %w", err)
+	}
+
+	def.Name = strings.TrimSpace(def.Name)
+	def.Description = strings.TrimSpace(def.Description)
+	def.DeveloperInstructions = strings.TrimSpace(def.DeveloperInstructions)
+
+	if def.Name == "" {
+		return nil, fmt.Errorf("codex agent TOML %s is missing required field: name", source)
+	}
+	if def.Description == "" {
+		return nil, fmt.Errorf("codex agent TOML %s is missing required field: description", source)
+	}
+	if def.DeveloperInstructions == "" {
+		return nil, fmt.Errorf("codex agent TOML %s is missing required field: developer_instructions", source)
+	}
+
+	promptFileName := def.Name + ".toml"
+	zipData, err := utils.CreateZipFromContent(promptFileName, content)
+	if err != nil {
+		return nil, err
+	}
+
+	meta := &metadata.Metadata{
+		MetadataVersion: "1.0",
+		Asset: metadata.Asset{
+			Name:        def.Name,
+			Type:        asset.TypeAgent,
+			Version:     "1.0",
+			Description: def.Description,
+			Clients:     []string{clients.ClientIDCodex},
+		},
+		Agent: &metadata.AgentConfig{PromptFile: promptFileName},
+	}
+
+	metaBytes, err := metadata.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.AddFileToZip(zipData, "metadata.toml", metaBytes)
 }
 
 // createZipFromPromptFile creates a zip for agent/command/skill files

--- a/internal/commands/add_single_file.go
+++ b/internal/commands/add_single_file.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ func createZipFromSingleFile(filePath string) ([]byte, error) {
 		return createZipFromRuleFile(filePath)
 	case asset.TypeAgent:
 		if strings.EqualFold(filepath.Ext(filePath), ".toml") {
-			return createZipFromCodexAgentFile(filePath, content)
+			return createZipFromCodexAgentContent(filePath, content)
 		}
 		return createZipFromPromptFile(filePath, *detectedType, content)
 	case asset.TypeCommand, asset.TypeSkill:
@@ -54,10 +55,6 @@ type codexAgentDefinition struct {
 	Name                  string `toml:"name"`
 	Description           string `toml:"description"`
 	DeveloperInstructions string `toml:"developer_instructions"`
-}
-
-func createZipFromCodexAgentFile(filePath string, content []byte) ([]byte, error) {
-	return createZipFromCodexAgentContent(filePath, content)
 }
 
 func createZipFromCodexAgentContent(source string, content []byte) ([]byte, error) {
@@ -78,6 +75,9 @@ func createZipFromCodexAgentContent(source string, content []byte) ([]byte, erro
 	}
 	if def.DeveloperInstructions == "" {
 		return nil, fmt.Errorf("codex agent TOML %s is missing required field: developer_instructions", source)
+	}
+	if err := validateCodexAgentName(def.Name); err != nil {
+		return nil, fmt.Errorf("codex agent TOML %s has invalid name %q: %w", source, def.Name, err)
 	}
 
 	promptFileName := def.Name + ".toml"
@@ -104,6 +104,16 @@ func createZipFromCodexAgentContent(source string, content []byte) ([]byte, erro
 	}
 
 	return utils.AddFileToZip(zipData, "metadata.toml", metaBytes)
+}
+
+func validateCodexAgentName(name string) error {
+	if strings.ContainsAny(name, `/\`) {
+		return errors.New("must not contain path separators")
+	}
+	if strings.Contains(name, "..") {
+		return errors.New("must not contain '..'")
+	}
+	return nil
 }
 
 // createZipFromPromptFile creates a zip for agent/command/skill files

--- a/internal/commands/add_single_file_test.go
+++ b/internal/commands/add_single_file_test.go
@@ -19,7 +19,8 @@ func TestIsSingleFileAsset(t *testing.T) {
 		{"my-agent.md", true},
 		{"my-agent.MD", true},
 		{"path/to/agent.md", true},
-		{"path/to/agents/security-reviewer.toml", true},
+		{"path/to/.codex/agents/security-reviewer.toml", true},
+		{"path/to/agents/security-reviewer.toml", false},
 		{"path/to/config.toml", false},
 		{"my-skill.zip", false},
 		{"my-skill", false},
@@ -66,21 +67,6 @@ func TestDetectAssetTypeFromPath(t *testing.T) {
 			path:     "/home/user/skills/my-skill.md",
 			content:  "Just some content",
 			expected: asset.TypeSkill,
-		},
-		{
-			name:     "codex agent toml by path",
-			path:     "/home/user/.codex/agents/security-reviewer.toml",
-			content:  `name = "security_reviewer"`,
-			expected: asset.TypeAgent,
-		},
-		{
-			name: "codex agent toml by content",
-			path: "/some/path/security-reviewer.toml",
-			content: `name = "security_reviewer"
-description = "Security reviewer"
-developer_instructions = "Review security risks."
-`,
-			expected: asset.TypeAgent,
 		},
 		{
 			name: "agent frontmatter with tools",
@@ -139,6 +125,36 @@ Command prompt here.`,
 	}
 }
 
+func TestDetectAssetTypeFromPath_IgnoresTOML(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+	}{
+		{
+			name:    "codex agent toml belongs to codex client detection",
+			path:    "/home/user/.codex/agents/security-reviewer.toml",
+			content: `name = "security_reviewer"`,
+		},
+		{
+			name: "content-shaped toml is not generic",
+			path: "/some/path/security-reviewer.toml",
+			content: `name = "security_reviewer"
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectors.DetectAssetTypeFromPath(tc.path, []byte(tc.content)); got != nil {
+				t.Fatalf("DetectAssetTypeFromPath() = %v, want nil", got)
+			}
+		})
+	}
+}
+
 func TestCreateZipFromSingleFile(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -170,7 +186,7 @@ func TestCreateZipFromSingleFile(t *testing.T) {
 		{
 			name:     "codex agent toml uses name from file",
 			filename: "security-reviewer.toml",
-			dirPath:  "agents",
+			dirPath:  ".codex/agents",
 			content: `name = "security_reviewer"
 description = "Security reviewer"
 developer_instructions = "Review security risks."
@@ -290,7 +306,7 @@ Agent with tools`,
 
 func TestCreateZipFromSingleFile_CodexAgentTOMLMissingRequiredField(t *testing.T) {
 	tmpDir := t.TempDir()
-	agentsDir := filepath.Join(tmpDir, "agents")
+	agentsDir := filepath.Join(tmpDir, ".codex", "agents")
 	if err := os.MkdirAll(agentsDir, 0755); err != nil {
 		t.Fatalf("Failed to create dir: %v", err)
 	}
@@ -302,5 +318,39 @@ func TestCreateZipFromSingleFile_CodexAgentTOMLMissingRequiredField(t *testing.T
 
 	if _, err := createZipFromSingleFile(filePath); err == nil {
 		t.Fatal("createZipFromSingleFile succeeded, want missing required field error")
+	}
+}
+
+func TestCreateZipFromSingleFile_CodexAgentTOMLInvalidName(t *testing.T) {
+	tests := []struct {
+		name          string
+		agentNameTOML string
+	}{
+		{name: "slash", agentNameTOML: `"security/reviewer"`},
+		{name: "backslash", agentNameTOML: `'security\reviewer'`},
+		{name: "dotdot", agentNameTOML: `"security..reviewer"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			agentsDir := filepath.Join(tmpDir, ".codex", "agents")
+			if err := os.MkdirAll(agentsDir, 0755); err != nil {
+				t.Fatalf("Failed to create dir: %v", err)
+			}
+
+			filePath := filepath.Join(agentsDir, "security-reviewer.toml")
+			content := []byte(`name = ` + tc.agentNameTOML + `
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+`)
+			if err := os.WriteFile(filePath, content, 0644); err != nil {
+				t.Fatalf("Failed to write file: %v", err)
+			}
+
+			if _, err := createZipFromSingleFile(filePath); err == nil {
+				t.Fatal("createZipFromSingleFile succeeded, want invalid name error")
+			}
+		})
 	}
 }

--- a/internal/commands/add_single_file_test.go
+++ b/internal/commands/add_single_file_test.go
@@ -19,6 +19,8 @@ func TestIsSingleFileAsset(t *testing.T) {
 		{"my-agent.md", true},
 		{"my-agent.MD", true},
 		{"path/to/agent.md", true},
+		{"path/to/agents/security-reviewer.toml", true},
+		{"path/to/config.toml", false},
 		{"my-skill.zip", false},
 		{"my-skill", false},
 		{"README.md", true}, // Any .md file is considered via fallback
@@ -64,6 +66,21 @@ func TestDetectAssetTypeFromPath(t *testing.T) {
 			path:     "/home/user/skills/my-skill.md",
 			content:  "Just some content",
 			expected: asset.TypeSkill,
+		},
+		{
+			name:     "codex agent toml by path",
+			path:     "/home/user/.codex/agents/security-reviewer.toml",
+			content:  `name = "security_reviewer"`,
+			expected: asset.TypeAgent,
+		},
+		{
+			name: "codex agent toml by content",
+			path: "/some/path/security-reviewer.toml",
+			content: `name = "security_reviewer"
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+`,
+			expected: asset.TypeAgent,
 		},
 		{
 			name: "agent frontmatter with tools",
@@ -149,6 +166,19 @@ func TestCreateZipFromSingleFile(t *testing.T) {
 			expectedType:      asset.TypeCommand,
 			expectedPrompt:    "review-pr.md",
 			expectedAssetName: "review-pr",
+		},
+		{
+			name:     "codex agent toml uses name from file",
+			filename: "security-reviewer.toml",
+			dirPath:  "agents",
+			content: `name = "security_reviewer"
+description = "Security reviewer"
+developer_instructions = "Review security risks."
+model = "gpt-5.4"
+`,
+			expectedType:      asset.TypeAgent,
+			expectedPrompt:    "security_reviewer.toml",
+			expectedAssetName: "security_reviewer",
 		},
 		{
 			name:     "agent detected from frontmatter",
@@ -238,6 +268,14 @@ Agent with tools`,
 				if meta.Agent.PromptFile != tc.expectedPrompt {
 					t.Errorf("Agent.PromptFile = %q, want %q", meta.Agent.PromptFile, tc.expectedPrompt)
 				}
+				if filepath.Ext(tc.expectedPrompt) == ".toml" {
+					if meta.Asset.Description != "Security reviewer" {
+						t.Errorf("Asset.Description = %q, want %q", meta.Asset.Description, "Security reviewer")
+					}
+					if len(meta.Asset.Clients) != 1 || meta.Asset.Clients[0] != "codex" {
+						t.Errorf("Asset.Clients = %v, want [codex]", meta.Asset.Clients)
+					}
+				}
 			} else {
 				if meta.Command == nil {
 					t.Fatal("Command config is nil")
@@ -247,5 +285,22 @@ Agent with tools`,
 				}
 			}
 		})
+	}
+}
+
+func TestCreateZipFromSingleFile_CodexAgentTOMLMissingRequiredField(t *testing.T) {
+	tmpDir := t.TempDir()
+	agentsDir := filepath.Join(tmpDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0755); err != nil {
+		t.Fatalf("Failed to create dir: %v", err)
+	}
+
+	filePath := filepath.Join(agentsDir, "security-reviewer.toml")
+	if err := os.WriteFile(filePath, []byte(`name = "security_reviewer"`), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	if _, err := createZipFromSingleFile(filePath); err == nil {
+		t.Fatal("createZipFromSingleFile succeeded, want missing required field error")
 	}
 }

--- a/internal/commands/integration_codex_test.go
+++ b/internal/commands/integration_codex_test.go
@@ -53,7 +53,7 @@ func TestCodexSupportedAssetTypes(t *testing.T) {
 	}
 
 	// Should support
-	supported := []string{"skill", "command", "mcp"}
+	supported := []string{"skill", "command", "agent", "mcp"}
 	for _, typeName := range supported {
 		if !client.SupportsAssetType(asset.FromString(typeName)) {
 			t.Errorf("Codex should support %s assets", typeName)
@@ -61,7 +61,7 @@ func TestCodexSupportedAssetTypes(t *testing.T) {
 	}
 
 	// Should not support
-	unsupported := []string{"agent", "rule", "hook"}
+	unsupported := []string{"rule", "hook"}
 	for _, typeName := range unsupported {
 		if client.SupportsAssetType(asset.FromString(typeName)) {
 			t.Errorf("Codex should not support %s assets", typeName)


### PR DESCRIPTION
Tested with
```
go run ./cmd/sx add ~/.codex/agents/qa-reviewer.toml
```

and verified it showed up in the [vault](https://github.com/pmenglund/skills/tree/main/assets/qa-reviewer)
