### PR TITLE
SK-623: Fix stale In-library flag on library switch

### DIFF
--- a/app/frontend/src/components/MarketplaceSection.tsx
+++ b/app/frontend/src/components/MarketplaceSection.tsx
@@ -235,9 +235,13 @@ export default function MarketplaceSection() {
                   const mine = installedPlugins.find(
                     (p) => !p.builtIn && p.manifest.id === r.id,
                   );
-                  // Derived reactively (not from the fetched flag), so
-                  // installs/updates flip this card without a refetch.
-                  const installed = r.installed || !!mine;
+                  // Derived from the LIVE host registry only. The
+                  // catalog's fetched `installed` flag was stamped
+                  // against whichever library was current at fetch
+                  // time, and the catalog cache outlives library
+                  // switches — trusting it showed "In library" for
+                  // extensions the newly selected library doesn't have.
+                  const installed = !!mine;
                   if (
                     installed &&
                     mine &&


### PR DESCRIPTION
## Summary
- Marketplace cards showed "✓ In library" after switching to a library that doesn't have the extension installed (correct again only after a restart)
- Cause: the card trusted the catalog's fetched `installed` flag, which is stamped against whichever library was current at fetch time — and the shared catalog cache outlives library switches
- Cards now derive installed state solely from the live plugin-host registry, which re-syncs on every library switch; verified in the sandbox by switching between a library with all 15 extensions and an empty one (15 Install buttons, zero stale labels)

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)