### PR TITLE
SK-560: Parse object form of plugin source

### DIFF
--- a/internal/clients/claude_code/handlers/claude_code_plugin_util.go
+++ b/internal/clients/claude_code/handlers/claude_code_plugin_util.go
@@ -401,6 +401,41 @@ func ResolveMarketplacePluginPath(marketplaceName, pluginName string) (string, e
 	return ResolveMarketplacePluginPathFromFile(knownMarketsPath, marketplaceName, pluginName)
 }
 
+// pluginSourceLocalPath extracts a marketplace-relative directory path from a
+// plugin's "source" field in marketplace.json. The field may be either:
+//
+//   - a string: a relative path, e.g. "./" or "./plugins/foo"
+//   - an object: {"source": "local", "path": "./plugins/foo"} (plus the
+//     "github"/"git" variants, which point outside the marketplace dir)
+//
+// It returns the relative path for the string form and for local object
+// sources, or "" for non-local object sources (github/git) and anything it
+// can't interpret, signalling the caller to fall back to its directory search.
+func pluginSourceLocalPath(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	// String form.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	// Object form.
+	var obj struct {
+		Source string `json:"source"`
+		Path   string `json:"path"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	// Only local object sources resolve to a path inside the marketplace dir;
+	// treat a bare {"path": ...} (no source type) as local too.
+	if obj.Source == "" || strings.EqualFold(obj.Source, "local") {
+		return obj.Path
+	}
+	return ""
+}
+
 // ResolveMarketplacePluginPathFromFile looks up a plugin using a specific known_marketplaces.json path.
 // The marketplaceName must be the resolved name (as registered in known_marketplaces.json).
 func ResolveMarketplacePluginPathFromFile(knownMarketsPath, marketplaceName, pluginName string) (string, error) {
@@ -434,23 +469,32 @@ func ResolveMarketplacePluginPathFromFile(knownMarketsPath, marketplaceName, plu
 	if mjData, err := os.ReadFile(marketplaceJSONPath); err == nil {
 		var mj struct {
 			Plugins []struct {
-				Name   string `json:"name"`
-				Source string `json:"source"`
+				Name string `json:"name"`
+				// Source may be a string (relative path) or an object
+				// ({"source": "local"|"github"|"git", ...}); parse it lazily.
+				Source json.RawMessage `json:"source"`
 			} `json:"plugins"`
 		}
 		if err := json.Unmarshal(mjData, &mj); err != nil {
 			fmt.Fprintf(os.Stderr, "  ⚠ Failed to parse marketplace.json: %v\n", err)
 		} else {
 			for _, p := range mj.Plugins {
-				if p.Name == pluginName {
-					resolved := filepath.Join(marketplace.InstallLocation, p.Source)
-					// Ensure resolved path stays within the marketplace directory
-					if !strings.HasPrefix(resolved+string(filepath.Separator), marketplace.InstallLocation+string(filepath.Separator)) {
-						continue
-					}
-					if utils.IsDirectory(resolved) {
-						return resolved, nil
-					}
+				if p.Name != pluginName {
+					continue
+				}
+				relPath := pluginSourceLocalPath(p.Source)
+				if relPath == "" {
+					// Non-local source (github/git) or uninterpretable;
+					// fall back to the standard directory search below.
+					continue
+				}
+				resolved := filepath.Join(marketplace.InstallLocation, relPath)
+				// Ensure resolved path stays within the marketplace directory
+				if !strings.HasPrefix(resolved+string(filepath.Separator), marketplace.InstallLocation+string(filepath.Separator)) {
+					continue
+				}
+				if utils.IsDirectory(resolved) {
+					return resolved, nil
 				}
 			}
 		}

--- a/internal/clients/claude_code/handlers/claude_code_plugin_util_test.go
+++ b/internal/clients/claude_code/handlers/claude_code_plugin_util_test.go
@@ -171,6 +171,92 @@ func TestResolveMarketplacePluginPathFromFile(t *testing.T) {
 		}
 	})
 
+	t.Run("found plugin via object source", func(t *testing.T) {
+		// marketplace.json where the plugin's source is an object form:
+		// {"source": "local", "path": "./pkg"} rather than a bare string.
+		objMarketDir := filepath.Join(tmpDir, "object-source-market")
+		claudePluginDir := filepath.Join(objMarketDir, ".claude-plugin")
+		if err := os.MkdirAll(claudePluginDir, 0755); err != nil {
+			t.Fatalf("failed to create .claude-plugin dir: %v", err)
+		}
+		pluginDir := filepath.Join(objMarketDir, "pkg")
+		if err := os.MkdirAll(pluginDir, 0755); err != nil {
+			t.Fatalf("failed to create plugin dir: %v", err)
+		}
+		marketplaceJSON := `{
+			"name": "object-source-market",
+			"plugins": [
+				{"name": "obj-plugin", "source": {"source": "local", "path": "./pkg"}}
+			]
+		}`
+		if err := os.WriteFile(filepath.Join(claudePluginDir, "marketplace.json"), []byte(marketplaceJSON), 0644); err != nil {
+			t.Fatalf("failed to write marketplace.json: %v", err)
+		}
+
+		markets := map[string]any{
+			"my-market":            map[string]any{"installLocation": marketplaceDir},
+			"object-source-market": map[string]any{"installLocation": objMarketDir},
+		}
+		data, _ := json.Marshal(markets)
+		if err := os.WriteFile(knownMarketsPath, data, 0644); err != nil {
+			t.Fatalf("failed to write known_marketplaces.json: %v", err)
+		}
+
+		path, err := ResolveMarketplacePluginPathFromFile(knownMarketsPath, "object-source-market", "obj-plugin")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if path != pluginDir {
+			t.Errorf("expected %q, got %q", pluginDir, path)
+		}
+	})
+
+	t.Run("non-local object source falls back to directory search", func(t *testing.T) {
+		// A github-sourced plugin object doesn't resolve to a path inside the
+		// marketplace dir; resolution must not crash on the object and should
+		// fall through to the plugins/ directory search.
+		ghMarketDir := filepath.Join(tmpDir, "github-source-market")
+		claudePluginDir := filepath.Join(ghMarketDir, ".claude-plugin")
+		if err := os.MkdirAll(claudePluginDir, 0755); err != nil {
+			t.Fatalf("failed to create .claude-plugin dir: %v", err)
+		}
+		// The plugin actually lives under plugins/<name>.
+		fallbackDir := filepath.Join(ghMarketDir, "plugins", "gh-plugin", ".claude-plugin")
+		if err := os.MkdirAll(fallbackDir, 0755); err != nil {
+			t.Fatalf("failed to create fallback dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(fallbackDir, "plugin.json"), []byte(`{}`), 0644); err != nil {
+			t.Fatalf("failed to write plugin.json: %v", err)
+		}
+		marketplaceJSON := `{
+			"name": "github-source-market",
+			"plugins": [
+				{"name": "gh-plugin", "source": {"source": "github", "repo": "org/gh-plugin"}}
+			]
+		}`
+		if err := os.WriteFile(filepath.Join(claudePluginDir, "marketplace.json"), []byte(marketplaceJSON), 0644); err != nil {
+			t.Fatalf("failed to write marketplace.json: %v", err)
+		}
+
+		markets := map[string]any{
+			"my-market":            map[string]any{"installLocation": marketplaceDir},
+			"github-source-market": map[string]any{"installLocation": ghMarketDir},
+		}
+		data, _ := json.Marshal(markets)
+		if err := os.WriteFile(knownMarketsPath, data, 0644); err != nil {
+			t.Fatalf("failed to write known_marketplaces.json: %v", err)
+		}
+
+		path, err := ResolveMarketplacePluginPathFromFile(knownMarketsPath, "github-source-market", "gh-plugin")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := filepath.Join(ghMarketDir, "plugins", "gh-plugin")
+		if path != expected {
+			t.Errorf("expected fallback %q, got %q", expected, path)
+		}
+	})
+
 	t.Run("plugins dir takes precedence over external_plugins", func(t *testing.T) {
 		// Create plugin in both plugins/ and external_plugins/
 		for _, subdir := range []string{"plugins", "external_plugins"} {


### PR DESCRIPTION
## Summary
- A customer hit `Failed to parse marketplace.json: json: cannot unmarshal object into Go struct field .plugins.source of type string`.
- The marketplace.json parser only ever handled `source` as a string, but the Claude Code spec also allows the object form (`{"source": "github"|"git"|"local", ...}`). One object-form entry blew up the whole parse.
- Not new code — this has been broken since `638de58` (2026-03-25), shipped since v0.14.3. Nothing to do with the codex work; it just never showed up because every marketplace we tested used the string form.

What changed:
- Parse `source` lazily as `json.RawMessage` so an object no longer kills the parse.
- New `pluginSourceLocalPath` accepts both forms: string -> the path, local object -> its `path`, github/git object -> empty so we fall through to the normal `plugins/` directory search instead of crashing.
- Added tests for the local object source and the github fallback.

**Security implications of changes have been considered**