### PR TITLE
SK-648: Smooth remote-vault loading in the app

### DIFF
--- a/app/frontend/src/components/AssetDetail.tsx
+++ b/app/frontend/src/components/AssetDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
 import {
@@ -52,6 +52,7 @@ export default function AssetDetail({
   onCollectionsChanged: () => void;
 }) {
   const [detail, setDetail] = useState<main.AssetDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(true);
   const [error, setError] = useState("");
   const [revision, setRevision] = useState("");
   const [activeFile, setActiveFile] = useState(0);
@@ -64,6 +65,7 @@ export default function AssetDetail({
     (t) => t.pluginId + ":" + t.spec.id === activeTab,
   );
   const [sharing, setSharing] = useState<main.InstallationsView | null>(null);
+  const [sharingLoading, setSharingLoading] = useState(true);
   const [shareOpen, setShareOpen] = useState(false);
   // Right-anchored panel: dragging its left edge outward grows it.
   const [panelWidth, startPanelResize] = usePanelSize(
@@ -74,9 +76,17 @@ export default function AssetDetail({
     true,
   );
 
+  // Switching assets blanks to the skeleton; switching revisions of the
+  // SAME asset keeps the current content on screen (dimmed) while the new
+  // one loads — on a slow remote vault a blank flash reads as data loss.
+  const loadedName = useRef<string | null>(null);
   useEffect(() => {
     let stale = false;
-    setDetail(null);
+    if (loadedName.current !== name) {
+      loadedName.current = name;
+      setDetail(null);
+    }
+    setDetailLoading(true);
     setError("");
     GetAsset(name, revision)
       .then((d) => {
@@ -86,6 +96,9 @@ export default function AssetDetail({
       })
       .catch((e) => {
         if (!stale) setError(String(e));
+      })
+      .finally(() => {
+        if (!stale) setDetailLoading(false);
       });
     return () => {
       stale = true;
@@ -148,12 +161,17 @@ export default function AssetDetail({
 
   useEffect(() => {
     let stale = false;
+    setSharing(null);
+    setSharingLoading(true);
     GetAssetInstallations(name)
       .then((s) => {
         if (!stale) setSharing(s);
       })
       .catch(() => {
         if (!stale) setSharing(null);
+      })
+      .finally(() => {
+        if (!stale) setSharingLoading(false);
       });
     return () => {
       stale = true;
@@ -356,6 +374,13 @@ export default function AssetDetail({
           </div>
         )}
 
+        {/* The row is reserved while installations load so the content
+            below doesn't jump down when a slow vault answers. */}
+        {sharingLoading && (
+          <div className="flex items-center border-b border-line px-6 py-2">
+            <div className="h-[22px] w-64 max-w-full animate-pulse rounded bg-canvas" />
+          </div>
+        )}
         {sharing && (
           <div className="flex items-center gap-2 border-b border-line px-6 py-2 text-xs text-ink-soft">
             <span>
@@ -441,7 +466,11 @@ export default function AssetDetail({
                   onSelect={setActiveFile}
                 />
               )}
-              <div className="min-w-0 flex-1 overflow-y-auto px-6 py-5">
+              <div
+                className={`min-w-0 flex-1 overflow-y-auto px-6 py-5 transition-opacity ${
+                  detailLoading && detail ? "opacity-50" : ""
+                }`}
+              >
                 {error && (
                   <div className="rounded-lg bg-danger-soft px-4 py-3 text-sm text-danger">
                     {error}

--- a/app/frontend/src/components/DraftSheet.tsx
+++ b/app/frontend/src/components/DraftSheet.tsx
@@ -12,6 +12,31 @@ import MarkdownEditor from "./MarkdownEditor";
 import { setPluginEditor } from "../plugins/sxapi";
 import type { EditorView } from "@uiw/react-codemirror";
 
+/**
+ * The sheet's frame, pulsing — shown while a draft is created or fetched
+ * from the vault (seconds, when it's remote) so the user's click has an
+ * immediate response and the real sheet lands without a size jump.
+ */
+export function DraftSheetSkeleton() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+      <div className="absolute inset-0 bg-black/30" />
+      <div className="relative flex h-[85vh] w-[980px] max-w-full flex-col overflow-hidden rounded-2xl border border-line bg-surface shadow-2xl">
+        <header className="border-b border-line px-6 py-4">
+          <div className="h-6 w-56 animate-pulse rounded bg-canvas" />
+        </header>
+        <div className="grid gap-3 border-b border-line px-6 py-4 sm:grid-cols-2">
+          <div className="h-[58px] animate-pulse rounded-lg bg-canvas" />
+          <div className="h-[58px] animate-pulse rounded-lg bg-canvas" />
+        </div>
+        <div className="min-h-0 flex-1 p-4">
+          <div className="h-full animate-pulse rounded-lg bg-canvas" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const TYPE_OPTIONS = [
   { key: "skill", label: "Skill" },
   { key: "rule", label: "Rule" },

--- a/app/frontend/src/components/RepoPicker.tsx
+++ b/app/frontend/src/components/RepoPicker.tsx
@@ -65,6 +65,7 @@ export default function RepoPicker({
   autoFocus?: boolean;
 }) {
   const [repos, setRepos] = useState<main.GitRepoOption[]>([]);
+  const [loadingRepos, setLoadingRepos] = useState(true);
   const [open, setOpen] = useState(false);
   const [activeIdx, setActiveIdx] = useState(-1);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -74,7 +75,8 @@ export default function RepoPicker({
   useEffect(() => {
     ListGitRepos()
       .then((r) => setRepos(r ?? []))
-      .catch(() => setRepos([]));
+      .catch(() => setRepos([]))
+      .finally(() => setLoadingRepos(false));
   }, []);
 
   // Close on outside clicks.
@@ -93,7 +95,9 @@ export default function RepoPicker({
   // Once the value is a picked/typed URL, suggestions are done.
   const isURL = q.includes("://") || q.startsWith("git@");
   const hasList = repos.length > 0;
-  const showList = open && !isURL && shown.length > 0;
+  // While the repo list is on the wire the dropdown says so instead of
+  // sitting empty and popping suggestions in seconds later.
+  const showList = open && !isURL && (loadingRepos || shown.length > 0);
 
   function pick(r: main.GitRepoOption) {
     onChange(r.url);
@@ -167,7 +171,7 @@ export default function RepoPicker({
         onFocus={() => setOpen(true)}
         onKeyDown={onKeyDown}
         placeholder={
-          hasList
+          hasList || loadingRepos
             ? "Search your repositories or paste a URL"
             : "https://github.com/acme/skills.git"
         }
@@ -209,6 +213,11 @@ export default function RepoPicker({
           role="listbox"
           className="absolute left-0 right-0 top-full z-50 mt-1 max-h-56 overflow-y-auto rounded-lg border border-line bg-surface py-1 shadow-lg"
         >
+          {loadingRepos && shown.length === 0 && (
+            <div className="animate-pulse px-3 py-1.5 text-sm text-ink-faint">
+              Loading your repositories…
+            </div>
+          )}
           {shown.map((r, i) => (
             <button
               key={r.name}

--- a/app/frontend/src/components/ShareModal.tsx
+++ b/app/frontend/src/components/ShareModal.tsx
@@ -223,7 +223,13 @@ export default function ShareModal({
   return (
     <Modal title={title} onClose={onClose} width="w-[480px]">
       {!view ? (
-        <div className="h-20 animate-pulse rounded-lg bg-canvas" />
+        // Shaped like the loaded layout (installations list, kind tabs,
+        // picker) so the modal doesn't grow abruptly when data lands.
+        <div className="space-y-3">
+          <div className="h-20 animate-pulse rounded-lg bg-canvas" />
+          <div className="h-7 animate-pulse rounded-lg bg-canvas" />
+          <div className="h-32 animate-pulse rounded-lg bg-canvas" />
+        </div>
       ) : (
         <>
           <div className="mb-1.5 text-xs font-semibold tracking-wide text-ink-faint">

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, type MouseEvent } from "react";
+import { useState, type MouseEvent, type ReactNode } from "react";
 import type { main } from "../../wailsjs/go/models";
 import { useSlot } from "../plugins/registry";
 import PluginMount from "./PluginMount";
@@ -71,6 +71,7 @@ export default function Sidebar({
   dropRepo,
   onCollectionDragHandle,
   onRepoDragHandle,
+  onUnpin,
   width,
 }: {
   vault: main.VaultInfo;
@@ -100,9 +101,26 @@ export default function Sidebar({
   dropRepo: string;
   onCollectionDragHandle: (name: string, e: MouseEvent) => void;
   onRepoDragHandle: (url: string, e: MouseEvent) => void;
+  onUnpin: (kind: "collections" | "teams" | "repos", name: string) => void;
   width: number;
 }) {
   const active = scopeKey(scope);
+  // One flat PINNED list instead of per-type sections: type icons carry
+  // the collection/team/repo distinction (the Finder/Linear/Notion
+  // favorites pattern). The BROWSE rows below are the durable path to
+  // the full catalogs, so the section can simply vanish when empty.
+  const pinnedCollectionRows = collections.filter((c) =>
+    pinnedCollections.includes(c.name),
+  );
+  const pinnedTeamRows = teams.filter((t) => pinnedTeams.includes(t.name));
+  const pinnedRepoRows = repoAssets
+    ? Object.keys(repoAssets)
+        .filter((url) => pinnedRepos.includes(url))
+        .sort((a, b) => repoLabel(a).localeCompare(repoLabel(b)))
+    : [];
+  const hasPins =
+    pinnedCollectionRows.length + pinnedTeamRows.length + pinnedRepoRows.length >
+    0;
   const sidebarPanels = useSlot("sidebar-panel");
   const dashboardWidgets = useSlot("dashboard-widget").length;
   const mainViews = useSlot("main-view");
@@ -225,146 +243,126 @@ export default function Sidebar({
           );
         })}
 
-        <div className="mt-4 flex items-center justify-between pr-1">
-          <SectionLabel>COLLECTIONS</SectionLabel>
-          <button
-            onClick={onNewCollection}
-            title="New collection"
-            className="rounded px-1.5 text-sm leading-none text-ink-faint transition hover:text-accent"
-          >
-            +
-          </button>
-        </div>
-        {collections.length === 0 ? (
-          <button
-            onClick={onNewCollection}
-            className="mx-1 mt-1 w-[calc(100%-8px)] rounded-lg border border-dashed border-line px-3 py-2.5 text-left text-xs text-ink-faint transition hover:border-accent hover:text-accent"
-          >
-            Group related assets into your first collection
-          </button>
-        ) : (
+        {/* PINNED: quick access the user curated (plus the first-few
+            defaults until they pin), one flat mixed list — icons carry
+            the type. Drop targets and drag handles are unchanged, so
+            dragging an asset onto a pinned collection/team/repo still
+            works. Vanishes when empty; BROWSE below is always there. */}
+        {hasPins && (
           <>
-            {collections
-              .filter((c) => pinnedCollections.includes(c.name))
-              .map((c) => (
-                <div
-                  key={c.name}
-                  data-drop-collection={c.name}
-                  onMouseDown={(e) => onCollectionDragHandle(c.name, e)}
-                  className={
-                    dropCollection === c.name
-                      ? "rounded-lg ring-2 ring-accent"
-                      : undefined
-                  }
-                >
-                  <Row
-                    label={c.name}
-                    count={(c.assets ?? []).length}
-                    active={active === "collection:" + c.name}
-                    onClick={() =>
-                      onScope({ kind: "collection", name: c.name })
-                    }
-                  />
-                </div>
-              ))}
-            <BrowseRow
-              label={`All collections (${collections.length})…`}
-              onClick={onBrowseCollections}
-            />
-          </>
-        )}
-
-        <div className="mt-4 flex items-center justify-between pr-1">
-          <SectionLabel>TEAMS</SectionLabel>
-          <button
-            onClick={onNewTeam}
-            title="New team"
-            className="rounded px-1.5 text-sm leading-none text-ink-faint transition hover:text-accent"
-          >
-            +
-          </button>
-        </div>
-        {teams.length === 0 ? (
-          <button
-            onClick={onNewTeam}
-            className="mx-1 mt-1 w-[calc(100%-8px)] rounded-lg border border-dashed border-line px-3 py-2.5 text-left text-xs text-ink-faint transition hover:border-accent hover:text-accent"
-          >
-            Create a team to share assets with the right people
-          </button>
-        ) : (
-          <>
-            {teams
-              .filter((t) => pinnedTeams.includes(t.name))
-              .map((t) => (
-                <div
-                  key={t.name}
-                  data-drop-team={t.name}
-                  className={
-                    dropTeam === t.name
-                      ? "rounded-lg ring-2 ring-accent"
-                      : undefined
-                  }
-                >
-                  <Row
-                    label={t.name}
-                    count={teamAssetCounts[t.name] ?? 0}
-                    active={active === "team:" + t.name}
-                    onClick={() => onScope({ kind: "team", name: t.name })}
-                  />
-                </div>
-              ))}
-            <BrowseRow
-              label={`All teams (${teams.length})…`}
-              onClick={onBrowseTeams}
-            />
-          </>
-        )}
-
-        {/* Per-library opt-in (Settings → Track repositories): which repos
-            assets are scoped to. Off means the concept never appears. Like
-            collections and teams, only pinned repos live in the sidebar;
-            the browse row searches and pins the rest. */}
-        {repoAssets !== null && (
-          <>
-            <div className="mt-4 flex items-center justify-between pr-1">
-              <SectionLabel>REPOSITORIES</SectionLabel>
+            <div className="mt-4">
+              <SectionLabel>PINNED</SectionLabel>
             </div>
-            {Object.keys(repoAssets).length === 0 ? (
-              <div className="mx-1 mt-1 rounded-lg border border-dashed border-line px-3 py-2.5 text-xs text-ink-faint">
-                Assets scoped to repositories will show up here
-              </div>
-            ) : (
-              <>
-                {Object.keys(repoAssets)
-                  .filter((url) => pinnedRepos.includes(url))
-                  .sort((a, b) => repoLabel(a).localeCompare(repoLabel(b)))
-                  .map((url) => (
-                    <div
-                      key={url}
-                      title={url}
-                      data-drop-repo={url}
-                      onMouseDown={(e) => onRepoDragHandle(url, e)}
-                      className={
-                        dropRepo === url
-                          ? "rounded-lg ring-2 ring-accent"
-                          : undefined
-                      }
-                    >
-                      <Row
-                        label={repoLabel(url)}
-                        count={(repoAssets[url] ?? []).length}
-                        active={active === "repo:" + url}
-                        onClick={() => onScope({ kind: "repo", name: url })}
-                      />
-                    </div>
-                  ))}
-                <BrowseRow
-                  label={`All repositories (${Object.keys(repoAssets).length})…`}
-                  onClick={onBrowseRepos}
+            {pinnedCollectionRows.map((c) => (
+              <div
+                key={"collection:" + c.name}
+                data-drop-collection={c.name}
+                onMouseDown={(e) => onCollectionDragHandle(c.name, e)}
+                className={
+                  dropCollection === c.name
+                    ? "rounded-lg ring-2 ring-accent"
+                    : undefined
+                }
+              >
+                <Row
+                  icon={<CollectionIcon />}
+                  label={c.name}
+                  count={(c.assets ?? []).length}
+                  active={active === "collection:" + c.name}
+                  onClick={() => onScope({ kind: "collection", name: c.name })}
+                  onUnpin={() => onUnpin("collections", c.name)}
                 />
-              </>
-            )}
+              </div>
+            ))}
+            {pinnedTeamRows.map((t) => (
+              <div
+                key={"team:" + t.name}
+                data-drop-team={t.name}
+                className={
+                  dropTeam === t.name
+                    ? "rounded-lg ring-2 ring-accent"
+                    : undefined
+                }
+              >
+                <Row
+                  icon={<TeamIcon />}
+                  label={t.name}
+                  count={teamAssetCounts[t.name] ?? 0}
+                  active={active === "team:" + t.name}
+                  onClick={() => onScope({ kind: "team", name: t.name })}
+                  onUnpin={() => onUnpin("teams", t.name)}
+                />
+              </div>
+            ))}
+            {pinnedRepoRows.map((url) => (
+              <div
+                key={"repo:" + url}
+                title={url}
+                data-drop-repo={url}
+                onMouseDown={(e) => onRepoDragHandle(url, e)}
+                className={
+                  dropRepo === url
+                    ? "rounded-lg ring-2 ring-accent"
+                    : undefined
+                }
+              >
+                <Row
+                  icon={<RepoIcon />}
+                  label={repoLabel(url)}
+                  count={(repoAssets?.[url] ?? []).length}
+                  active={active === "repo:" + url}
+                  onClick={() => onScope({ kind: "repo", name: url })}
+                  onUnpin={() => onUnpin("repos", url)}
+                />
+              </div>
+            ))}
           </>
+        )}
+
+        {/* BROWSE: one count-bearing row per catalog — the counts keep
+            the "how much is there" scope cue that fully hidden
+            navigation loses. An empty catalog's row becomes its own
+            create CTA. Repositories appear only when the library tracks
+            them (Settings → Track repositories). */}
+        <div className="mt-4">
+          <SectionLabel>BROWSE</SectionLabel>
+        </div>
+        <CatalogRow
+          icon={<CollectionIcon />}
+          label="Collections"
+          count={collections.length}
+          onClick={
+            collections.length > 0 ? onBrowseCollections : onNewCollection
+          }
+          title={
+            collections.length === 0
+              ? "Group related assets into your first collection"
+              : "Browse and pin collections"
+          }
+        />
+        <CatalogRow
+          icon={<TeamIcon />}
+          label="Teams"
+          count={teams.length}
+          onClick={teams.length > 0 ? onBrowseTeams : onNewTeam}
+          title={
+            teams.length === 0
+              ? "Create a team to share assets with the right people"
+              : "Browse and pin teams"
+          }
+        />
+        {repoAssets !== null && (
+          <CatalogRow
+            icon={<RepoIcon />}
+            label="Repositories"
+            count={Object.keys(repoAssets).length}
+            onClick={onBrowseRepos}
+            title={
+              Object.keys(repoAssets).length === 0
+                ? "Assets scoped to repositories will show up here"
+                : "Browse and pin repositories"
+            }
+          />
         )}
 
         {/* Extension-contributed tools live under ONE collapsed TOOLS
@@ -455,14 +453,82 @@ export default function Sidebar({
   );
 }
 
-function BrowseRow({ label, onClick }: { label: string; onClick: () => void }) {
+/** One catalog's browse entry: icon, name, count — the whole catalog
+ * (and its create button) lives behind it in the browse view, keeping
+ * the sidebar to pins while the count preserves the at-a-glance scope
+ * cue. An empty catalog's click goes straight to create. */
+function CatalogRow({
+  icon,
+  label,
+  count,
+  onClick,
+  title,
+}: {
+  icon: ReactNode;
+  label: string;
+  count: number;
+  onClick: () => void;
+  title: string;
+}) {
   return (
     <button
       onClick={onClick}
-      className="w-full rounded-lg px-2 py-1.5 text-left text-xs text-ink-faint transition hover:bg-canvas hover:text-ink"
+      title={title}
+      className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] text-ink-soft transition hover:bg-canvas hover:text-ink"
     >
-      {label}
+      {icon}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="text-xs tabular-nums text-ink-faint">{count}</span>
     </button>
+  );
+}
+
+// Type icons for the mixed PINNED list (and the matching BROWSE rows):
+// monochrome, inherit the row's text color, familiar shapes only —
+// folder = collection, people = team, branch = repository.
+function typeIcon(children: ReactNode): ReactNode {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3.5 w-3.5 shrink-0 opacity-70"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {children}
+    </svg>
+  );
+}
+
+function CollectionIcon() {
+  return typeIcon(
+    <path d="M1.75 4.25c0-.55.45-1 1-1h3.1l1.4 1.5h5a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H2.75a1 1 0 0 1-1-1z" />,
+  );
+}
+
+function TeamIcon() {
+  return typeIcon(
+    <>
+      <circle cx="5.5" cy="4.5" r="2" />
+      <path d="M1.75 13c.35-2.2 1.9-3.5 3.75-3.5s3.4 1.3 3.75 3.5" />
+      <path d="M10.5 2.9a2 2 0 0 1 0 3.9" />
+      <path d="M11.5 9.7c1.6.4 2.6 1.6 2.85 3.3" />
+    </>,
+  );
+}
+
+function RepoIcon() {
+  return typeIcon(
+    <>
+      <circle cx="4.5" cy="3.5" r="1.75" />
+      <circle cx="4.5" cy="12.5" r="1.75" />
+      <circle cx="11.5" cy="3.5" r="1.75" />
+      <path d="M4.5 5.25v5.5" />
+      <path d="M11.5 5.25c0 2.75-2.75 3.5-4.75 3.75" />
+    </>,
   );
 }
 
@@ -480,26 +546,35 @@ function Row({
   active,
   onClick,
   accent,
+  icon,
+  onUnpin,
 }: {
   label: string;
   count?: number;
   active: boolean;
   onClick: () => void;
   accent?: "amber";
+  icon?: ReactNode;
+  /** Hover affordance on PINNED rows: the count yields to a slashed
+   * pin. A span, not a nested button — buttons can't nest. */
+  onUnpin?: () => void;
 }) {
   return (
     <button
       onClick={onClick}
-      className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition ${
+      className={`group flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition ${
         active
           ? "bg-accent-soft font-medium text-accent"
           : "text-ink-soft hover:bg-canvas hover:text-ink"
       }`}
     >
+      {icon}
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {count !== undefined && (
         <span
           className={`text-xs tabular-nums ${
+            onUnpin ? "group-hover:hidden " : ""
+          }${
             accent === "amber" && !active
               ? "rounded-full bg-amber-50 px-1.5 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
               : "text-ink-faint"
@@ -508,6 +583,47 @@ function Row({
           {count}
         </span>
       )}
+      {onUnpin && (
+        <span
+          role="button"
+          aria-label={`Unpin ${label}`}
+          title="Unpin from sidebar"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnpin();
+          }}
+          className="hidden text-ink-faint transition hover:text-accent group-hover:inline-flex"
+        >
+          <PinIcon slashed />
+        </span>
+      )}
     </button>
+  );
+}
+
+/** Pin glyph (map-tack). `filled` marks pinned state on the scope
+ * toolbar toggle; `slashed` is the sidebar's hover-unpin affordance. */
+export function PinIcon({
+  filled,
+  slashed,
+}: {
+  filled?: boolean;
+  slashed?: boolean;
+}) {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3.5 w-3.5 shrink-0"
+      viewBox="0 0 16 16"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M5.5 2.5h5l-.75 4 2.25 2.5v1h-8v-1L6.25 6.5z" />
+      <path d="M8 10v3.5" />
+      {slashed && <path d="M2.5 2.5l11 11" />}
+    </svg>
   );
 }

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -258,11 +258,9 @@ export default function Sidebar({
                 key={"collection:" + c.name}
                 data-drop-collection={c.name}
                 onMouseDown={(e) => onCollectionDragHandle(c.name, e)}
-                className={
-                  dropCollection === c.name
-                    ? "rounded-lg ring-2 ring-accent"
-                    : undefined
-                }
+                className={`group relative ${
+                  dropCollection === c.name ? "rounded-lg ring-2 ring-accent" : ""
+                }`}
               >
                 <Row
                   icon={<CollectionIcon />}
@@ -270,7 +268,11 @@ export default function Sidebar({
                   count={(c.assets ?? []).length}
                   active={active === "collection:" + c.name}
                   onClick={() => onScope({ kind: "collection", name: c.name })}
-                  onUnpin={() => onUnpin("collections", c.name)}
+                  countYieldsOnHover
+                />
+                <UnpinButton
+                  label={c.name}
+                  onClick={() => onUnpin("collections", c.name)}
                 />
               </div>
             ))}
@@ -278,11 +280,9 @@ export default function Sidebar({
               <div
                 key={"team:" + t.name}
                 data-drop-team={t.name}
-                className={
-                  dropTeam === t.name
-                    ? "rounded-lg ring-2 ring-accent"
-                    : undefined
-                }
+                className={`group relative ${
+                  dropTeam === t.name ? "rounded-lg ring-2 ring-accent" : ""
+                }`}
               >
                 <Row
                   icon={<TeamIcon />}
@@ -290,7 +290,11 @@ export default function Sidebar({
                   count={teamAssetCounts[t.name] ?? 0}
                   active={active === "team:" + t.name}
                   onClick={() => onScope({ kind: "team", name: t.name })}
-                  onUnpin={() => onUnpin("teams", t.name)}
+                  countYieldsOnHover
+                />
+                <UnpinButton
+                  label={t.name}
+                  onClick={() => onUnpin("teams", t.name)}
                 />
               </div>
             ))}
@@ -300,11 +304,9 @@ export default function Sidebar({
                 title={url}
                 data-drop-repo={url}
                 onMouseDown={(e) => onRepoDragHandle(url, e)}
-                className={
-                  dropRepo === url
-                    ? "rounded-lg ring-2 ring-accent"
-                    : undefined
-                }
+                className={`group relative ${
+                  dropRepo === url ? "rounded-lg ring-2 ring-accent" : ""
+                }`}
               >
                 <Row
                   icon={<RepoIcon />}
@@ -312,7 +314,11 @@ export default function Sidebar({
                   count={(repoAssets?.[url] ?? []).length}
                   active={active === "repo:" + url}
                   onClick={() => onScope({ kind: "repo", name: url })}
-                  onUnpin={() => onUnpin("repos", url)}
+                  countYieldsOnHover
+                />
+                <UnpinButton
+                  label={repoLabel(url)}
+                  onClick={() => onUnpin("repos", url)}
                 />
               </div>
             ))}
@@ -547,7 +553,7 @@ function Row({
   onClick,
   accent,
   icon,
-  onUnpin,
+  countYieldsOnHover,
 }: {
   label: string;
   count?: number;
@@ -555,14 +561,15 @@ function Row({
   onClick: () => void;
   accent?: "amber";
   icon?: ReactNode;
-  /** Hover affordance on PINNED rows: the count yields to a slashed
-   * pin. A span, not a nested button — buttons can't nest. */
-  onUnpin?: () => void;
+  /** PINNED rows: fade the count on row hover so the sibling
+   * UnpinButton overlay (same spot) reads cleanly. Opacity, not
+   * display — the reserved width means no layout shift. */
+  countYieldsOnHover?: boolean;
 }) {
   return (
     <button
       onClick={onClick}
-      className={`group flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition ${
+      className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] transition ${
         active
           ? "bg-accent-soft font-medium text-accent"
           : "text-ink-soft hover:bg-canvas hover:text-ink"
@@ -572,8 +579,8 @@ function Row({
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {count !== undefined && (
         <span
-          className={`text-xs tabular-nums ${
-            onUnpin ? "group-hover:hidden " : ""
+          className={`text-xs tabular-nums transition-opacity ${
+            countYieldsOnHover ? "group-hover:opacity-0 " : ""
           }${
             accent === "amber" && !active
               ? "rounded-full bg-amber-50 px-1.5 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
@@ -583,20 +590,23 @@ function Row({
           {count}
         </span>
       )}
-      {onUnpin && (
-        <span
-          role="button"
-          aria-label={`Unpin ${label}`}
-          title="Unpin from sidebar"
-          onClick={(e) => {
-            e.stopPropagation();
-            onUnpin();
-          }}
-          className="hidden text-ink-faint transition hover:text-accent group-hover:inline-flex"
-        >
-          <PinIcon slashed />
-        </span>
-      )}
+    </button>
+  );
+}
+
+/** The hover/focus unpin affordance on PINNED rows. A real sibling
+ * button overlaying the count — never nested inside the row button
+ * (invalid interactive nesting), revealed by opacity so it stays in
+ * the tab order and focus-visible can show it to keyboard users. */
+function UnpinButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      aria-label={`Unpin ${label} from the sidebar`}
+      title="Unpin from sidebar"
+      onClick={onClick}
+      className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-ink-faint opacity-0 transition hover:text-accent focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
+    >
+      <PinIcon slashed />
     </button>
   );
 }

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -243,11 +243,11 @@ export default function Sidebar({
           );
         })}
 
-        {/* PINNED: quick access the user curated (plus the first-few
-            defaults until they pin), one flat mixed list — icons carry
-            the type. Drop targets and drag handles are unchanged, so
-            dragging an asset onto a pinned collection/team/repo still
-            works. Vanishes when empty; BROWSE below is always there. */}
+        {/* PINNED: quick access the user curated, one flat mixed list —
+            icons carry the type. Drop targets and drag handles are
+            unchanged, so dragging an asset onto a pinned collection/
+            team/repo still works. Vanishes when empty; BROWSE below is
+            always there. */}
         {hasPins && (
           <>
             <div className="mt-4">
@@ -580,9 +580,7 @@ function Row({
       {count !== undefined && (
         <span
           className={`text-xs tabular-nums transition-opacity ${
-            countYieldsOnHover
-              ? "group-hover:opacity-0 group-focus-within:opacity-0 "
-              : ""
+            countYieldsOnHover ? "group-hover:opacity-0 " : ""
           }${
             accent === "amber" && !active
               ? "rounded-full bg-amber-50 px-1.5 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
@@ -599,14 +597,17 @@ function Row({
 /** The hover/focus unpin affordance on PINNED rows. A real sibling
  * button overlaying the count — never nested inside the row button
  * (invalid interactive nesting), revealed by opacity so it stays in
- * the tab order and focus-visible can show it to keyboard users. */
+ * the tab order. Under keyboard focus it gets an opaque backing chip
+ * instead of fading the count: CSS can't scope the count's fade to
+ * THIS button's focus (it lives in the preceding sibling), and fading
+ * on any focus-within blanks the count when the row itself is tabbed. */
 function UnpinButton({ label, onClick }: { label: string; onClick: () => void }) {
   return (
     <button
       aria-label={`Unpin ${label} from the sidebar`}
       title="Unpin from sidebar"
       onClick={onClick}
-      className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-ink-faint opacity-0 transition hover:text-accent focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
+      className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-ink-faint opacity-0 transition hover:text-accent focus-visible:pointer-events-auto focus-visible:bg-surface focus-visible:opacity-100 focus-visible:shadow-sm group-hover:pointer-events-auto group-hover:opacity-100"
     >
       <PinIcon slashed />
     </button>

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -580,7 +580,9 @@ function Row({
       {count !== undefined && (
         <span
           className={`text-xs tabular-nums transition-opacity ${
-            countYieldsOnHover ? "group-hover:opacity-0 " : ""
+            countYieldsOnHover
+              ? "group-hover:opacity-0 group-focus-within:opacity-0 "
+              : ""
           }${
             accent === "amber" && !active
               ? "rounded-full bg-amber-50 px-1.5 text-amber-700 dark:bg-amber-950 dark:text-amber-300"

--- a/app/frontend/src/plugins/boot.ts
+++ b/app/frontend/src/plugins/boot.ts
@@ -6,9 +6,11 @@
 
 import {
   AppVersion,
+  CachedVaultPlugins,
   ListVaultPlugins,
   PluginDecisions,
 } from "../../wailsjs/go/main/App";
+import type { main } from "../../wailsjs/go/models";
 import {
   registerBuiltIn,
   registerVaultPlugin,
@@ -20,7 +22,12 @@ import {
   setAppVersion,
   unregisterVaultPlugin,
 } from "./host";
-import { hasConsent, loadPolicyAndConsents, policyBlocks } from "./policy";
+import {
+  hasConsent,
+  loadCachedPolicyAndConsents,
+  loadPolicyAndConsents,
+  policyBlocks,
+} from "./policy";
 import PublishDoctor, {
   publishDoctorManifest,
 } from "./builtins/publish-doctor";
@@ -101,27 +108,68 @@ export function syncVaultExtensions(): Promise<void> {
 
 async function doSyncVaultExtensions(): Promise<void> {
   // Drop the previous library's vault extensions entirely; built-ins
-  // stay registered and just re-evaluate against the new policy.
+  // stay registered and just re-evaluate against the new policy. (On
+  // plain boot this is a no-op; on a library switch the new profile's
+  // cache repopulates immediately below.)
   for (const p of listPlugins()) {
     if (!p.builtIn) unregisterVaultPlugin(p.manifest.id);
   }
-  await loadPolicyAndConsents();
 
-  // Vault-installed extensions: published like any asset, scoped to this
-  // user, surfaced ONLY in the Extensions screen. Default off; enabling
-  // is consent-gated below like everything else.
+  // FAST PATH: the cached policy plus cached copies of the vault's
+  // extensions register and enable before any vault I/O — built-ins
+  // included, which are otherwise gated on the policy round trip. On a
+  // remote vault the fresh listing below is the chattiest call in boot;
+  // waiting for it lands extension UI last and reflows everything.
+  // Bundles are immutable per revision, so cached copies are exact for
+  // unchanged extensions; staleness lasts one revalidation (an extension
+  // revoked since last boot runs for the seconds until the fresh listing
+  // prunes it — the same window policy-cache.json already accepts).
   try {
-    for (const vp of (await ListVaultPlugins()) ?? []) {
-      try {
-        registerVaultPlugin(parseVaultManifest(vp.manifest), vp.source, vp.scope);
-      } catch (e) {
-        console.error(`extension asset ${vp.assetName} rejected:`, e);
-      }
-    }
+    await loadCachedPolicyAndConsents();
+    registerListing((await CachedVaultPlugins()) ?? []);
+    await applyEnablement();
   } catch {
-    // Vault unreachable — built-ins still work.
+    // No usable cache — the fresh pass below is the first paint.
   }
 
+  // REVALIDATE: fresh policy, fresh listing (which rewrites the cache
+  // app-side). Same-revision extensions re-register as no-ops, so an
+  // unchanged vault causes zero UI churn; the enablement pass then
+  // applies the fresh policy (disabling anything newly blocked).
+  await loadPolicyAndConsents();
+  try {
+    registerListing((await ListVaultPlugins()) ?? []);
+  } catch {
+    // Vault unreachable — cached registrations (or built-ins) stand.
+  }
+  await applyEnablement();
+}
+
+/** Register one listing's extensions and prune vault extensions absent
+ * from it. Callers must pass a SUCCESSFUL listing: ListVaultPlugins
+ * throws on failure rather than returning empty, so a transient backend
+ * error never reads as "no extensions" and tears down what's running. */
+function registerListing(listed: main.VaultPlugin[]): void {
+  const seen = new Set<string>();
+  for (const vp of listed) {
+    try {
+      const manifest = parseVaultManifest(vp.manifest);
+      registerVaultPlugin(manifest, vp.source, vp.scope, vp.version);
+      seen.add(manifest.id);
+    } catch (e) {
+      console.error(`extension asset ${vp.assetName} rejected:`, e);
+    }
+  }
+  for (const p of listPlugins()) {
+    if (!p.builtIn && !seen.has(p.manifest.id)) {
+      unregisterVaultPlugin(p.manifest.id);
+    }
+  }
+}
+
+/** Enable/disable every registered extension per the current decisions,
+ * policy, and consents. */
+async function applyEnablement(): Promise<void> {
   let decisions: Record<string, boolean> = {};
   try {
     decisions = (await PluginDecisions()) ?? {};
@@ -158,28 +206,11 @@ async function doSyncVaultExtensions(): Promise<void> {
 /** Re-scan the vault for extensions (after install, remove, or a sharing
  * change). Upserts what the vault lists and drops vault extensions that
  * no longer reach this user — a remove or scope change must not leave a
- * stale row behind. The prune runs ONLY on a successful listing:
- * ListVaultPlugins throws on a listing failure rather than returning
- * empty, so a transient backend error lands in the catch below instead
- * of reading as "no extensions" and tearing down everything running. */
+ * stale row behind. The prune runs ONLY on a successful listing (see
+ * registerListing). */
 export async function refreshVaultPlugins(): Promise<void> {
   try {
-    const listed = (await ListVaultPlugins()) ?? [];
-    const seen = new Set<string>();
-    for (const vp of listed) {
-      try {
-        const manifest = parseVaultManifest(vp.manifest);
-        registerVaultPlugin(manifest, vp.source, vp.scope);
-        seen.add(manifest.id);
-      } catch (e) {
-        console.error(`extension asset ${vp.assetName} rejected:`, e);
-      }
-    }
-    for (const p of listPlugins()) {
-      if (!p.builtIn && !seen.has(p.manifest.id)) {
-        unregisterVaultPlugin(p.manifest.id);
-      }
-    }
+    registerListing((await ListVaultPlugins()) ?? []);
   } catch {
     // Listing failed — leave the registry as-is; the next boot or
     // refresh reconciles.

--- a/app/frontend/src/plugins/boot.ts
+++ b/app/frontend/src/plugins/boot.ts
@@ -129,7 +129,9 @@ async function doSyncVaultExtensions(): Promise<void> {
     registerListing((await CachedVaultPlugins()) ?? []);
     await applyEnablement();
   } catch {
-    // No usable cache — the fresh pass below is the first paint.
+    // An empty cache flows through the success path above; this guards
+    // the bridge itself being unavailable (dev browser without the
+    // backend) — the fresh pass below is then the first paint.
   }
 
   // REVALIDATE: fresh policy, fresh listing (which rewrites the cache

--- a/app/frontend/src/plugins/builtins/adoption-widget.ts
+++ b/app/frontend/src/plugins/builtins/adoption-widget.ts
@@ -4,7 +4,7 @@
 // or replace them individually.
 
 import type { PluginManifest, SxAPI, SxPlugin, ViewMount } from "../api";
-import { donut, headline } from "./charts";
+import { donut, headline, loadingSkeleton } from "./charts";
 
 export const adoptionWidgetManifest: PluginManifest = {
   id: "adoption-widget",
@@ -28,6 +28,7 @@ export default class AdoptionWidget implements SxPlugin {
   onunload(): void {}
 
   private async mount(sx: SxAPI, view: ViewMount): Promise<void> {
+    view.el.replaceChildren(loadingSkeleton());
     try {
       const stats = await sx.usage.userStats(30);
       const total = stats.knownUsers.length;

--- a/app/frontend/src/plugins/builtins/charts.ts
+++ b/app/frontend/src/plugins/builtins/charts.ts
@@ -29,6 +29,20 @@ export function headline(text: string): HTMLElement {
   return el;
 }
 
+/** Pulsing placeholder sized like a headline + chart, shown while a
+ * widget's data is on the wire — on a remote vault that's seconds, and
+ * an empty card that suddenly grows reads as broken. */
+export function loadingSkeleton(): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.className = "space-y-3 p-3";
+  const line = document.createElement("div");
+  line.className = "h-4 w-2/3 animate-pulse rounded bg-canvas";
+  const block = document.createElement("div");
+  block.className = "h-36 animate-pulse rounded-lg bg-canvas";
+  wrap.append(line, block);
+  return wrap;
+}
+
 /** Donut with two segments (e.g. with/without usage) plus a legend. */
 export function donut(
   a: { label: string; value: number; color: string; who?: string[] },

--- a/app/frontend/src/plugins/builtins/leaderboard-widget.ts
+++ b/app/frontend/src/plugins/builtins/leaderboard-widget.ts
@@ -2,7 +2,7 @@
 // top users by distinct assets used in the last 30 days.
 
 import type { PluginManifest, SxAPI, SxPlugin, ViewMount } from "../api";
-import { barList, CHART_COLORS, headline } from "./charts";
+import { barList, CHART_COLORS, headline, loadingSkeleton } from "./charts";
 
 export const leaderboardWidgetManifest: PluginManifest = {
   id: "leaderboard-widget",
@@ -28,6 +28,7 @@ export default class LeaderboardWidget implements SxPlugin {
   onunload(): void {}
 
   private async mount(sx: SxAPI, view: ViewMount): Promise<void> {
+    view.el.replaceChildren(loadingSkeleton());
     try {
       const stats = await sx.usage.userStats(30);
       const top = stats.active.slice(0, TOP_USERS);

--- a/app/frontend/src/plugins/builtins/usage-trends-widget.ts
+++ b/app/frontend/src/plugins/builtins/usage-trends-widget.ts
@@ -9,7 +9,13 @@ import type {
   UsageEvent,
   ViewMount,
 } from "../api";
-import { CHART_COLORS, headline, lineChart, type Series } from "./charts";
+import {
+  CHART_COLORS,
+  headline,
+  lineChart,
+  loadingSkeleton,
+  type Series,
+} from "./charts";
 
 export const usageTrendsWidgetManifest: PluginManifest = {
   id: "usage-trends-widget",
@@ -108,6 +114,7 @@ export default class UsageTrendsWidget implements SxPlugin {
   onunload(): void {}
 
   private async mount(sx: SxAPI, view: ViewMount): Promise<void> {
+    view.el.replaceChildren(loadingSkeleton());
     try {
       const events = await sx.usage.events(WINDOW_DAYS);
       const { labels, series, total, perDay, trendPct } = buildSeries(events);

--- a/app/frontend/src/plugins/host.ts
+++ b/app/frontend/src/plugins/host.ts
@@ -57,6 +57,9 @@ interface Registered {
   enabled: boolean;
   error?: string;
   scope?: ExtensionScope;
+  /** Vault revision the source came from — re-registration with the
+   * same revision is a no-op (same revision = identical bytes). */
+  version?: string;
 }
 
 const plugins = new Map<string, Registered>();
@@ -172,6 +175,7 @@ export function registerVaultPlugin(
   manifest: PluginManifest,
   source: string,
   scope?: ExtensionScope,
+  version?: string,
 ): void {
   const existing = plugins.get(manifest.id);
   if (existing?.builtIn) {
@@ -183,6 +187,16 @@ export function registerVaultPlugin(
     return;
   }
   if (existing) {
+    // Unchanged revision and scope: nothing to apply — skipping keeps
+    // revalidation (cached copy first, fresh listing after) from
+    // re-rendering every extension surface for identical bytes.
+    if (
+      version !== undefined &&
+      existing.version === version &&
+      sameScope(existing.scope, scope)
+    ) {
+      return;
+    }
     // Re-registration of a vault plugin is the normal refresh path
     // (marketplace install, publish, sync) — upsert, don't complain. A
     // running instance keeps its loaded code; the updated manifest and
@@ -191,6 +205,7 @@ export function registerVaultPlugin(
     existing.manifest = manifest;
     existing.make = () => importFromSource(source);
     existing.scope = scope;
+    existing.version = version;
     notify();
     return;
   }
@@ -200,8 +215,16 @@ export function registerVaultPlugin(
     make: () => importFromSource(source),
     enabled: false,
     scope,
+    version,
   });
   notify();
+}
+
+function sameScope(a?: ExtensionScope, b?: ExtensionScope): boolean {
+  if (!a || !b) return a === b;
+  return (
+    a.shared === b.shared && a.personal === b.personal && a.label === b.label
+  );
 }
 
 /** Drop a vault extension from the host entirely (its asset was removed

--- a/app/frontend/src/plugins/policy.ts
+++ b/app/frontend/src/plugins/policy.ts
@@ -3,6 +3,7 @@
 // re-prompted whenever an extension's declared permissions change.
 
 import {
+  CachedPluginPolicy,
   GetPluginPolicy,
   PluginConsents,
   SetPluginConsent,
@@ -27,6 +28,27 @@ export async function loadPolicyAndConsents(): Promise<void> {
   } catch {
     policy = { mode: "open", allowed: [] };
   }
+  await loadConsents();
+}
+
+/** The boot fast path's policy: the last successfully read policy from
+ * the local cache, no vault I/O — paired with cached extensions so
+ * enablement gates run before any network round trip. The fresh policy
+ * (loadPolicyAndConsents) re-evaluates seconds later. */
+export async function loadCachedPolicyAndConsents(): Promise<void> {
+  try {
+    const p = await CachedPluginPolicy();
+    policy = {
+      mode: (p.mode as PluginPolicy["mode"]) || "open",
+      allowed: p.allowed ?? [],
+    };
+  } catch {
+    policy = { mode: "open", allowed: [] };
+  }
+  await loadConsents();
+}
+
+async function loadConsents(): Promise<void> {
   try {
     consents = (await PluginConsents()) ?? {};
   } catch {

--- a/app/frontend/src/screens/Library.tsx
+++ b/app/frontend/src/screens/Library.tsx
@@ -48,7 +48,7 @@ import DraftSheet, { DraftSheetSkeleton } from "../components/DraftSheet";
 import Modal from "../components/Modal";
 import SettingsModal from "../components/SettingsModal";
 import ShareModal from "../components/ShareModal";
-import Sidebar, { repoLabel, Scope } from "../components/Sidebar";
+import Sidebar, { PinIcon, repoLabel, Scope } from "../components/Sidebar";
 import CommandPalette from "../components/CommandPalette";
 import Dashboard from "../components/Dashboard";
 import PluginMount from "../components/PluginMount";
@@ -1072,12 +1072,13 @@ export default function Library({
     [repoAssets],
   );
 
-  // Never-pinned libraries default to the first few so the sidebar isn't
-  // empty; an explicit pin/unpin takes over from there.
-  const shownCollectionPins =
-    pinnedCollections ?? collections.slice(0, 5).map((c) => c.name);
-  const shownTeamPins = pinnedTeams ?? teams.slice(0, 5).map((t) => t.name);
-  const shownRepoPins = pinnedRepos ?? repoUrls.slice(0, 5);
+  // Pins are explicit only: a never-pinned library shows no PINNED
+  // section at all (the BROWSE rows are the durable path in), instead
+  // of first-few defaults that read as pins the user never made.
+  // Creating a collection/team still auto-pins it (ensurePinned).
+  const shownCollectionPins = pinnedCollections ?? [];
+  const shownTeamPins = pinnedTeams ?? [];
+  const shownRepoPins = pinnedRepos ?? [];
 
   const teamAssetCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -1117,6 +1118,26 @@ export default function Library({
   function ensurePinned(kind: PinKind, name: string) {
     const current = pinShown[kind];
     if (!current.includes(name)) setPins(kind, [...current, name]);
+  }
+
+  // Pin state lives where you're looking at the thing: each scope's
+  // action bar (beside Rename/Manage/Delete) carries its pin toggle.
+  function scopePinButton(kind: PinKind, name: string) {
+    const isPinned = pinShown[kind].includes(name);
+    return (
+      <button
+        onClick={() => togglePin(kind, name)}
+        title={isPinned ? "Unpin from the sidebar" : "Pin to the sidebar"}
+        className={`flex items-center gap-1 rounded-md border bg-surface px-2.5 py-1 font-medium transition ${
+          isPinned
+            ? "border-accent/40 text-accent hover:border-accent"
+            : "border-line text-ink-soft hover:border-accent hover:text-ink"
+        }`}
+      >
+        <PinIcon filled={isPinned} />
+        {isPinned ? "Pinned" : "Pin"}
+      </button>
+    );
   }
 
   const visible = useMemo(() => {
@@ -1314,6 +1335,7 @@ export default function Library({
         pinnedCollections={shownCollectionPins}
         pinnedTeams={shownTeamPins}
         pinnedRepos={shownRepoPins}
+        onUnpin={togglePin}
         onNewCollection={() => setShowCollectionModal(true)}
         onNewTeam={() => setShowNewTeam(true)}
         onBrowseCollections={() => setBrowse("collections")}
@@ -1662,6 +1684,7 @@ export default function Library({
                   "Assets in this collection can be set up together."}
               </span>
               <div className="flex-1" />
+              {scopePinButton("collections", activeCollection.name)}
               <button
                 disabled={busyAction}
                 onClick={() => startRename("collection", activeCollection.name)}
@@ -1718,6 +1741,7 @@ export default function Library({
                 members
               </span>
               <div className="flex-1" />
+              {scopePinButton("teams", activeTeam.name)}
               <button
                 onClick={() => startRename("team", activeTeam.name)}
                 className="rounded-md border border-line bg-surface px-2.5 py-1 font-medium text-ink-soft transition hover:border-accent hover:text-ink"
@@ -1751,6 +1775,23 @@ export default function Library({
               >
                 Delete
               </button>
+            </div>
+          )}
+
+          {/* Repos have no rename/delete (they exist by being scoped
+              to), but their pin control lives in the same bar position
+              as collections' and teams'. */}
+          {scope.kind === "repo" && (
+            <div
+              className="flex items-center gap-3 border-t border-line bg-accent-soft/50 px-5 py-2 text-xs"
+              style={{ ["--wails-draggable" as never]: "no-drag" }}
+            >
+              <span className="min-w-0 truncate text-ink-soft" title={scope.name}>
+                {scope.name} · assets scoped to this repository install for
+                whoever works in it
+              </span>
+              <div className="flex-1" />
+              {scopePinButton("repos", scope.name)}
             </div>
           )}
         </header>

--- a/app/frontend/src/screens/Library.tsx
+++ b/app/frontend/src/screens/Library.tsx
@@ -548,21 +548,34 @@ export default function Library({
   useEffect(() => {
     if (assets === null || !loadedOnce.current) return;
     const timer = setTimeout(() => {
+      const key = `sx-boot:${vault.location}`;
+      const snapshot: BootSnapshot = {
+        assets,
+        collections,
+        teams,
+        teamAssets,
+        personalAssets,
+        repoAssets,
+      };
+      const json = JSON.stringify(snapshot);
       try {
-        const snapshot: BootSnapshot = {
-          assets,
-          collections,
-          teams,
-          teamAssets,
-          personalAssets,
-          repoAssets,
-        };
-        localStorage.setItem(
-          `sx-boot:${vault.location}`,
-          JSON.stringify(snapshot),
-        );
+        localStorage.setItem(key, json);
       } catch {
-        // Storage full or unavailable — the next boot just skeletons.
+        // Quota pressure: other libraries' snapshots are the growth
+        // (one per vault, never visited again = never rewritten), so
+        // evict them and retry once. The library in use wins; a second
+        // failure means storage is genuinely unavailable and the next
+        // boot just skeletons.
+        try {
+          for (const k of Object.keys(localStorage)) {
+            if (k.startsWith("sx-boot:") && k !== key) {
+              localStorage.removeItem(k);
+            }
+          }
+          localStorage.setItem(key, json);
+        } catch {
+          // Storage unavailable — nothing to persist.
+        }
       }
     }, 800);
     return () => clearTimeout(timer);

--- a/app/frontend/src/screens/Library.tsx
+++ b/app/frontend/src/screens/Library.tsx
@@ -44,7 +44,7 @@ import AddAssetModal from "../components/AddAssetModal";
 import AssetDetail from "../components/AssetDetail";
 import BrowseModal from "../components/BrowseModal";
 import CollectionModal from "../components/CollectionModal";
-import DraftSheet from "../components/DraftSheet";
+import DraftSheet, { DraftSheetSkeleton } from "../components/DraftSheet";
 import Modal from "../components/Modal";
 import SettingsModal from "../components/SettingsModal";
 import ShareModal from "../components/ShareModal";
@@ -184,6 +184,9 @@ export default function Library({
   const searchRef = useRef<HTMLInputElement>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [openDraft, setOpenDraft] = useState<main.Draft | null>(null);
+  // True while a draft is being created or fetched from the vault —
+  // renders the sheet's skeleton so the click responds immediately.
+  const [openingDraft, setOpeningDraft] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [sidebarWidth, startSidebarResize] = usePanelSize(
     "sx-panel-sidebar",
@@ -655,12 +658,14 @@ export default function Library({
       // in-app row drags that carry no files — ignore those.
       const real = (paths ?? []).filter((p) => p);
       if (real.length === 0) return;
+      setOpeningDraft(true);
       CreateDraftFromPaths(real)
         .then((draft) => {
           setOpenDraft(draft);
           load();
         })
-        .catch((e) => setToastMessage(String(e)));
+        .catch((e) => setToastMessage(String(e)))
+        .finally(() => setOpeningDraft(false));
     }, false);
     const over = (e: DragEvent) => {
       // Only external file drags get the drop overlay — in-app asset
@@ -1105,6 +1110,7 @@ export default function Library({
   }, [drafts, query, scope]);
 
   async function editAsset(name: string) {
+    setOpeningDraft(true);
     try {
       const draft = await CreateDraftFromAsset(name);
       setSelected(null);
@@ -1112,14 +1118,19 @@ export default function Library({
       load();
     } catch (e) {
       setToastMessage(String(e));
+    } finally {
+      setOpeningDraft(false);
     }
   }
 
   async function openExistingDraft(id: string) {
+    setOpeningDraft(true);
     try {
       setOpenDraft(await GetDraft(id));
     } catch (e) {
       setToastMessage(String(e));
+    } finally {
+      setOpeningDraft(false);
     }
   }
 
@@ -2217,6 +2228,8 @@ export default function Library({
           onCollectionsChanged={load}
         />
       )}
+
+      {openingDraft && !openDraft && <DraftSheetSkeleton />}
 
       {openDraft && (
         <DraftSheet

--- a/app/frontend/src/screens/Library.tsx
+++ b/app/frontend/src/screens/Library.tsx
@@ -80,6 +80,30 @@ function readPins(kind: PinKind, location: string): string[] | null {
   }
 }
 
+/** The last boot's list data, persisted per library. Seeding state from
+ * it renders the sidebar and list in their final shape immediately —
+ * on a remote vault the fresh responses land seconds apart and would
+ * otherwise assemble the sidebar section by section, shoving everything
+ * below each arrival. Stale entries correct themselves silently when
+ * the fresh data replaces them (identical data changes nothing). */
+interface BootSnapshot {
+  assets: main.AssetCard[];
+  collections: main.Collection[];
+  teams: main.TeamInfo[];
+  teamAssets: Record<string, string[]>;
+  personalAssets: string[];
+  repoAssets: Record<string, string[]> | null;
+}
+
+function readBootSnapshot(location: string): BootSnapshot | null {
+  try {
+    const raw = localStorage.getItem(`sx-boot:${location}`);
+    return raw ? (JSON.parse(raw) as BootSnapshot) : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Library: a source-list sidebar (scopes + collections) and one scrollable
  * content pane. List view is the default — dense rows scan better than
@@ -92,17 +116,28 @@ export default function Library({
   vault: main.VaultInfo;
   onVaultChanged: () => void;
 }) {
-  const [assets, setAssets] = useState<main.AssetCard[] | null>(null);
+  // Seed list state from the persisted snapshot (Library remounts per
+  // vault, so the seed always matches this library).
+  const [boot] = useState(() => readBootSnapshot(vault.location));
+  const [assets, setAssets] = useState<main.AssetCard[] | null>(
+    boot?.assets ?? null,
+  );
   const [drafts, setDrafts] = useState<main.Draft[]>([]);
-  const [collections, setCollections] = useState<main.Collection[]>([]);
-  const [teams, setTeams] = useState<main.TeamInfo[]>([]);
-  const [teamAssets, setTeamAssets] = useState<Record<string, string[]>>({});
+  const [collections, setCollections] = useState<main.Collection[]>(
+    boot?.collections ?? [],
+  );
+  const [teams, setTeams] = useState<main.TeamInfo[]>(boot?.teams ?? []);
+  const [teamAssets, setTeamAssets] = useState<Record<string, string[]>>(
+    boot?.teamAssets ?? {},
+  );
   // Assets installed just for this user — drives the sidebar's
   // conditional "My skills" row and its scope filter.
-  const [personalAssets, setPersonalAssets] = useState<string[]>([]);
+  const [personalAssets, setPersonalAssets] = useState<string[]>(
+    boot?.personalAssets ?? [],
+  );
   // Repo URL → asset names; null when this library doesn't track repos.
   const [repoAssets, setRepoAssets] = useState<Record<string, string[]> | null>(
-    null,
+    boot?.repoAssets ?? null,
   );
   const [openTeam, setOpenTeam] = useState<main.TeamInfo | null>(null);
   const [showNewTeam, setShowNewTeam] = useState(false);
@@ -442,6 +477,9 @@ export default function Library({
   // only the very first load falls back to empty (with the error shown).
   const loadGen = useRef(0);
   const loadedOnce = useRef(false);
+  // Snapshot-seeded state counts as "something on screen": a failed
+  // first load keeps it (with the error banner) instead of blanking it.
+  const seeded = useRef(boot !== null);
   const load = useCallback(() => {
     const gen = ++loadGen.current;
     const apply =
@@ -452,7 +490,8 @@ export default function Library({
     const applyFallback =
       <T,>(setter: (v: T) => void, fallback: T) =>
       () => {
-        if (gen === loadGen.current && !loadedOnce.current) setter(fallback);
+        if (gen === loadGen.current && !loadedOnce.current && !seeded.current)
+          setter(fallback);
       };
     setError("");
     ListAssets()
@@ -468,7 +507,7 @@ export default function Library({
         if (gen !== loadGen.current) return;
         if (!loadedOnce.current) {
           setError(String(e));
-          setAssets([]);
+          if (!seeded.current) setAssets([]);
         }
       });
     ListDrafts().then(apply(setDrafts)).catch(applyFallback(setDrafts, []));
@@ -499,6 +538,43 @@ export default function Library({
   useEffect(() => {
     loadRef.current = load;
   }, [load]);
+
+  // Write-through for the boot snapshot: whenever the list data settles,
+  // persist it so the NEXT boot paints this shape immediately. Debounced
+  // — the boot fetches land seconds apart and each would otherwise
+  // serialize ~the whole library. Gated on loadedOnce (a REAL listing
+  // succeeded this session): a failed first load sets assets to [] and
+  // must not persist "empty library" over a good snapshot.
+  useEffect(() => {
+    if (assets === null || !loadedOnce.current) return;
+    const timer = setTimeout(() => {
+      try {
+        const snapshot: BootSnapshot = {
+          assets,
+          collections,
+          teams,
+          teamAssets,
+          personalAssets,
+          repoAssets,
+        };
+        localStorage.setItem(
+          `sx-boot:${vault.location}`,
+          JSON.stringify(snapshot),
+        );
+      } catch {
+        // Storage full or unavailable — the next boot just skeletons.
+      }
+    }, 800);
+    return () => clearTimeout(timer);
+  }, [
+    assets,
+    collections,
+    teams,
+    teamAssets,
+    personalAssets,
+    repoAssets,
+    vault.location,
+  ]);
 
   // Extension system: boot once, and hand extensions the app's real UI
   // services (toast + confirm) so sx.ui works.

--- a/app/frontend/wailsjs/go/main/App.d.ts
+++ b/app/frontend/wailsjs/go/main/App.d.ts
@@ -21,6 +21,10 @@ export function AppVersion():Promise<string>;
 
 export function AvailableRepoName(arg1:string):Promise<string>;
 
+export function CachedPluginPolicy():Promise<main.PluginPolicy>;
+
+export function CachedVaultPlugins():Promise<Array<main.VaultPlugin>>;
+
 export function CanInstallForEveryone():Promise<boolean>;
 
 export function CancelSleuthLogin():Promise<void>;

--- a/app/frontend/wailsjs/go/main/App.js
+++ b/app/frontend/wailsjs/go/main/App.js
@@ -38,6 +38,14 @@ export function AvailableRepoName(arg1) {
   return window['go']['main']['App']['AvailableRepoName'](arg1);
 }
 
+export function CachedPluginPolicy() {
+  return window['go']['main']['App']['CachedPluginPolicy']();
+}
+
+export function CachedVaultPlugins() {
+  return window['go']['main']['App']['CachedVaultPlugins']();
+}
+
 export function CanInstallForEveryone() {
   return window['go']['main']['App']['CanInstallForEveryone']();
 }

--- a/app/frontend/wailsjs/go/models.ts
+++ b/app/frontend/wailsjs/go/models.ts
@@ -748,6 +748,7 @@ export namespace main {
 	}
 	export class VaultPlugin {
 	    assetName: string;
+	    version: string;
 	    manifest: string;
 	    source: string;
 	    scope: ExtensionScope;
@@ -759,6 +760,7 @@ export namespace main {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.assetName = source["assetName"];
+	        this.version = source["version"];
 	        this.manifest = source["manifest"];
 	        this.source = source["source"];
 	        this.scope = this.convertValues(source["scope"], ExtensionScope);

--- a/app/plugin_cache.go
+++ b/app/plugin_cache.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+// Extension cache: local copies of the vault's extensions (manifest +
+// code + scope, keyed by asset name and vault revision) so boot serves
+// extension UI before any network round trip — on a remote vault the
+// listing is the chattiest call in startup and extensions otherwise
+// arrive last, reflowing the UI. Extension bundles are immutable per
+// revision, so "same revision → same bytes" is exact, and revalidation
+// (a fresh ListVaultPlugins) rewrites the cache on every successful
+// listing. Per profile, beside decisions/consents/policy-cache; the
+// accepted staleness window matches policy-cache.json: a revoked
+// extension can run for the seconds until revalidation prunes it.
+
+// extensionCacheDir is <config>/app-plugins/<profile>/extensions-cache.
+func (a *App) extensionCacheDir() (string, error) {
+	dir, err := a.pluginDataDir()
+	if err != nil {
+		return "", err
+	}
+	cacheDir := filepath.Join(dir, "extensions-cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", err
+	}
+	return cacheDir, nil
+}
+
+// CachedVaultPlugins returns the last successful ListVaultPlugins result
+// from the local cache — no vault I/O. Corrupt or oversized entries are
+// skipped; an empty result just means the fresh listing is the first
+// paint. Never errors: the fast path degrades to "no cache", it doesn't
+// break boot.
+func (a *App) CachedVaultPlugins() []VaultPlugin {
+	out := []VaultPlugin{}
+	dir, err := a.extensionCacheDir()
+	if err != nil {
+		return out
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var p VaultPlugin
+		if err := json.Unmarshal(data, &p); err != nil {
+			continue
+		}
+		// The same gates the live listing applies: a cache file must not
+		// smuggle in what ListVaultPlugins would have rejected.
+		if p.AssetName == "" || p.Manifest == "" || p.Source == "" {
+			continue
+		}
+		if len(p.Source) > maxPluginSourceBytes {
+			continue
+		}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AssetName < out[j].AssetName })
+	return out
+}
+
+// writeExtensionCache replaces the cache with a successful listing:
+// upserts every entry and prunes files for extensions no longer listed.
+// Best-effort — a cache write failure must never fail the listing.
+func (a *App) writeExtensionCache(plugins []VaultPlugin) {
+	dir, err := a.extensionCacheDir()
+	if err != nil {
+		return
+	}
+	keep := map[string]bool{}
+	for _, p := range plugins {
+		// The asset name becomes a filename; the same guard every asset
+		// entry point uses keeps a hostile name from becoming a path.
+		if err := validateAssetRef(p.AssetName, ""); err != nil {
+			continue
+		}
+		data, err := json.Marshal(p)
+		if err != nil {
+			continue
+		}
+		file := p.AssetName + ".json"
+		if atomicWriteFile(filepath.Join(dir, file), data) == nil {
+			keep[file] = true
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") && !keep[e.Name()] {
+			_ = os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+}
+
+// CachedPluginPolicy returns the last successfully read extension policy
+// without touching the vault — the boot fast path pairs it with
+// CachedVaultPlugins so enablement gates run before any network I/O.
+// No cache falls back to open, matching GetPluginPolicy's fallback.
+func (a *App) CachedPluginPolicy() PluginPolicy {
+	open := PluginPolicy{Mode: vaultpkg.AppPluginModeOpen, Allowed: []string{}}
+	return a.cachedPluginPolicy(open)
+}

--- a/app/plugin_cache_test.go
+++ b/app/plugin_cache_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+func TestExtensionCacheRoundTrip(t *testing.T) {
+	a := pluginTestApp(t)
+
+	// Empty cache reads as an empty list, never an error.
+	if got := a.CachedVaultPlugins(); len(got) != 0 {
+		t.Fatalf("empty cache = %+v", got)
+	}
+
+	one := VaultPlugin{
+		AssetName: "hello-team",
+		Version:   "1.0",
+		Manifest:  `{"id":"hello-team"}`,
+		Source:    "export default class {}",
+		Scope:     ExtensionScope{Shared: true, Label: "Everyone"},
+	}
+	two := VaultPlugin{
+		AssetName: "other",
+		Version:   "3.0",
+		Manifest:  `{"id":"other"}`,
+		Source:    "export default class {}",
+	}
+	a.writeExtensionCache([]VaultPlugin{two, one})
+
+	got := a.CachedVaultPlugins()
+	if len(got) != 2 || got[0].AssetName != "hello-team" || got[1].AssetName != "other" {
+		t.Fatalf("cache = %+v; want hello-team, other (sorted)", got)
+	}
+	if got[0].Version != "1.0" || !got[0].Scope.Shared || got[0].Scope.Label != "Everyone" {
+		t.Fatalf("cached entry lost fields: %+v", got[0])
+	}
+
+	// A later listing without an extension prunes its cache file.
+	a.writeExtensionCache([]VaultPlugin{one})
+	if got := a.CachedVaultPlugins(); len(got) != 1 || got[0].AssetName != "hello-team" {
+		t.Fatalf("after prune = %+v; want hello-team only", got)
+	}
+
+	// A path-shaped asset name must not become a path.
+	a.writeExtensionCache([]VaultPlugin{
+		{AssetName: "../evil", Version: "1", Manifest: "{}", Source: "x"},
+	})
+	if got := a.CachedVaultPlugins(); len(got) != 0 {
+		t.Fatalf("path-shaped name cached: %+v", got)
+	}
+}
+
+func TestCachedVaultPluginsSkipsBadEntries(t *testing.T) {
+	a := pluginTestApp(t)
+	dir, err := a.extensionCacheDir()
+	if err != nil {
+		t.Fatalf("cache dir: %v", err)
+	}
+
+	// Corrupt JSON, an incomplete entry, and an oversized source are all
+	// skipped — the fast path degrades, it never breaks boot.
+	if err := os.WriteFile(filepath.Join(dir, "corrupt.json"), []byte("{nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "empty.json"), []byte(`{"assetName":"empty"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	huge := VaultPlugin{
+		AssetName: "huge",
+		Version:   "1",
+		Manifest:  "{}",
+		Source:    strings.Repeat("x", maxPluginSourceBytes+1),
+	}
+	a.writeExtensionCache([]VaultPlugin{huge})
+	if got := a.CachedVaultPlugins(); len(got) != 0 {
+		t.Fatalf("bad entries served: %d", len(got))
+	}
+}
+
+func TestCachedPluginPolicy(t *testing.T) {
+	a := pluginTestApp(t)
+
+	// No cache: open, matching GetPluginPolicy's fallback.
+	p := a.CachedPluginPolicy()
+	if p.Mode != vaultpkg.AppPluginModeOpen || len(p.Allowed) != 0 {
+		t.Fatalf("no-cache policy = %+v; want open", p)
+	}
+
+	a.cachePluginPolicy(PluginPolicy{Mode: "allowlist", Allowed: []string{"hello-team"}})
+	p = a.CachedPluginPolicy()
+	if p.Mode != "allowlist" || len(p.Allowed) != 1 || p.Allowed[0] != "hello-team" {
+		t.Fatalf("cached policy = %+v", p)
+	}
+}
+
+// A successful ListVaultPlugins IS the cache: the next boot serves the
+// same extensions (revision included) without touching the vault.
+func TestListVaultPluginsWritesCache(t *testing.T) {
+	a := pluginTestApp(t)
+	vdir := t.TempDir()
+	runGitCmd(t, vdir, "init")
+	runGitCmd(t, vdir, "config", "user.email", "alice@example.com")
+	runGitCmd(t, vdir, "config", "user.name", "Alice")
+	v, err := vaultpkg.NewPathVault("file://" + vdir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	a.vault = v
+	a.ctx = context.Background()
+
+	src := t.TempDir()
+	if err := os.WriteFile(src+"/plugin.json", []byte(`{"id":"hello-team","name":"Hello Team","version":"1.0.0","description":"Demo.","permissions":["commands"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src+"/main.js", []byte("export default class { onload(sx) {} }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := a.addExtensionFrom(src); err != nil {
+		t.Fatalf("addExtensionFrom: %v", err)
+	}
+
+	listed, err := a.ListVaultPlugins()
+	if err != nil || len(listed) != 1 {
+		t.Fatalf("ListVaultPlugins = %+v err=%v", listed, err)
+	}
+	if listed[0].Version == "" {
+		t.Fatalf("listing carries no revision: %+v", listed[0])
+	}
+
+	cached := a.CachedVaultPlugins()
+	if len(cached) != 1 || cached[0].AssetName != "hello-team" {
+		t.Fatalf("cache after listing = %+v", cached)
+	}
+	if cached[0].Version != listed[0].Version || cached[0].Source != listed[0].Source {
+		t.Fatalf("cache diverges from listing: %+v vs %+v", cached[0], listed[0])
+	}
+}

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -673,6 +673,7 @@ func (a *App) addExtensionFrom(dir string) (string, string, error) {
 // receives it (for scope chips and the remove/share actions).
 type VaultPlugin struct {
 	AssetName string         `json:"assetName"`
+	Version   string         `json:"version"`  // vault revision — the extension cache's key
 	Manifest  string         `json:"manifest"` // raw plugin.json
 	Source    string         `json:"source"`   // bundled ES module (entry file)
 	Scope     ExtensionScope `json:"scope"`
@@ -717,7 +718,7 @@ func (a *App) ListVaultPlugins() ([]VaultPlugin, error) {
 		if !scope.Shared && !scope.Personal {
 			continue // installed just for someone else
 		}
-		plugin, err := a.loadVaultPlugin(summary.Name)
+		plugin, err := a.loadVaultPlugin(summary.Name, summary.LatestVersion)
 		if err != nil {
 			logger.Get().Warn("skipping malformed extension asset", "asset", summary.Name, "error", err)
 			continue
@@ -725,11 +726,45 @@ func (a *App) ListVaultPlugins() ([]VaultPlugin, error) {
 		plugin.Scope = scope
 		out = append(out, plugin)
 	}
+	// A successful listing IS the cache: next boot serves these copies
+	// before any vault I/O (CachedVaultPlugins) and revalidates against
+	// a listing like this one.
+	a.writeExtensionCache(out)
 	return out, nil
 }
 
-func (a *App) loadVaultPlugin(name string) (VaultPlugin, error) {
-	zipData, err := a.latestAssetZip(name)
+// vaultPluginZip fetches an extension bundle and reports which revision
+// the bytes are — the extension cache's key. The listing's version skips
+// the per-asset GetVersionList round trip; an empty or stale version
+// falls back to resolving the newest revision, so a listing/fetch
+// mismatch costs an extra round trip instead of a skipped extension.
+func (a *App) vaultPluginZip(name, version string) ([]byte, string, error) {
+	v, err := a.currentVault()
+	if err != nil {
+		return nil, "", err
+	}
+	if version != "" {
+		if zipData, err := v.GetAssetByVersion(a.ctx, name, version); err == nil {
+			return zipData, version, nil
+		}
+	}
+	versions, err := v.GetVersionList(a.ctx, name)
+	if err != nil {
+		return nil, "", friendlyVaultError(err)
+	}
+	if len(versions) == 0 {
+		return nil, "", fmt.Errorf("%s has no versions", name)
+	}
+	latest := versions[len(versions)-1]
+	zipData, err := v.GetAssetByVersion(a.ctx, name, latest)
+	if err != nil {
+		return nil, "", friendlyVaultError(err)
+	}
+	return zipData, latest, nil
+}
+
+func (a *App) loadVaultPlugin(name, version string) (VaultPlugin, error) {
+	zipData, resolved, err := a.vaultPluginZip(name, version)
 	if err != nil {
 		return VaultPlugin{}, err
 	}
@@ -752,6 +787,7 @@ func (a *App) loadVaultPlugin(name string) (VaultPlugin, error) {
 	}
 	return VaultPlugin{
 		AssetName: name,
+		Version:   resolved,
 		Manifest:  string(manifestBytes),
 		Source:    string(source),
 	}, nil

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -744,9 +744,15 @@ func (a *App) vaultPluginZip(name, version string) ([]byte, string, error) {
 		return nil, "", err
 	}
 	if version != "" {
-		if zipData, err := v.GetAssetByVersion(a.ctx, name, version); err == nil {
+		zipData, err := v.GetAssetByVersion(a.ctx, name, version)
+		if err == nil {
 			return zipData, version, nil
 		}
+		// Fall back to resolving latest — but keep the cause visible: a
+		// persistent auth/network failure here would otherwise hide as a
+		// silent extra round trip on every listing.
+		logger.Get().Debug("extension fetch by listed version failed; resolving latest",
+			"asset", name, "version", version, "error", err)
 	}
 	versions, err := v.GetVersionList(a.ctx, name)
 	if err != nil {

--- a/app/settings.go
+++ b/app/settings.go
@@ -695,9 +695,13 @@ func (a *App) deleteGitHubRepo(repoURL string) error {
 }
 
 // PickDirectory opens the native folder picker (for new local libraries).
+// CanCreateDirectories puts macOS's "New Folder" button in the panel —
+// a new library usually WANTS a fresh empty folder, and without the
+// flag the user has to leave the app to make one.
 func (a *App) PickDirectory() (string, error) {
 	dir, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
-		Title: "Choose a folder for the library",
+		Title:                "Choose a folder for the library",
+		CanCreateDirectories: true,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
- Add loading skeletons everywhere remote-vault responses used to pop in: dashboard widgets, the asset detail sharing row, revision switches (dim instead of blank), draft opening, the repo picker, and the share modal
- Cache vault extensions locally (per profile, keyed by asset name + vault revision) so boot registers and enables extension UI before any vault I/O, then revalidates against a fresh listing; extensions keep working from cache when the vault is unreachable
- Seed the sidebar and skill list from a per-library boot snapshot (localStorage, written only after a successful listing) — boot goes from 7 layout shifts over ~8s to 2 micro-shifts inside 330ms on a skills.new vault
- Consolidate the sidebar: one flat PINNED section (type icons, hover-unpin, hidden until first pin) replaces the collections/teams/repositories sections; count-bearing BROWSE rows open the full catalogs; each scope's action bar gets a pin toggle
- Show macOS's New Folder button in the local-library folder picker (CanCreateDirectories)

**Security implications of changes have been considered**