### PR TITLE
SK-670: Fix vault migrate for namespaced assets

### DIFF
--- a/internal/vault/migratev2.go
+++ b/internal/vault/migratev2.go
@@ -85,12 +85,34 @@ func v1AssetDirNames(vaultRoot string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A name that is simultaneously an asset and a namespace prefix
+	// ("opsx" alongside "opsx/apply") has no correct migration: moving
+	// opsx as an asset archives apply/ as a phantom version, and treating
+	// it as a namespace strands opsx's own versions. Refuse rather than
+	// silently pick one interpretation.
+	if conflict := assetNamespaceConflict(manifestNames); conflict != "" {
+		return nil, fmt.Errorf("manifest declares %q both as an asset and as a namespace prefix of other assets; rename one of them before migrating", conflict)
+	}
 	var names []string
 	if err := collectV1AssetDirNames(vaultRoot, "", manifestNames, &names); err != nil {
 		return nil, err
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+// assetNamespaceConflict returns a declared asset name that is also a
+// namespace prefix of another declared name (e.g. "opsx" when both "opsx"
+// and "opsx/apply" exist), or "" when there is no conflict.
+func assetNamespaceConflict(names map[string]bool) string {
+	for name := range names {
+		for i := len(name) - 1; i > 0; i-- {
+			if name[i] == '/' && names[name[:i]] {
+				return name[:i]
+			}
+		}
+	}
+	return ""
 }
 
 // manifestAssetNameSet returns the set of asset names declared in the
@@ -130,7 +152,7 @@ func collectV1AssetDirNames(vaultRoot, prefix string, manifestNames map[string]b
 		// namespace has an archive directory of its own (holding the
 		// children already moved), which must not hide the children
 		// still waiting under assets/{rel}.
-		if isV1NamespaceDir(vaultRoot, rel, manifestNames) {
+		if isNamespaceDir(filepath.Join(vaultRoot, "assets"), rel, manifestNames) {
 			if err := collectV1AssetDirNames(vaultRoot, rel, manifestNames, names); err != nil {
 				return err
 			}
@@ -158,15 +180,27 @@ func collectV1AssetDirNames(vaultRoot, prefix string, manifestNames map[string]b
 	return nil
 }
 
-// isV1NamespaceDir reports whether assets/{rel} is a namespace directory —
+// isNamespaceDir reports whether {baseDir}/{rel} is a namespace directory —
 // a path segment of namespaced asset names (e.g. "opsx" for "opsx/apply") —
-// rather than an asset directory. The manifest is the primary signal: a
-// declared asset name is always an asset, and declared names nested under
-// rel make it a namespace. On-disk shape settles undeclared directories: a
-// directory holding its own list.txt is an asset, one whose children hold
-// list.txt files is a namespace, and anything else defaults to asset,
-// matching the pre-namespace behavior.
-func isV1NamespaceDir(vaultRoot, rel string, manifestNames map[string]bool) bool {
+// rather than an asset directory. baseDir is the tree being classified:
+// the v1 assets root or the v2 archive root. The manifest is the primary
+// signal: a declared asset name is always an asset, and declared names
+// nested under rel make it a namespace (a name that is both is rejected
+// up front by assetNamespaceConflict). On-disk shape settles undeclared
+// directories:
+//
+//   - rel holding its own list.txt → asset.
+//   - a child holding list.txt → the children are assets → namespace.
+//   - no list.txt anywhere: a version directory holds the asset's files
+//     directly, while an asset directory holds only version
+//     subdirectories. So a child with regular files at its root marks
+//     rel an asset, and file-less children with subdirectories mark it
+//     a namespace. (An asset whose EVERY version dir has no root files
+//     — no metadata.toml, no prompt file — would be misread as a
+//     namespace, but such an asset has nothing recognizable to migrate
+//     anyway.)
+//   - anything else defaults to asset, matching pre-namespace behavior.
+func isNamespaceDir(baseDir, rel string, manifestNames map[string]bool) bool {
 	if manifestNames[rel] {
 		return false
 	}
@@ -175,7 +209,7 @@ func isV1NamespaceDir(vaultRoot, rel string, manifestNames map[string]bool) bool
 			return true
 		}
 	}
-	dir := filepath.Join(vaultRoot, "assets", filepath.FromSlash(rel))
+	dir := filepath.Join(baseDir, filepath.FromSlash(rel))
 	if _, err := os.Stat(filepath.Join(dir, "list.txt")); err == nil {
 		return false
 	}
@@ -183,15 +217,37 @@ func isV1NamespaceDir(vaultRoot, rel string, manifestNames map[string]bool) bool
 	if err != nil {
 		return false
 	}
+	anyChildFile := false
+	anyChildSubdirOnly := false
 	for _, entry := range filterScanEntries(entries) {
 		if !entry.IsDir() {
 			continue
 		}
-		if _, err := os.Stat(filepath.Join(dir, entry.Name(), "list.txt")); err == nil {
-			return true
+		childEntries, err := os.ReadDir(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		hasFile, hasSubdir := false, false
+		for _, ce := range filterScanEntries(childEntries) {
+			if ce.IsDir() {
+				hasSubdir = true
+				continue
+			}
+			if ce.Name() == "list.txt" {
+				return true
+			}
+			hasFile = true
+		}
+		if hasFile {
+			anyChildFile = true
+		} else if hasSubdir {
+			anyChildSubdirOnly = true
 		}
 	}
-	return false
+	if anyChildFile {
+		return false
+	}
+	return anyChildSubdirOnly
 }
 
 // dirHasSubdirectories reports whether dir contains at least one
@@ -365,7 +421,7 @@ func refreshRootViewsUnder(vaultRoot string, v2 layout.Layout, prefix string, ma
 			continue
 		}
 		rel := path.Join(prefix, entry.Name())
-		if isArchiveNamespaceDir(vaultRoot, rel, manifestNames) {
+		if isNamespaceDir(filepath.Join(vaultRoot, ".sx", "versions"), rel, manifestNames) {
 			if err := refreshRootViewsUnder(vaultRoot, v2, rel, manifestNames); err != nil {
 				return err
 			}
@@ -376,39 +432,6 @@ func refreshRootViewsUnder(vaultRoot string, v2 layout.Layout, prefix string, ma
 		}
 	}
 	return nil
-}
-
-// isArchiveNamespaceDir reports whether .sx/versions/{rel} is a namespace
-// directory holding nested asset archives rather than an asset's own
-// archive. Mirrors isV1NamespaceDir: manifest names are the primary signal,
-// the directory's own list.txt marks an asset, and children with list.txt
-// mark a namespace.
-func isArchiveNamespaceDir(vaultRoot, rel string, manifestNames map[string]bool) bool {
-	if manifestNames[rel] {
-		return false
-	}
-	for name := range manifestNames {
-		if strings.HasPrefix(name, rel+"/") {
-			return true
-		}
-	}
-	dir := filepath.Join(vaultRoot, ".sx", "versions", filepath.FromSlash(rel))
-	if _, err := os.Stat(filepath.Join(dir, "list.txt")); err == nil {
-		return false
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, entry := range filterScanEntries(entries) {
-		if !entry.IsDir() {
-			continue
-		}
-		if _, err := os.Stat(filepath.Join(dir, entry.Name(), "list.txt")); err == nil {
-			return true
-		}
-	}
-	return false
 }
 
 // ensureMigrated runs the storage migration on a path vault before a

--- a/internal/vault/migratev2.go
+++ b/internal/vault/migratev2.go
@@ -190,7 +190,11 @@ func collectV1AssetDirNames(vaultRoot, prefix string, manifestNames map[string]b
 // directories:
 //
 //   - rel holding its own list.txt → asset.
-//   - a child holding list.txt → the children are assets → namespace.
+//   - a child holding list.txt BESIDE subdirectories (the v1 asset-dir
+//     signature) → the children are assets → namespace. A lone list.txt
+//     with no sibling subdirectories is treated as version-dir payload,
+//     not a signal — though an undeclared version dir that bundles both
+//     a payload list.txt and payload subdirectories can still trip this.
 //   - no list.txt anywhere: a version directory holds the asset's files
 //     directly, while an asset directory holds only version
 //     subdirectories. So a child with regular files at its root marks
@@ -227,18 +231,26 @@ func isNamespaceDir(baseDir, rel string, manifestNames map[string]bool) bool {
 		if err != nil {
 			continue
 		}
-		hasFile, hasSubdir := false, false
+		hasFile, hasSubdir, hasList := false, false, false
 		for _, ce := range filterScanEntries(childEntries) {
 			if ce.IsDir() {
 				hasSubdir = true
 				continue
 			}
 			if ce.Name() == "list.txt" {
-				return true
+				hasList = true
+				continue
 			}
 			hasFile = true
 		}
-		if hasFile {
+		// A list.txt BESIDE version subdirectories is the v1 asset-dir
+		// signature — the child is an asset, so rel is a namespace. A
+		// list.txt with no subdirectories next to it is just a payload
+		// file inside a version directory and counts as a regular file.
+		if hasList && hasSubdir {
+			return true
+		}
+		if hasFile || hasList {
 			anyChildFile = true
 		} else if hasSubdir {
 			anyChildSubdirOnly = true
@@ -416,8 +428,12 @@ func refreshRootViewsUnder(vaultRoot string, v2 layout.Layout, prefix string, ma
 		}
 		return err
 	}
-	for _, entry := range entries {
-		if !entry.IsDir() || utils.IsSyncArtifact(entry.Name()) {
+	// filterScanEntries, not just an IsSyncArtifact check: the scan side
+	// uses it too, and it additionally skips numbered sync-conflict copies
+	// ("apply 2") — refreshing one of those would materialize a phantom
+	// root view for the conflict copy.
+	for _, entry := range filterScanEntries(entries) {
+		if !entry.IsDir() {
 			continue
 		}
 		rel := path.Join(prefix, entry.Name())

--- a/internal/vault/migratev2.go
+++ b/internal/vault/migratev2.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -74,22 +75,70 @@ func planStorageMigration(vaultRoot string) (*MigrationPlan, error) {
 
 // v1AssetDirNames lists the asset directories under assets/ that hold v1
 // version storage (i.e. have not been converted to a v2 root view yet).
+// Namespaced asset names ("opsx/apply") live in nested directories: each
+// directory is classified as an asset or a namespace segment, and namespaces
+// are recursed into rather than migrated as assets themselves — treating a
+// namespace directory as an asset would archive its child assets as phantom
+// versions.
 func v1AssetDirNames(vaultRoot string) ([]string, error) {
-	entries, err := os.ReadDir(filepath.Join(vaultRoot, "assets"))
+	manifestNames, err := manifestAssetNameSet(vaultRoot)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read assets directory: %w", err)
+		return nil, err
 	}
 	var names []string
+	if err := collectV1AssetDirNames(vaultRoot, "", manifestNames, &names); err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// manifestAssetNameSet returns the set of asset names declared in the
+// vault's manifest, or an empty set when there is no manifest.
+func manifestAssetNameSet(vaultRoot string) (map[string]bool, error) {
+	m, ok, err := manifest.Load(vaultRoot)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[string]bool)
+	if ok {
+		for i := range m.Assets {
+			names[m.Assets[i].Name] = true
+		}
+	}
+	return names, nil
+}
+
+// collectV1AssetDirNames scans one level of the assets/ tree, appending the
+// slash-separated names of migratable v1 asset directories and recursing
+// into namespace directories. prefix is the slash-separated path scanned so
+// far ("" for the assets/ root).
+func collectV1AssetDirNames(vaultRoot, prefix string, manifestNames map[string]bool, names *[]string) error {
+	entries, err := os.ReadDir(filepath.Join(vaultRoot, "assets", filepath.FromSlash(prefix)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read assets directory: %w", err)
+	}
 	for _, entry := range filterScanEntries(entries) {
 		if !entry.IsDir() {
 			continue
 		}
+		rel := path.Join(prefix, entry.Name())
+		// Classify before the archived check: a partially migrated
+		// namespace has an archive directory of its own (holding the
+		// children already moved), which must not hide the children
+		// still waiting under assets/{rel}.
+		if isV1NamespaceDir(vaultRoot, rel, manifestNames) {
+			if err := collectV1AssetDirNames(vaultRoot, rel, manifestNames, names); err != nil {
+				return err
+			}
+			continue
+		}
 		// An existing archive for this asset means a prior (interrupted)
-		// migration already moved it; assets/{name} is its root view now.
-		archived := filepath.Join(vaultRoot, ".sx", "versions", entry.Name())
+		// migration already moved it; assets/{rel} is its root view now.
+		archived := filepath.Join(vaultRoot, ".sx", "versions", filepath.FromSlash(rel))
 		if _, err := os.Stat(archived); err == nil {
 			continue
 		}
@@ -97,17 +146,52 @@ func v1AssetDirNames(vaultRoot string) ([]string, error) {
 		// are migratable. Anything else — an empty folder, a hand-made
 		// directory of loose files — is left in place untouched rather
 		// than moved somewhere it can never be completed from.
-		hasVersions, err := dirHasSubdirectories(filepath.Join(vaultRoot, "assets", entry.Name()))
+		hasVersions, err := dirHasSubdirectories(filepath.Join(vaultRoot, "assets", filepath.FromSlash(rel)))
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if !hasVersions {
 			continue
 		}
-		names = append(names, entry.Name())
+		*names = append(*names, rel)
 	}
-	sort.Strings(names)
-	return names, nil
+	return nil
+}
+
+// isV1NamespaceDir reports whether assets/{rel} is a namespace directory —
+// a path segment of namespaced asset names (e.g. "opsx" for "opsx/apply") —
+// rather than an asset directory. The manifest is the primary signal: a
+// declared asset name is always an asset, and declared names nested under
+// rel make it a namespace. On-disk shape settles undeclared directories: a
+// directory holding its own list.txt is an asset, one whose children hold
+// list.txt files is a namespace, and anything else defaults to asset,
+// matching the pre-namespace behavior.
+func isV1NamespaceDir(vaultRoot, rel string, manifestNames map[string]bool) bool {
+	if manifestNames[rel] {
+		return false
+	}
+	for name := range manifestNames {
+		if strings.HasPrefix(name, rel+"/") {
+			return true
+		}
+	}
+	dir := filepath.Join(vaultRoot, "assets", filepath.FromSlash(rel))
+	if _, err := os.Stat(filepath.Join(dir, "list.txt")); err == nil {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range filterScanEntries(entries) {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, entry.Name(), "list.txt")); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // dirHasSubdirectories reports whether dir contains at least one
@@ -255,7 +339,21 @@ func ensureVersionList(vaultRoot string, v2 layout.Layout, name string) error {
 // refreshAllRootViews re-materializes the root view of every archived asset.
 // Used to complete interrupted migrations and repair root-view drift.
 func refreshAllRootViews(vaultRoot string, v2 layout.Layout) error {
-	entries, err := os.ReadDir(filepath.Join(vaultRoot, ".sx", "versions"))
+	manifestNames, err := manifestAssetNameSet(vaultRoot)
+	if err != nil {
+		return err
+	}
+	return refreshRootViewsUnder(vaultRoot, v2, "", manifestNames)
+}
+
+// refreshRootViewsUnder refreshes the root views of the archived assets one
+// level below .sx/versions/{prefix}, recursing into namespace directories.
+// A namespace directory (a segment of namespaced asset names like "opsx"
+// for "opsx/apply") must never be refreshed as an asset itself: it has no
+// list.txt, so refreshRootView would read an empty version list and delete
+// every child root view under assets/{prefix}.
+func refreshRootViewsUnder(vaultRoot string, v2 layout.Layout, prefix string, manifestNames map[string]bool) error {
+	entries, err := os.ReadDir(filepath.Join(vaultRoot, ".sx", "versions", filepath.FromSlash(prefix)))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -266,11 +364,51 @@ func refreshAllRootViews(vaultRoot string, v2 layout.Layout) error {
 		if !entry.IsDir() || utils.IsSyncArtifact(entry.Name()) {
 			continue
 		}
-		if err := refreshRootView(vaultRoot, v2, entry.Name()); err != nil {
+		rel := path.Join(prefix, entry.Name())
+		if isArchiveNamespaceDir(vaultRoot, rel, manifestNames) {
+			if err := refreshRootViewsUnder(vaultRoot, v2, rel, manifestNames); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := refreshRootView(vaultRoot, v2, rel); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// isArchiveNamespaceDir reports whether .sx/versions/{rel} is a namespace
+// directory holding nested asset archives rather than an asset's own
+// archive. Mirrors isV1NamespaceDir: manifest names are the primary signal,
+// the directory's own list.txt marks an asset, and children with list.txt
+// mark a namespace.
+func isArchiveNamespaceDir(vaultRoot, rel string, manifestNames map[string]bool) bool {
+	if manifestNames[rel] {
+		return false
+	}
+	for name := range manifestNames {
+		if strings.HasPrefix(name, rel+"/") {
+			return true
+		}
+	}
+	dir := filepath.Join(vaultRoot, ".sx", "versions", filepath.FromSlash(rel))
+	if _, err := os.Stat(filepath.Join(dir, "list.txt")); err == nil {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range filterScanEntries(entries) {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, entry.Name(), "list.txt")); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // ensureMigrated runs the storage migration on a path vault before a

--- a/internal/vault/migratev2_test.go
+++ b/internal/vault/migratev2_test.go
@@ -484,6 +484,83 @@ func TestMigrateStorageToV2NamespaceByDiskShape(t *testing.T) {
 	mustNotExist(t, filepath.Join(dir, ".sx", "versions", "tools", "list.txt"))
 }
 
+func TestMigrateStorageToV2UndeclaredNamespaceWithoutListTxt(t *testing.T) {
+	dir := t.TempDir()
+	seedV1Vault(t, dir)
+
+	// A namespaced asset neither declared in the manifest nor carrying any
+	// list.txt: classification must fall back to the version-shape signal
+	// (file-less children that hold subdirectories are asset-shaped, so the
+	// parent is a namespace).
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("assets/bare/fmt/1/COMMAND.md", "# bare/fmt")
+	write("assets/bare/lint/1/COMMAND.md", "# bare/lint")
+
+	result, err := migrateStorageToV2(dir, "alice@example.com")
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if result == nil || result.Assets != 4 {
+		t.Fatalf("result = %+v, want 4 assets migrated", result)
+	}
+	for _, rel := range []string{
+		".sx/versions/bare/fmt/1/COMMAND.md",
+		".sx/versions/bare/fmt/list.txt", // synthesized by ensureVersionList
+		".sx/versions/bare/lint/1/COMMAND.md",
+		"assets/bare/fmt/COMMAND.md",
+		"assets/bare/lint/COMMAND.md",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Errorf("missing after migration: %s (%v)", rel, err)
+		}
+	}
+	// "bare" itself must not have been archived as an asset with fmt/lint
+	// as phantom versions.
+	mustNotExist(t, filepath.Join(dir, ".sx", "versions", "bare", "list.txt"))
+}
+
+func TestMigrateStorageToV2AssetNamespaceConflictErrors(t *testing.T) {
+	dir := t.TempDir()
+	seedV1Vault(t, dir)
+
+	// Declare a name that is both an asset and a namespace prefix. There is
+	// no correct migration for this shape, so both the plan and the
+	// migration must refuse with an actionable error.
+	m, _, err := manifest.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Assets = append(m.Assets,
+		manifest.Asset{Name: "chat/sub", Version: "1", Type: asset.TypeCommand,
+			SourcePath: &manifest.SourcePath{Path: "./assets/chat/sub/1"}},
+	)
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := func(err error) {
+		t.Helper()
+		if err == nil || !strings.Contains(err.Error(), `"chat"`) {
+			t.Fatalf("err = %v, want conflict error naming \"chat\"", err)
+		}
+	}
+	_, err = planStorageMigration(dir)
+	wantErr(err)
+	_, err = migrateStorageToV2(dir, "alice@example.com")
+	wantErr(err)
+	// Refused means untouched: nothing may have been archived.
+	mustNotExist(t, filepath.Join(dir, ".sx", "versions"))
+}
+
 func TestMigrateStorageToV2SkipsSyncConflictDirs(t *testing.T) {
 	dir := t.TempDir()
 	seedV1Vault(t, dir)

--- a/internal/vault/migratev2_test.go
+++ b/internal/vault/migratev2_test.go
@@ -312,6 +312,178 @@ func TestMigrateStorageToV2LeavesNonAssetDirsInPlace(t *testing.T) {
 	}
 }
 
+// seedV1NamespacedVault builds a v1 vault whose manifest declares namespaced
+// asset names (names with a "/", e.g. "opsx/apply") plus one top-level asset.
+// There is no bare "opsx" asset: assets/opsx is only a namespace directory.
+func seedV1NamespacedVault(t *testing.T, dir string) {
+	t.Helper()
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var assets []manifest.Asset
+	for _, c := range []string{"apply", "archive", "explore", "propose"} {
+		write("assets/opsx/"+c+"/1/COMMAND.md", "# opsx/"+c)
+		write("assets/opsx/"+c+"/1/metadata.toml", "[asset]\nname = \"opsx/"+c+"\"\nversion = \"1\"\ntype = \"command\"\n")
+		write("assets/opsx/"+c+"/list.txt", "1\n")
+		assets = append(assets, manifest.Asset{
+			Name: "opsx/" + c, Version: "1", Type: asset.TypeCommand,
+			SourcePath: &manifest.SourcePath{Path: "./assets/opsx/" + c + "/1"},
+		})
+	}
+	write("assets/plain/1/SKILL.md", "# plain")
+	write("assets/plain/1/metadata.toml", "[asset]\nname = \"plain\"\nversion = \"1\"\ntype = \"skill\"\n")
+	write("assets/plain/list.txt", "1\n")
+	assets = append(assets, manifest.Asset{
+		Name: "plain", Version: "1", Type: asset.TypeSkill,
+		SourcePath: &manifest.SourcePath{Path: "./assets/plain/1"},
+	})
+
+	if err := manifest.Save(dir, &manifest.Manifest{SchemaVersion: 1, Assets: assets}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMigrateStorageToV2NamespacedAssets(t *testing.T) {
+	dir := t.TempDir()
+	seedV1NamespacedVault(t, dir)
+
+	plan, err := planStorageMigration(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(plan.Assets, ",") != "opsx/apply,opsx/archive,opsx/explore,opsx/propose,plain" {
+		t.Errorf("plan assets = %v", plan.Assets)
+	}
+
+	result, err := migrateStorageToV2(dir, "alice@example.com")
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if result == nil || result.Assets != 5 {
+		t.Fatalf("result = %+v, want 5 assets migrated", result)
+	}
+
+	// Each namespaced asset is archived individually with its own list.txt,
+	// and gets a root view like every top-level asset.
+	for _, c := range []string{"apply", "archive", "explore", "propose"} {
+		for _, rel := range []string{
+			".sx/versions/opsx/" + c + "/1/COMMAND.md",
+			".sx/versions/opsx/" + c + "/list.txt",
+			"assets/opsx/" + c + "/COMMAND.md",
+		} {
+			if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+				t.Errorf("missing after migration: %s (%v)", rel, err)
+			}
+		}
+	}
+
+	// The namespace directory itself must not be treated as an asset: no
+	// version list of asset names, no phantom root view.
+	mustNotExist(t, filepath.Join(dir, ".sx", "versions", "opsx", "list.txt"))
+	mustNotExist(t, filepath.Join(dir, "assets", "opsx", "list.txt"))
+	mustNotExist(t, filepath.Join(dir, "assets", "opsx", "1"))
+
+	// Manifest source paths follow the archive.
+	m, _, err := manifest.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []string{"apply", "archive", "explore", "propose"} {
+		a := m.FindAsset("opsx/" + c)
+		if a == nil || a.SourcePath == nil || a.SourcePath.Path != ".sx/versions/opsx/"+c+"/1" {
+			t.Errorf("opsx/%s source path = %+v", c, a)
+		}
+	}
+
+	// A rerun (which re-refreshes all root views) reports up-to-date and
+	// must not delete the namespaced root views.
+	if _, err := migrateStorageToV2(dir, "alice@example.com"); !errors.Is(err, ErrStorageUpToDate) {
+		t.Errorf("second migration err = %v, want ErrStorageUpToDate", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "assets", "opsx", "apply", "COMMAND.md")); err != nil {
+		t.Errorf("namespaced root view lost on rerun: %v", err)
+	}
+}
+
+func TestMigrateStorageToV2NamespacedResume(t *testing.T) {
+	dir := t.TempDir()
+	seedV1NamespacedVault(t, dir)
+
+	// Simulate an interrupted earlier run: "opsx/apply" was archived but the
+	// process died before its root view was materialized.
+	if err := os.MkdirAll(filepath.Join(dir, ".sx", "versions", "opsx"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(
+		filepath.Join(dir, "assets", "opsx", "apply"),
+		filepath.Join(dir, ".sx", "versions", "opsx", "apply"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := migrateStorageToV2(dir, "alice@example.com")
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// apply was already moved; the other four are fresh moves.
+	if result == nil || result.Assets != 4 {
+		t.Fatalf("result = %+v, want 4 freshly moved assets", result)
+	}
+	for _, c := range []string{"apply", "archive", "explore", "propose"} {
+		if _, err := os.Stat(filepath.Join(dir, "assets", "opsx", c, "COMMAND.md")); err != nil {
+			t.Errorf("opsx/%s root view missing after resume: %v", c, err)
+		}
+	}
+	mustNotExist(t, filepath.Join(dir, ".sx", "versions", "opsx", "list.txt"))
+}
+
+func TestMigrateStorageToV2NamespaceByDiskShape(t *testing.T) {
+	dir := t.TempDir()
+	seedV1Vault(t, dir)
+
+	// A namespaced asset present on disk but NOT declared in the manifest:
+	// classification must fall back to shape (children holding list.txt).
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("assets/tools/fmt/1/COMMAND.md", "# tools/fmt")
+	write("assets/tools/fmt/1/metadata.toml", "[asset]\nname = \"tools/fmt\"\nversion = \"1\"\ntype = \"command\"\n")
+	write("assets/tools/fmt/list.txt", "1\n")
+
+	result, err := migrateStorageToV2(dir, "alice@example.com")
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if result == nil || result.Assets != 3 {
+		t.Fatalf("result = %+v, want 3 assets migrated", result)
+	}
+	for _, rel := range []string{
+		".sx/versions/tools/fmt/1/COMMAND.md",
+		".sx/versions/tools/fmt/list.txt",
+		"assets/tools/fmt/COMMAND.md",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Errorf("missing after migration: %s (%v)", rel, err)
+		}
+	}
+	mustNotExist(t, filepath.Join(dir, ".sx", "versions", "tools", "list.txt"))
+}
+
 func TestMigrateStorageToV2SkipsSyncConflictDirs(t *testing.T) {
 	dir := t.TempDir()
 	seedV1Vault(t, dir)

--- a/internal/vault/migratev2_test.go
+++ b/internal/vault/migratev2_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
+	"github.com/sleuth-io/sx/internal/vault/layout"
 )
 
 // seedV1Vault builds a v1-format vault: exploded version dirs + list.txt
@@ -588,4 +589,86 @@ func TestMigrateStorageToV2SkipsSyncConflictDirs(t *testing.T) {
 		t.Errorf("conflicted dir was moved or lost: %v", err)
 	}
 	mustNotExist(t, filepath.Join(dir, ".sx", "versions", conflictDir))
+}
+
+func TestRefreshRootViewsSkipsNumberedConflictCopies(t *testing.T) {
+	dir := t.TempDir()
+	seedV1Vault(t, dir)
+	if _, err := migrateStorageToV2(dir, "alice@example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A numbered sync-conflict copy of an asset's archive ("chat (2)") left
+	// by a cloud-sync client. The root-view refresh must skip it with the
+	// same filtering the scan side uses — refreshing it would materialize
+	// a phantom root view at assets/chat (2).
+	if err := os.MkdirAll(filepath.Join(dir, ".sx", "versions", "chat (2)", "1.0"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".sx", "versions", "chat (2)", "list.txt"), []byte("1.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".sx", "versions", "chat (2)", "1.0", "SKILL.md"), []byte("junk"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	v2, err := layout.ForVersion(layout.V2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := refreshAllRootViews(dir, v2); err != nil {
+		t.Fatalf("refreshAllRootViews: %v", err)
+	}
+	mustNotExist(t, filepath.Join(dir, "assets", "chat (2)"))
+	// Real assets still refresh normally.
+	if _, err := os.Stat(filepath.Join(dir, "assets", "chat", "SKILL.md")); err != nil {
+		t.Errorf("real root view lost: %v", err)
+	}
+}
+
+func TestMigrateStorageToV2PayloadListTxtIsNotNamespaceSignal(t *testing.T) {
+	dir := t.TempDir()
+	seedV1Vault(t, dir)
+
+	// An undeclared asset with no top-level list.txt whose version dir
+	// bundles a payload file literally named list.txt. The lone list.txt
+	// (no sibling subdirectories) must read as version-dir payload, so
+	// "bundler" migrates as ONE asset — not as a namespace with "1" as a
+	// phantom sub-asset.
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("assets/bundler/1/SKILL.md", "# bundler")
+	write("assets/bundler/1/list.txt", "payload, not a version list")
+
+	result, err := migrateStorageToV2(dir, "alice@example.com")
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if result == nil || result.Assets != 3 {
+		t.Fatalf("result = %+v, want 3 assets migrated", result)
+	}
+	for _, rel := range []string{
+		".sx/versions/bundler/1/SKILL.md",
+		".sx/versions/bundler/1/list.txt",
+		".sx/versions/bundler/list.txt",
+		"assets/bundler/SKILL.md",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Errorf("missing after migration: %s (%v)", rel, err)
+		}
+	}
+	// The version dir must not have become a phantom sub-asset with its
+	// own root view.
+	mustNotExist(t, filepath.Join(dir, ".sx", "versions", "bundler", "1", "1"))
+	if _, err := os.Stat(filepath.Join(dir, "assets", "bundler", "1", "SKILL.md")); !os.IsNotExist(err) {
+		t.Errorf("assets/bundler/1 root view should not exist (err=%v)", err)
+	}
 }

--- a/internal/vault/storage.go
+++ b/internal/vault/storage.go
@@ -84,8 +84,10 @@ func refreshRootView(vaultRoot string, l layout.Layout, name string) error {
 		}
 	}
 	// PID-suffixed so two processes sharing a path vault never fight over
-	// the same staging directory.
-	stagingDir := filepath.Join(vaultRoot, l.AssetsRoot(), fmt.Sprintf(".%s.staging-%d", name, os.Getpid()))
+	// the same staging directory. Namespaced names ("opsx/apply") are
+	// flattened so the staging dir stays directly under assets/.
+	stagingName := strings.ReplaceAll(name, "/", "-")
+	stagingDir := filepath.Join(vaultRoot, l.AssetsRoot(), fmt.Sprintf(".%s.staging-%d", stagingName, os.Getpid()))
 	if err := os.RemoveAll(stagingDir); err != nil {
 		return err
 	}
@@ -94,6 +96,12 @@ func refreshRootView(vaultRoot string, l layout.Layout, name string) error {
 		return fmt.Errorf("failed to stage root view for %s: %w", name, err)
 	}
 	if err := os.RemoveAll(viewDir); err != nil {
+		_ = os.RemoveAll(stagingDir)
+		return err
+	}
+	// A namespaced asset's view lives in a nested directory that may not
+	// exist yet (assets/opsx/ for "opsx/apply").
+	if err := os.MkdirAll(filepath.Dir(viewDir), 0755); err != nil {
 		_ = os.RemoveAll(stagingDir)
 		return err
 	}


### PR DESCRIPTION
## Summary
- Classify directories under `assets/` as asset vs. namespace during the v1→v2 scan (manifest names first, then on-disk shape) and recurse into namespaces
- Migrate each namespaced asset (e.g. `opsx/apply`) individually: own archive dir, own `list.txt`, manifest source path rewritten
- Never treat a namespace dir as an asset — no more phantom root view or `list.txt` full of asset names
- Materialize root views for namespaced assets (they previously got none)
- Fix `refreshRootView` for names containing `/` (staging dir name, missing parent dir on rename)

Fixes #189

**Security implications of changes have been considered**