### PR TITLE
SK-669: Fix deep-link reset under StrictMode

### DIFF
--- a/app/frontend/src/components/AssetDetail.tsx
+++ b/app/frontend/src/components/AssetDetail.tsx
@@ -67,23 +67,18 @@ export default function AssetDetail({
   // A deep-link nonce is consumed exactly once: a name change without a
   // fresh nonce resets to the content view, so plain list clicks never
   // inherit a previously-requested tab.
-  const consumedTabNonce = useRef(0);
+  // Idempotent on purpose: StrictMode double-runs effects, so a
+  // consume-once ref would apply the tab and then immediately reset it.
+  // Staleness is handled at the source instead — Library clears the
+  // deep-link when the panel closes, and a name mismatch resets here.
   useEffect(() => {
-    if (pluginTab && pluginTab.name === name && pluginTab.nonce !== consumedTabNonce.current) {
-      consumedTabNonce.current = pluginTab.nonce;
+    if (pluginTab && pluginTab.name === name) {
       setActiveTab(pluginTab.tab);
     } else {
       setActiveTab("");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name]);
-  useEffect(() => {
-    if (pluginTab && pluginTab.name === name && pluginTab.nonce !== consumedTabNonce.current) {
-      consumedTabNonce.current = pluginTab.nonce;
-      setActiveTab(pluginTab.tab);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pluginTab?.nonce]);
+  }, [name, pluginTab?.nonce]);
   const currentTab = assetTabs.find(
     (t) => t.pluginId + ":" + t.spec.id === activeTab,
   );

--- a/app/frontend/src/screens/Library.tsx
+++ b/app/frontend/src/screens/Library.tsx
@@ -2345,7 +2345,10 @@ export default function Library({
           teams={teams}
           installed={installed.has(selected)}
           installedScopes={installedScopes.get(selected) ?? []}
-          onClose={() => setSelected(null)}
+          onClose={() => {
+            setSelected(null);
+            setPluginTab(null);
+          }}
           onEdit={() => void editAsset(selected)}
           onDelete={() => {
             const name = selected;


### PR DESCRIPTION
Follow-up to the \`openAsset(name, {tab})\` deep link (ee59364, which landed on \`2.2\` directly — a push.default=upstream slip on my side; it's review-covered by #192): the consume-once nonce ref applied the requested tab and then immediately reset it when StrictMode double-ran the effect, so deep links always landed on the content view in dev.

The effect is idempotent now (same result on every run); staleness is handled at the source instead — Library clears the deep-link when the panel closes, and a name mismatch resets to the content view. Verified live: dashboard row click lands on the Evals tab.

Base \`2.2\`, flows into #192. \`make prepush\` green, frontend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)