### PR TITLE
SK-627: Fix self-update picking app archive

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -36,6 +36,16 @@ jobs:
           # the -unsigned suffix at runtime and emits both a zip and a
           # DMG); the other platforms use exact file names. Upload steps
           # glob `artifact*` so both conventions work.
+          #
+          # Linux/Windows names carry a "-portable" qualifier so they do NOT
+          # end in "<os>-<arch>.<ext>". The CLI's self-updater (go-selfupdate)
+          # selects a release asset by that trailing suffix; without the
+          # qualifier a name like "sx-app-linux-amd64.tar.gz" matches the same
+          # pattern as the CLI's own "sx_Linux_x86_64.tar.gz" and, being first
+          # alphabetically, gets picked — then the update fails because the app
+          # tar has no "sx" binary. macOS uses "macos" (not "darwin"), so its
+          # names never collide and keep the prefix the app updater expects
+          # (sx-app-macos-<arch>, see app/update.go).
           - name: macos-arm64
             os: macos-latest
             platform: darwin/arm64
@@ -49,19 +59,19 @@ jobs:
           - name: windows-amd64
             os: windows-latest
             platform: windows/amd64
-            artifact: sx-app-windows-amd64.zip
+            artifact: sx-app-windows-amd64-portable.zip
           - name: windows-arm64
             os: windows-11-arm
             platform: windows/arm64
-            artifact: sx-app-windows-arm64.zip
+            artifact: sx-app-windows-arm64-portable.zip
           - name: linux-amd64
             os: ubuntu-latest
             platform: linux/amd64
-            artifact: sx-app-linux-amd64.tar.gz
+            artifact: sx-app-linux-amd64-portable.tar.gz
           - name: linux-arm64
             os: ubuntu-24.04-arm
             platform: linux/arm64
-            artifact: sx-app-linux-arm64.tar.gz
+            artifact: sx-app-linux-arm64-portable.tar.gz
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -25,6 +26,42 @@ const (
 	pendingUpdateFile = "pending-update.json"
 	updateTimeout     = 30 * time.Second
 )
