### PR TITLE
SK-614: Fix release build on fresh checkouts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,11 @@ project_name: sx
 before:
   hooks:
     - go mod tidy
+    # app/main.go embeds frontend/dist (go:embed all:); a fresh checkout
+    # has no built frontend, so the embed target must exist or the app
+    # package fails to compile. Mirrors the Makefile's ensure-app-embed.
+    - mkdir -p app/frontend/dist
+    - touch app/frontend/dist/.gitkeep
     - go test ./...
 
 builds:


### PR DESCRIPTION
## Summary
- GoReleaser's before hook runs `go test ./...` on a fresh checkout where the frontend was never built, so `app`'s `//go:embed all:frontend/dist` fails to compile and the v2.0.0 release aborted
- Create the embed target (dist dir + .gitkeep) in the before hooks, mirroring the Makefile's `ensure-app-embed`

**Security implications of changes have been considered**