+
+// CLIAssetFilter returns a regexp matching only the GoReleaser CLI archive
+// for the current platform, e.g. "sx_Linux_x86_64.tar.gz". It mirrors the
+// name_template in .goreleaser.yml.
+//
+// The GitHub release also carries desktop-app archives (sx-app-<os>-<arch>…)
+// whose names would otherwise satisfy go-selfupdate's default <os><sep><arch>
+// suffix match and get selected instead of the CLI binary — the app tar has
+// no "sx" executable inside, so the update then fails with "executable not
+// found in tar". Constraining asset selection to "sx_<OS>_<ARCH>" avoids that.
+// go-selfupdate lowercases asset names before matching, so this pattern is
+// lowercase and anchored.
+func CLIAssetFilter() string {
+	arch := runtime.GOARCH
+	switch arch {
+	case "amd64":
+		arch = "x86_64"
+	case "386":
+		arch = "i386"
+	}
+	return fmt.Sprintf(`^sx_%s_%s\.(tar\.gz|zip)$`, runtime.GOOS, arch)
+}
+
+// NewUpdater builds a go-selfupdate Updater restricted to the CLI's own
+// release archives via CLIAssetFilter. Shared by the background auto-updater
+// and the `sx update` command so both select the same asset.
+func NewUpdater() (*selfupdate.Updater, error) {
+	source, err := selfupdate.NewGitHubSource(selfupdate.GitHubConfig{})
+	if err != nil {
+		return nil, err
+	}
+	return selfupdate.NewUpdater(selfupdate.Config{
+		Source:  source,
+		Filters: []string{CLIAssetFilter()},
+	})
+}
 
 // pendingUpdate represents a pending update marker file
 type pendingUpdate struct {
@@ -183,11 +220,12 @@ func checkAndUpdate() error {
 	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
 	defer cancel()
 
-	// Use the library's Updater with silent output
-	source, _ := selfupdate.NewGitHubSource(selfupdate.GitHubConfig{})
-	updater, _ := selfupdate.NewUpdater(selfupdate.Config{
-		Source: source,
-	})
+	// Use the library's Updater with silent output, restricted to the CLI's
+	// own release archives (see CLIAssetFilter).
+	updater, err := NewUpdater()
+	if err != nil {
+		return err
+	}
 
 	// Detect latest release
 	release, found, err := updater.DetectLatest(ctx, selfupdate.ParseSlug(fmt.Sprintf("%s/%s", GithubOwner, GithubRepo)))

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -4,11 +4,61 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sleuth-io/sx/internal/buildinfo"
 )
+
+// TestCLIAssetFilter guards the fix for the 2.0.0 auto-update break: the
+// GitHub release carries both the CLI archive (sx_<OS>_<ARCH>.tar.gz) and
+// desktop-app archives (sx-app-<os>-<arch>-portable.tar.gz). The filter must
+// select the former and reject the latter. go-selfupdate lowercases asset
+// names before matching, so the filter is applied to lowercased names here.
+func TestCLIAssetFilter(t *testing.T) {
+	re, err := regexp.Compile(CLIAssetFilter())
+	if err != nil {
+		t.Fatalf("CLIAssetFilter is not a valid regexp: %v", err)
+	}
+
+	// Build the goreleaser CLI archive name for the current platform, mirroring
+	// the name_template in .goreleaser.yml ({{ title .Os }}_<arch>).
+	osTitle := strings.ToUpper(runtime.GOOS[:1]) + runtime.GOOS[1:]
+	arch := runtime.GOARCH
+	switch arch {
+	case "amd64":
+		arch = "x86_64"
+	case "386":
+		arch = "i386"
+	}
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+	cliName := "sx_" + osTitle + "_" + arch + "." + ext
+
+	if !re.MatchString(strings.ToLower(cliName)) {
+		t.Errorf("filter %q did not match CLI archive %q", re.String(), cliName)
+	}
+
+	// Every desktop-app archive for this platform must be rejected — these are
+	// the names that broke deployed clients when they matched the default
+	// <os><sep><arch> suffix.
+	appNames := []string{
+		"sx-app-" + runtime.GOOS + "-" + runtime.GOARCH + "-portable." + ext,
+		"sx-app-" + runtime.GOOS + "-" + runtime.GOARCH + "." + ext, // the pre-fix name
+		"sx-app-macos-" + runtime.GOARCH + "-unsigned.zip",
+		"checksums.txt",
+	}
+	for _, name := range appNames {
+		if re.MatchString(strings.ToLower(name)) {
+			t.Errorf("filter %q wrongly matched non-CLI asset %q", re.String(), name)
+		}
+	}
+}
 
 // useTempCache isolates the test from the real cache directory
 func useTempCache(t *testing.T) {

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -53,10 +53,18 @@ func runUpdate(cmd *cobra.Command, checkOnly bool) error {
 
 	repository := selfupdate.ParseSlug(fmt.Sprintf("%s/%s", autoupdate.GithubOwner, autoupdate.GithubRepo))
 
+	// Restrict asset selection to the CLI's own release archives; the release
+	// also carries desktop-app archives that would otherwise be picked (see
+	// autoupdate.CLIAssetFilter).
+	updater, err := autoupdate.NewUpdater()
+	if err != nil {
+		return fmt.Errorf("failed to initialize updater: %w", err)
+	}
+
 	if checkOnly {
 		// Just check for latest version without updating
 		status.Start("Checking for updates")
-		latest, found, err := selfupdate.DetectLatest(ctx, repository)
+		latest, found, err := updater.DetectLatest(ctx, repository)
 		if err != nil {
 			status.Fail("Failed to check")
 			return fmt.Errorf("failed to check for updates: %w", err)
@@ -81,7 +89,7 @@ func runUpdate(cmd *cobra.Command, checkOnly bool) error {
 
 	// Check if there's actually a newer version available
 	status.Start("Checking for updates")
-	latest, found, err := selfupdate.DetectLatest(ctx, repository)
+	latest, found, err := updater.DetectLatest(ctx, repository)
 	if err != nil {
 		status.Fail("Failed to check")
 		return fmt.Errorf("failed to check for updates: %w", err)
@@ -101,7 +109,7 @@ func runUpdate(cmd *cobra.Command, checkOnly bool) error {
 
 	// Perform the update using the library's high-level function
 	status.Start("Downloading and installing update")
-	release, err := selfupdate.UpdateSelf(ctx, currentVersion, repository)
+	release, err := updater.UpdateSelf(ctx, currentVersion, repository)
 	if err != nil {
 		status.Fail("Failed to update")
 		return fmt.Errorf("failed to update: %w", err)


### PR DESCRIPTION
See [this Slack thread](https://sleuthio.slack.com/archives/CRE387BEK/p1783385994123999) for details on the issue.

- Rename Linux/Windows desktop archives with -portable so they no longer match the CLI updater's os-arch suffix
- Restrict go-selfupdate asset selection to sx_<OS>_<ARCH> via CLIAssetFilter, shared by update cmd and background
- Add regression test for the asset filter