### PR TITLE
SK-671: Update manifest row in place on republish (PR 1 of 2)

### DIFF
--- a/internal/commands/add_already_installed_test.go
+++ b/internal/commands/add_already_installed_test.go
@@ -23,6 +23,40 @@ import (
 // the absence of the bug's wording, so that future copy changes don't
 // silently regress the behavior.
 
+// assertRepublishedVersion asserts the manifest/archive state after
+// republishing an edited asset: the manifest holds exactly ONE row for the
+// asset (a republish updates the row in place — a second [[assets]] block
+// for the same name would make lock resolution ambiguous), pinned at
+// wantVersion, while the archive retains every published version.
+func assertRepublishedVersion(t *testing.T, env *TestEnv, vaultDir, name, wantVersion string) {
+	t.Helper()
+	lf, ok := env.ReadVaultAssets(vaultDir)
+	if !ok {
+		t.Fatal("vault manifest missing")
+	}
+	count := 0
+	gotVersion := ""
+	for _, a := range lf.Assets {
+		if a.Name == name {
+			count++
+			gotVersion = a.Version
+		}
+	}
+	if count != 1 {
+		t.Fatalf("manifest rows for %s = %d, want exactly 1 (no duplicate blocks)", name, count)
+	}
+	if gotVersion != wantVersion {
+		t.Errorf("manifest pins %s@%s, want @%s", name, gotVersion, wantVersion)
+	}
+	listData, err := os.ReadFile(filepath.Join(vaultDir, ".sx", "versions", name, "list.txt"))
+	if err != nil {
+		t.Fatalf("read archive version list: %v", err)
+	}
+	if !strings.Contains(string(listData), wantVersion) {
+		t.Errorf("archive list.txt %q does not record version %s", string(listData), wantVersion)
+	}
+}
+
 // assertOutput fails the test if any of want is missing or any of notWant is
 // present in output. Reports the full output once on failure.
 func assertOutput(t *testing.T, output string, want, notWant []string) {
@@ -279,20 +313,9 @@ func TestAddAlreadyInstalled(t *testing.T) {
 			t.Fatalf("add edited: %v", err)
 		}
 
-		// Vault must hold two versions of editable-skill.
-		lf, ok := env.ReadVaultAssets(vaultDir)
-		if !ok {
-			t.Fatal("vault manifest missing")
-		}
-		count := 0
-		for _, a := range lf.Assets {
-			if a.Name == "editable-skill" {
-				count++
-			}
-		}
-		if count < 2 {
-			t.Errorf("expected at least 2 versions of editable-skill in vault, got %d", count)
-		}
+		// The vault archive must hold two versions, and the manifest's
+		// single row for the asset must be pinned at the new one.
+		assertRepublishedVersion(t, env, vaultDir, "editable-skill", "2")
 	})
 
 	// Scenario 5d: name-form equivalent of 5c. `sx add <name>` must resolve
@@ -314,19 +337,7 @@ func TestAddAlreadyInstalled(t *testing.T) {
 			t.Fatalf("add by name after edit: %v", err)
 		}
 
-		lf, ok := env.ReadVaultAssets(vaultDir)
-		if !ok {
-			t.Fatal("vault manifest missing")
-		}
-		count := 0
-		for _, a := range lf.Assets {
-			if a.Name == "named-editable" {
-				count++
-			}
-		}
-		if count < 2 {
-			t.Errorf("expected at least 2 versions after edit-then-add-by-name, got %d", count)
-		}
+		assertRepublishedVersion(t, env, vaultDir, "named-editable", "2")
 	})
 
 	// Scenario 5e: after a new-version upload, the scope data feeding the

--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -42,15 +42,22 @@ func writeLockFileForNoInstall(ctx context.Context, out *outputHelper, repo vaul
 	if err != nil {
 		return err
 	}
+	// No scope flags at all (Inherit with --yes, Remove without): keep any
+	// existing scopes. Republishing an already-scoped asset with a plain
+	// `--no-install` must not silently re-scope it to global; a brand-new
+	// asset has nothing to inherit and still lands global, preserving the
+	// long-standing --no-install default.
+	if result.Inherit || result.Remove {
+		if err := inheritLockFile(ctx, out, repo, asset); err != nil {
+			return fmt.Errorf("failed to update lock file: %w", err)
+		}
+		return nil
+	}
 	asset.Scopes = result.Scopes
 	if asset.Scopes == nil {
-		// Three getScopes branches produce nil Scopes:
-		//   - Inherit / Remove (no scope flag set) — fall back to global
-		//     to match pre-fix behavior; strict inherit semantics under
-		//     --no-install would be a broader change.
-		//   - --scope=<entity> — the entity is forwarded via
-		//     result.ScopeEntity to updateLockFile / SetInstallations;
-		//     an empty Scopes slice is the correct payload.
+		// --scope=<entity> produces nil Scopes: the entity is forwarded via
+		// result.ScopeEntity to updateLockFile / SetInstallations; an empty
+		// Scopes slice is the correct payload.
 		asset.Scopes = []lockfile.Scope{}
 	}
 	if err := updateLockFile(ctx, out, repo, asset, result); err != nil {

--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -115,6 +115,16 @@ type installSetter interface {
 	SetAssetInstallations(ctx context.Context, assetName string, targets []vault.InstallTarget, appendMode bool) (skipped []vault.SkippedTarget, err error)
 }
 
+// publishedInstallSetter is implemented by vaults whose manifest row must
+// advance when scopes are applied right after a publish (the file-backed
+// git/path vaults). The version bump and the scope apply happen in ONE
+// transaction — one commit on git vaults — so they land together or not at
+// all. The Sleuth vault doesn't implement it: the server registers versions
+// at upload, so its name-only installSetter path is already correct.
+type publishedInstallSetter interface {
+	SetPublishedAssetInstallations(ctx context.Context, asset *lockfile.Asset, targets []vault.InstallTarget, appendMode bool) (skipped []vault.SkippedTarget, err error)
+}
+
 // targetUninstaller is implemented by vaults that can remove specific
 // installations by server GID in one best-effort call (the Sleuth/skills.new
 // vault). It returns how many installs were removed and a per-target failure
@@ -132,22 +142,21 @@ func updateLockFile(ctx context.Context, out *outputHelper, repo vault.Vault, as
 		return applyScopeEdit(ctx, out, repo, asset.Name, result.Added, result.Removed)
 	}
 	if result.ApplyTargets || result.Append || hasIdentityScope(result.Targets) {
-		// The bulk installer keys on the asset NAME only, so it adjusts
-		// scopes on whatever version the manifest already pins. When this
-		// call follows a fresh publish, the manifest row must first advance
-		// to the just-published version (preserving its scopes) or the
-		// vault desyncs: archive and root view at the new version, manifest
-		// still resolving the old one. File-backed vaults upsert the row
-		// here; the Sleuth vault registers versions at upload and its
-		// InheritInstallations is a no-op. Scope-only callers (`sx install
-		// --repo X asset`) pass a bare name with no version — nothing was
-		// published, so there is no row to advance.
+		// The plain bulk installer keys on the asset NAME only, so it
+		// adjusts scopes on whatever version the manifest already pins.
+		// When this call follows a fresh publish, the manifest row must
+		// also advance to the just-published version (preserving its
+		// scopes) or the vault desyncs: archive and root view at the new
+		// version, manifest still resolving the old one. Passing the asset
+		// through lets file-backed vaults fold that advance into the same
+		// transaction as the scope apply. Scope-only callers (`sx install
+		// --repo X asset`) carry no version — nothing was published, so
+		// there is no row to advance.
+		var published *lockfile.Asset
 		if asset.Version != "" {
-			if err := repo.InheritInstallations(ctx, asset); err != nil {
-				return fmt.Errorf("failed to update asset version in manifest: %w", err)
-			}
+			published = asset
 		}
-		return bulkSetInstallTargets(ctx, out, repo, asset.Name, result.Targets, result.Append)
+		return bulkSetInstallTargets(ctx, out, repo, asset.Name, published, result.Targets, result.Append)
 	}
 
 	// SetInstallations updates the vault's lock file with the installation configuration
@@ -161,8 +170,11 @@ func updateLockFile(ctx context.Context, out *outputHelper, repo vault.Vault, as
 
 // bulkSetInstallTargets resolves the "me" alias and persists targets via the
 // vault's bulk installer. appendMode merges with the asset's existing
-// installations server-side; otherwise the set is replaced.
-func bulkSetInstallTargets(ctx context.Context, out *outputHelper, repo vault.Vault, assetName string, targets []vault.InstallTarget, appendMode bool) error {
+// installations server-side; otherwise the set is replaced. A non-nil
+// published asset routes through the vault's published-aware installer when
+// it has one, advancing the manifest row to that version in the same
+// transaction (see publishedInstallSetter).
+func bulkSetInstallTargets(ctx context.Context, out *outputHelper, repo vault.Vault, assetName string, published *lockfile.Asset, targets []vault.InstallTarget, appendMode bool) error {
 	setter, ok := repo.(installSetter)
 	if !ok {
 		return errors.New("this vault does not support team/user/bot scopes")
@@ -171,7 +183,12 @@ func bulkSetInstallTargets(ctx context.Context, out *outputHelper, repo vault.Va
 	if err != nil {
 		return err
 	}
-	skipped, err := setter.SetAssetInstallations(ctx, assetName, resolved, appendMode)
+	var skipped []vault.SkippedTarget
+	if ps, isPublished := repo.(publishedInstallSetter); isPublished && published != nil {
+		skipped, err = ps.SetPublishedAssetInstallations(ctx, published, resolved, appendMode)
+	} else {
+		skipped, err = setter.SetAssetInstallations(ctx, assetName, resolved, appendMode)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to set installations: %w", err)
 	}
@@ -222,7 +239,9 @@ func applyScopeEdit(ctx context.Context, out *outputHelper, repo vault.Vault, as
 	if len(added) > 0 {
 		// Append the new targets; resolveSelfUserScopes ("me") and entity
 		// resolution happen inside bulkSetInstallTargets.
-		if err := bulkSetInstallTargets(ctx, out, repo, assetName, added, true); err != nil {
+		// Scope edits adjust an existing installation; no publish precedes
+		// them, so there is no version row to advance (published = nil).
+		if err := bulkSetInstallTargets(ctx, out, repo, assetName, nil, added, true); err != nil {
 			return err
 		}
 	}

--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -132,6 +132,21 @@ func updateLockFile(ctx context.Context, out *outputHelper, repo vault.Vault, as
 		return applyScopeEdit(ctx, out, repo, asset.Name, result.Added, result.Removed)
 	}
 	if result.ApplyTargets || result.Append || hasIdentityScope(result.Targets) {
+		// The bulk installer keys on the asset NAME only, so it adjusts
+		// scopes on whatever version the manifest already pins. When this
+		// call follows a fresh publish, the manifest row must first advance
+		// to the just-published version (preserving its scopes) or the
+		// vault desyncs: archive and root view at the new version, manifest
+		// still resolving the old one. File-backed vaults upsert the row
+		// here; the Sleuth vault registers versions at upload and its
+		// InheritInstallations is a no-op. Scope-only callers (`sx install
+		// --repo X asset`) pass a bare name with no version — nothing was
+		// published, so there is no row to advance.
+		if asset.Version != "" {
+			if err := repo.InheritInstallations(ctx, asset); err != nil {
+				return fmt.Errorf("failed to update asset version in manifest: %w", err)
+			}
+		}
 		return bulkSetInstallTargets(ctx, out, repo, asset.Name, result.Targets, result.Append)
 	}
 

--- a/internal/commands/add_lockfile_test.go
+++ b/internal/commands/add_lockfile_test.go
@@ -87,11 +87,11 @@ func TestWriteLockFileForNoInstall(t *testing.T) {
 		}
 	})
 
-	t.Run("plain --no-install (Remove branch) falls back to global", func(t *testing.T) {
+	t.Run("plain --no-install (Remove branch) inherits existing scopes", func(t *testing.T) {
 		// --no-install with no --yes and no scope flag puts getScopes()
-		// in the Remove branch, which the helper deliberately treats as
-		// global. Locks in the explicit fallback so a future change to
-		// Remove semantics doesn't silently regress this path.
+		// in the Remove branch. No scope was expressed, so the asset's
+		// existing scopes must be preserved via InheritInstallations —
+		// republishing must not silently re-scope to global (issue #190).
 		spy := &spyVault{}
 		out := &outputHelper{}
 		asset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0"}
@@ -101,23 +101,18 @@ func TestWriteLockFileForNoInstall(t *testing.T) {
 			t.Fatalf("writeLockFileForNoInstall: %v", err)
 		}
 
-		if len(spy.setCalls) != 1 {
-			t.Fatalf("SetInstallations calls = %d, want 1", len(spy.setCalls))
+		if len(spy.setCalls) != 0 {
+			t.Fatalf("SetInstallations calls = %d, want 0 (no scope expressed)", len(spy.setCalls))
 		}
-		if spy.setCalls[0].scopeEntity != "" {
-			t.Errorf("scopeEntity = %q, want \"\" (no entity flag)", spy.setCalls[0].scopeEntity)
-		}
-		// Global is represented by an empty (but non-nil) Scopes slice.
-		if spy.setCalls[0].asset.Scopes == nil {
-			t.Errorf("Scopes = nil, want empty slice (Remove fallback should produce global)")
-		}
-		if len(spy.setCalls[0].asset.Scopes) != 0 {
-			t.Errorf("Scopes = %v, want empty slice (global)", spy.setCalls[0].asset.Scopes)
+		if len(spy.inheritCalls) != 1 {
+			t.Fatalf("InheritInstallations calls = %d, want 1", len(spy.inheritCalls))
 		}
 	})
 
-	t.Run("--yes --no-install (Inherit branch) falls back to global", func(t *testing.T) {
-		// Same fallback as Remove, different getScopes branch.
+	t.Run("--yes --no-install (Inherit branch) inherits existing scopes", func(t *testing.T) {
+		// Same as Remove, different getScopes branch. A brand-new asset
+		// has nothing to inherit and still lands global (the vault's
+		// inherit is a no-op upsert with no scopes).
 		spy := &spyVault{}
 		out := &outputHelper{}
 		asset := &lockfile.Asset{Name: "my-skill", Version: "1.0.0"}
@@ -127,11 +122,11 @@ func TestWriteLockFileForNoInstall(t *testing.T) {
 			t.Fatalf("writeLockFileForNoInstall: %v", err)
 		}
 
-		if len(spy.setCalls) != 1 {
-			t.Fatalf("SetInstallations calls = %d, want 1", len(spy.setCalls))
+		if len(spy.setCalls) != 0 {
+			t.Fatalf("SetInstallations calls = %d, want 0 (no scope expressed)", len(spy.setCalls))
 		}
-		if spy.setCalls[0].asset.Scopes == nil || len(spy.setCalls[0].asset.Scopes) != 0 {
-			t.Errorf("Scopes = %v, want empty slice (global)", spy.setCalls[0].asset.Scopes)
+		if len(spy.inheritCalls) != 1 {
+			t.Fatalf("InheritInstallations calls = %d, want 1", len(spy.inheritCalls))
 		}
 	})
 

--- a/internal/commands/add_republish_test.go
+++ b/internal/commands/add_republish_test.go
@@ -52,3 +52,79 @@ func TestRepublishUpdatesManifestRowInPlace(t *testing.T) {
 		t.Fatalf("scopes = %+v, want the original repo scope preserved", row.Scopes)
 	}
 }
+
+// republishedRow loads the vault manifest and returns the single row for
+// name, failing the test on duplicates or absence.
+func republishedRow(t *testing.T, vaultDir, name string) manifest.Asset {
+	t.Helper()
+	m, ok, err := manifest.Load(vaultDir)
+	if err != nil || !ok {
+		t.Fatalf("load vault manifest: ok=%v err=%v", ok, err)
+	}
+	var rows []manifest.Asset
+	for _, a := range m.Assets {
+		if a.Name == name {
+			rows = append(rows, a)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("manifest rows for %s = %d, want exactly 1", name, len(rows))
+	}
+	return rows[0]
+}
+
+// TestRepublishWithReplaceScopeAdvancesManifest covers issue #191: a
+// republish routed through the bulk scope installer (--org --replace-scope)
+// must advance the manifest row to the just-published version. Before the
+// fix, the archive and root view moved to v2 while sx.toml stayed pinned at
+// v1 — a silent desync where authors ship a version consumers never receive.
+func TestRepublishWithReplaceScopeAdvancesManifest(t *testing.T) {
+	env := NewTestEnv(t)
+	vaultDir := env.SetupPathVault()
+	sourceDir := createSourceSkill(env, "resc-skill")
+
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--repo", "git@github.com:org/consumer.git"); err != nil {
+		t.Fatalf("add v1: %v\n%s", err, out)
+	}
+	env.WriteFile(filepath.Join(sourceDir, "SKILL.md"), "You are resc-skill (edited)")
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--org", "--replace-scope"); err != nil {
+		t.Fatalf("republish --org --replace-scope: %v\n%s", err, out)
+	}
+
+	row := republishedRow(t, vaultDir, "resc-skill")
+	if row.Version != "2" {
+		t.Errorf("manifest pins version %q, want \"2\" (archive advanced without the manifest)", row.Version)
+	}
+	if row.SourcePath == nil || row.SourcePath.Path != ".sx/versions/resc-skill/2" {
+		t.Errorf("source path = %+v, want .sx/versions/resc-skill/2", row.SourcePath)
+	}
+	// --org is the empty scope set: the repo scope is replaced, org-wide.
+	if len(row.Scopes) != 0 {
+		t.Errorf("scopes = %+v, want none (org-wide)", row.Scopes)
+	}
+}
+
+// TestRepublishWithAppendScopeAdvancesManifest is the append-mode variant of
+// issue #191: `sx add --repo Y` on a new version must bump the row AND end up
+// with both the inherited and the newly appended scope.
+func TestRepublishWithAppendScopeAdvancesManifest(t *testing.T) {
+	env := NewTestEnv(t)
+	vaultDir := env.SetupPathVault()
+	sourceDir := createSourceSkill(env, "appd-skill")
+
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--repo", "git@github.com:org/one.git"); err != nil {
+		t.Fatalf("add v1: %v\n%s", err, out)
+	}
+	env.WriteFile(filepath.Join(sourceDir, "SKILL.md"), "You are appd-skill (edited)")
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--repo", "git@github.com:org/two.git"); err != nil {
+		t.Fatalf("republish --repo two: %v\n%s", err, out)
+	}
+
+	row := republishedRow(t, vaultDir, "appd-skill")
+	if row.Version != "2" {
+		t.Errorf("manifest pins version %q, want \"2\"", row.Version)
+	}
+	if len(row.Scopes) != 2 {
+		t.Fatalf("scopes = %+v, want inherited repo one + appended repo two", row.Scopes)
+	}
+}

--- a/internal/commands/add_republish_test.go
+++ b/internal/commands/add_republish_test.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/manifest"
+)
+
+// TestRepublishUpdatesManifestRowInPlace covers issue #190: publishing a new
+// version of an asset that already exists in the vault must update the
+// existing [[assets]] block in place — version bumped, source path repointed,
+// scopes preserved — not append a second block for the same name with no
+// scopes.
+func TestRepublishUpdatesManifestRowInPlace(t *testing.T) {
+	env := NewTestEnv(t)
+	vaultDir := env.SetupPathVault()
+	sourceDir := createSourceSkill(env, "repub-skill")
+
+	// v1, scoped to a repo.
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--repo", "git@github.com:org/consumer.git"); err != nil {
+		t.Fatalf("add v1: %v\n%s", err, out)
+	}
+
+	// Edit and republish with no scope flags.
+	env.WriteFile(filepath.Join(sourceDir, "SKILL.md"), "You are repub-skill (edited)")
+	if out, err := execAdd(sourceDir, "--yes", "--no-install"); err != nil {
+		t.Fatalf("republish: %v\n%s", err, out)
+	}
+
+	m, ok, err := manifest.Load(vaultDir)
+	if err != nil || !ok {
+		t.Fatalf("load vault manifest: ok=%v err=%v", ok, err)
+	}
+	var rows []manifest.Asset
+	for _, a := range m.Assets {
+		if a.Name == "repub-skill" {
+			rows = append(rows, a)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("manifest rows for repub-skill = %d, want exactly 1 (no duplicate [[assets]] blocks)", len(rows))
+	}
+	row := rows[0]
+	if row.Version != "2" {
+		t.Errorf("manifest pins version %q, want \"2\"", row.Version)
+	}
+	if row.SourcePath == nil || row.SourcePath.Path != ".sx/versions/repub-skill/2" {
+		t.Errorf("source path = %+v, want .sx/versions/repub-skill/2", row.SourcePath)
+	}
+	if len(row.Scopes) != 1 || row.Scopes[0].Kind != manifest.ScopeKindRepo {
+		t.Fatalf("scopes = %+v, want the original repo scope preserved", row.Scopes)
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -487,8 +487,11 @@ func (m *Manifest) FindAsset(name string) *Asset {
 // version updates the existing row in place (keeping its position and
 // bumping its version) rather than appending a second [[assets]] block for
 // the same name — a duplicate would make lock resolution ambiguous. Any
-// legacy duplicate rows for the name are pruned. Returns the pointer into
-// the manifest's slice.
+// legacy duplicate rows for the name are pruned. Note the match key is the
+// NAME alone (it was name+version before schema v2 hardening): no caller
+// keeps multiple versions of one name as separate rows — callers that need
+// per-version granularity (RemoveAsset, findAssetVersionInManifest) take an
+// explicit version instead. Returns the pointer into the manifest's slice.
 func (m *Manifest) UpsertAsset(a Asset) *Asset {
 	idx := -1
 	for i := range m.Assets {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -482,17 +482,34 @@ func (m *Manifest) FindAsset(name string) *Asset {
 	return nil
 }
 
-// UpsertAsset replaces an asset by (name, version) or appends if missing.
-// Returns the pointer into the manifest's slice.
+// UpsertAsset replaces the asset with the same name or appends if missing.
+// The manifest pins one live version per asset name, so publishing a new
+// version updates the existing row in place (keeping its position and
+// bumping its version) rather than appending a second [[assets]] block for
+// the same name — a duplicate would make lock resolution ambiguous. Any
+// legacy duplicate rows for the name are pruned. Returns the pointer into
+// the manifest's slice.
 func (m *Manifest) UpsertAsset(a Asset) *Asset {
+	idx := -1
 	for i := range m.Assets {
-		if m.Assets[i].Name == a.Name && m.Assets[i].Version == a.Version {
-			m.Assets[i] = a
-			return &m.Assets[i]
+		if m.Assets[i].Name == a.Name {
+			idx = i
+			break
 		}
 	}
-	m.Assets = append(m.Assets, a)
-	return &m.Assets[len(m.Assets)-1]
+	if idx == -1 {
+		m.Assets = append(m.Assets, a)
+		return &m.Assets[len(m.Assets)-1]
+	}
+	m.Assets[idx] = a
+	kept := m.Assets[:idx+1]
+	for _, other := range m.Assets[idx+1:] {
+		if other.Name != a.Name {
+			kept = append(kept, other)
+		}
+	}
+	m.Assets = kept
+	return &m.Assets[idx]
 }
 
 // RemoveAsset removes every entry matching name. If version is non-empty,

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -296,29 +296,56 @@ func TestAssetUpsertRemove(t *testing.T) {
 	m := &Manifest{SchemaVersion: CurrentSchemaVersion}
 
 	m.UpsertAsset(Asset{Name: "foo", Version: "1.0.0", Type: asset.TypeSkill})
-	m.UpsertAsset(Asset{Name: "foo", Version: "2.0.0", Type: asset.TypeSkill})
 	m.UpsertAsset(Asset{Name: "bar", Version: "1.0.0", Type: asset.TypeSkill})
 
-	if len(m.Assets) != 3 {
-		t.Fatalf("assets: got %d want 3", len(m.Assets))
+	// Publishing a new version replaces the name's row in place — the
+	// manifest pins one live version per asset name.
+	m.UpsertAsset(Asset{Name: "foo", Version: "2.0.0", Type: asset.TypeSkill})
+	if len(m.Assets) != 2 {
+		t.Fatalf("assets: got %d want 2", len(m.Assets))
+	}
+	if m.Assets[0].Name != "foo" || m.Assets[0].Version != "2.0.0" {
+		t.Errorf("version bump must update the row in place: %+v", m.Assets[0])
 	}
 
-	// Replace existing (name, version) tuple.
-	m.UpsertAsset(Asset{Name: "foo", Version: "1.0.0", Type: asset.TypeSkill, Clients: []string{"claude"}})
-	if len(m.Assets) != 3 {
+	// Replace same name+version too.
+	m.UpsertAsset(Asset{Name: "foo", Version: "2.0.0", Type: asset.TypeSkill, Clients: []string{"claude"}})
+	if len(m.Assets) != 2 {
 		t.Errorf("replace should not grow: got %d", len(m.Assets))
 	}
 	if len(m.FindAsset("foo").Clients) != 1 {
 		t.Error("upsert did not replace asset body")
 	}
 
-	// Remove all versions of foo.
 	removed := m.RemoveAsset("foo", "")
-	if removed != 2 {
-		t.Errorf("removed: got %d want 2", removed)
+	if removed != 1 {
+		t.Errorf("removed: got %d want 1", removed)
 	}
 	if len(m.Assets) != 1 {
 		t.Errorf("remaining: got %d want 1", len(m.Assets))
+	}
+}
+
+func TestUpsertAssetPrunesDuplicateNameRows(t *testing.T) {
+	// Manifests written by older builds can carry duplicate [[assets]]
+	// blocks for one name; an upsert heals them down to a single row.
+	m := &Manifest{
+		SchemaVersion: CurrentSchemaVersion,
+		Assets: []Asset{
+			{Name: "foo", Version: "1.0.0", Type: asset.TypeSkill},
+			{Name: "bar", Version: "1.0.0", Type: asset.TypeSkill},
+			{Name: "foo", Version: "2.0.0", Type: asset.TypeSkill},
+		},
+	}
+	m.UpsertAsset(Asset{Name: "foo", Version: "3.0.0", Type: asset.TypeSkill})
+	if len(m.Assets) != 2 {
+		t.Fatalf("assets: got %d want 2 (duplicates pruned)", len(m.Assets))
+	}
+	if m.Assets[0].Name != "foo" || m.Assets[0].Version != "3.0.0" {
+		t.Errorf("first row = %+v, want foo@3.0.0 in place", m.Assets[0])
+	}
+	if m.Assets[1].Name != "bar" {
+		t.Errorf("unrelated row disturbed: %+v", m.Assets[1])
 	}
 }
 

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -836,9 +836,8 @@ func (g *GitVault) SetInstallations(ctx context.Context, asset *lockfile.Asset, 
 	return nil
 }
 
-// InheritInstallations copies scopes from any existing entry of this
-// asset in the manifest, upserts the asset with those scopes, and
-// commits/pushes.
+// InheritInstallations upserts the asset into the manifest, carrying any
+// existing entry's scopes through verbatim, and commits/pushes.
 func (g *GitVault) InheritInstallations(ctx context.Context, asset *lockfile.Asset) error {
 	fileLock, err := g.acquireFileLock(ctx)
 	if err != nil {
@@ -853,10 +852,7 @@ func (g *GitVault) InheritInstallations(ctx context.Context, asset *lockfile.Ass
 		return err
 	}
 
-	if err := inheritAssetScopesFromManifest(g.repoPath, asset); err != nil {
-		return fmt.Errorf("failed to inherit scopes: %w", err)
-	}
-	if err := upsertAssetInManifest(g.repoPath, asset); err != nil {
+	if err := upsertAssetInheritingScopes(g.repoPath, asset); err != nil {
 		return fmt.Errorf("failed to update manifest: %w", err)
 	}
 

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sleuth-io/sx/internal/cache"
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
@@ -355,7 +356,22 @@ func (g *GitVault) SetAssetInstallations(ctx context.Context, assetName string, 
 	}
 	msg := verb + assetName
 	err = g.runInVaultTx(ctx, msg, func(root string, actor mgmt.Actor) error {
-		skipped, err = commonSetAssetInstallations(ctx, root, actor, assetName, targets, appendMode)
+		skipped, err = commonSetAssetInstallations(ctx, root, actor, assetName, targets, appendMode, nil)
+		return err
+	})
+	return skipped, err
+}
+
+// SetPublishedAssetInstallations is SetAssetInstallations for a just-published
+// asset version: the manifest row advances to asset's version (existing scopes
+// carried through) in the SAME transaction — and so the same commit/push — the
+// targets apply in. A scoped republish therefore lands as one commit, and the
+// version and scopes change together or not at all. Satisfies
+// publishedInstallSetter.
+func (g *GitVault) SetPublishedAssetInstallations(ctx context.Context, asset *lockfile.Asset, targets []InstallTarget, appendMode bool) (skipped []SkippedTarget, err error) {
+	msg := fmt.Sprintf("Set %s %s installations", asset.Name, asset.Version)
+	err = g.runInVaultTx(ctx, msg, func(root string, actor mgmt.Actor) error {
+		skipped, err = commonSetAssetInstallations(ctx, root, actor, asset.Name, targets, appendMode, asset)
 		return err
 	})
 	return skipped, err

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -81,6 +81,16 @@ func upsertAssetInheritingScopes(vaultRoot string, asset *lockfile.Asset) error 
 	if err != nil {
 		return err
 	}
+	upsertAssetInheritingScopesTx(m, asset)
+	return manifest.Save(vaultRoot, m)
+}
+
+// upsertAssetInheritingScopesTx is upsertAssetInheritingScopes against an
+// already-loaded manifest, for callers composing it into a larger
+// transaction (commonSetAssetInstallations folds the version advance and
+// the scope apply into one manifest write — and one commit on git vaults).
+// Returns the upserted row.
+func upsertAssetInheritingScopesTx(m *manifest.Manifest, asset *lockfile.Asset) *manifest.Asset {
 	// Gather scopes from EVERY same-name row, not just FindAsset's first
 	// match: the rest of the system treats an asset's effective scopes as
 	// the union across legacy duplicate rows (see commonCurrentInstallTargets),
@@ -120,7 +130,7 @@ func upsertAssetInheritingScopes(vaultRoot string, asset *lockfile.Asset) error 
 	if inherit {
 		row.Scopes = preserved
 	}
-	return manifest.Save(vaultRoot, m)
+	return row
 }
 
 // removeAssetFromManifest deletes every entry for the named asset, or

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -40,8 +40,8 @@ func resolveLockBytesForActor(ctx context.Context, vaultRoot string) ([]byte, er
 
 // upsertAssetInManifest inserts or replaces an asset in the vault's
 // manifest. Scopes on the incoming asset are preserved verbatim —
-// callers that want to inherit existing scopes should call
-// inheritAssetScopesFromManifest before invoking this.
+// callers that want to inherit existing scopes should use
+// upsertAssetInheritingScopes instead.
 func upsertAssetInManifest(vaultRoot string, asset *lockfile.Asset) error {
 	m, err := loadManifest(vaultRoot)
 	if err != nil {

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -81,11 +81,25 @@ func upsertAssetInheritingScopes(vaultRoot string, asset *lockfile.Asset) error 
 	if err != nil {
 		return err
 	}
+	// Gather scopes from EVERY same-name row, not just FindAsset's first
+	// match: the rest of the system treats an asset's effective scopes as
+	// the union across legacy duplicate rows (see commonCurrentInstallTargets),
+	// and the upsert below prunes those rows — seeding from the first row
+	// alone would silently drop any scope that lives only on a later one.
 	var preserved []manifest.Scope
 	inherit := false
-	if existing := m.FindAsset(asset.Name); existing != nil {
+	seen := map[string]bool{}
+	for i := range m.Assets {
+		if m.Assets[i].Name != asset.Name {
+			continue
+		}
 		inherit = true
-		preserved = append([]manifest.Scope(nil), existing.Scopes...)
+		for _, s := range m.Assets[i].Scopes {
+			if k := scopeDedupKey(s); !seen[k] {
+				seen[k] = true
+				preserved = append(preserved, s)
+			}
+		}
 	}
 	ma := lockfileAssetToManifest(*asset)
 	// Preserve Clients from any existing same name+version entry when the

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -67,39 +67,42 @@ func upsertAssetInManifest(vaultRoot string, asset *lockfile.Asset) error {
 	return manifest.Save(vaultRoot, m)
 }
 
-// inheritAssetScopesFromManifest copies the scope list from any existing
-// entry for asset.Name into the incoming asset. No-op if the asset is
-// not present. Produces lockfile scopes (the caller typically turns
-// around and passes the asset back to upsert, which converts both the
-// asset and its scopes into manifest form).
-func inheritAssetScopesFromManifest(vaultRoot string, asset *lockfile.Asset) error {
+// upsertAssetInheritingScopes inserts or replaces an asset in the vault's
+// manifest, carrying any existing entry's scope rows through verbatim —
+// every kind included. Converting scopes through the lockfile.Scope shape
+// here would silently drop team/user/bot rows (that shape can only express
+// repo/path) and thereby GLOBALIZE a team- or user-scoped asset on every
+// republish. Used when publishing a new version with no scope change
+// requested: the asset's sharing must survive the version bump. The RBAC
+// edit gate (docs/rbac.md) has already vetted that the caller may
+// republish the asset.
+func upsertAssetInheritingScopes(vaultRoot string, asset *lockfile.Asset) error {
 	m, err := loadManifest(vaultRoot)
 	if err != nil {
 		return err
 	}
-	existing := m.FindAsset(asset.Name)
-	if existing == nil {
-		return nil
+	var preserved []manifest.Scope
+	inherit := false
+	if existing := m.FindAsset(asset.Name); existing != nil {
+		inherit = true
+		preserved = append([]manifest.Scope(nil), existing.Scopes...)
 	}
-	// Inherited scopes carry across kinds (repo, path, team, user). Convert
-	// them through a trivial Resolve against the no-op actor so they land
-	// in lockfile.Scope form. We intentionally skip team/user rows because
-	// those are identity-dependent and the new owner may not be in the
-	// same teams; keep only the structural (repo/path) scopes.
-	asset.Scopes = nil
-	for _, s := range existing.Scopes {
-		switch s.Kind {
-		case manifest.ScopeKindRepo:
-			asset.Scopes = append(asset.Scopes, lockfile.Scope{Repo: s.Repo})
-		case manifest.ScopeKindPath:
-			asset.Scopes = append(asset.Scopes, lockfile.Scope{Repo: s.Repo, Paths: append([]string(nil), s.Paths...)})
-		case manifest.ScopeKindOrg, manifest.ScopeKindTeam, manifest.ScopeKindUser, manifest.ScopeKindBot:
-			// Identity-dependent scopes do not inherit — the new
-			// owner may not be in the same teams or bot identities,
-			// and a blanket carry-over would leak access.
+	ma := lockfileAssetToManifest(*asset)
+	// Preserve Clients from any existing same name+version entry when the
+	// incoming asset declares none (mirrors upsertAssetInManifest).
+	if len(ma.Clients) == 0 {
+		for i := range m.Assets {
+			if m.Assets[i].Name == ma.Name && m.Assets[i].Version == ma.Version && len(m.Assets[i].Clients) > 0 {
+				ma.Clients = append([]string(nil), m.Assets[i].Clients...)
+				break
+			}
 		}
 	}
-	return nil
+	row := m.UpsertAsset(ma)
+	if inherit {
+		row.Scopes = preserved
+	}
+	return manifest.Save(vaultRoot, m)
 }
 
 // removeAssetFromManifest deletes every entry for the named asset, or

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -103,7 +103,11 @@ func upsertAssetInheritingScopes(vaultRoot string, asset *lockfile.Asset) error 
 	}
 	ma := lockfileAssetToManifest(*asset)
 	// Preserve Clients from any existing same name+version entry when the
-	// incoming asset declares none (mirrors upsertAssetInManifest).
+	// incoming asset declares none (mirrors upsertAssetInManifest). This
+	// fires only on same-version re-adds (the handleIdenticalAsset inherit
+	// path builds the asset without metadata in scope); on a new-version
+	// republish the version differs and the loop is deliberately inert, so
+	// a version that drops [asset].clients does not inherit the old filter.
 	if len(ma.Clients) == 0 {
 		for i := range m.Assets {
 			if m.Assets[i].Name == ma.Name && m.Assets[i].Version == ma.Version && len(m.Assets[i].Clients) > 0 {

--- a/internal/vault/manifest_assets_test.go
+++ b/internal/vault/manifest_assets_test.go
@@ -107,6 +107,65 @@ func TestUpsertAssetInManifest_NewVersionDoesNotInherit(t *testing.T) {
 	}
 }
 
+// TestUpsertAssetInheritingScopes_UnionsLegacyDuplicateRows covers manifests
+// written by older builds that hold duplicate same-name rows with divergent
+// scopes. The asset's effective reach is the union across those rows (see
+// commonCurrentInstallTargets), so collapsing them on republish must
+// preserve the union — seeding from the first row alone would silently
+// drop scopes that live only on a later row.
+func TestUpsertAssetInheritingScopes_UnionsLegacyDuplicateRows(t *testing.T) {
+	vaultRoot := t.TempDir()
+
+	m := &manifest.Manifest{
+		Assets: []manifest.Asset{
+			{
+				Name: "dup-skill", Version: "1", Type: asset.TypeSkill,
+				Scopes: []manifest.Scope{
+					{Kind: manifest.ScopeKindRepo, Repo: "github.com/org/repo-a"},
+				},
+			},
+			{
+				Name: "dup-skill", Version: "2", Type: asset.TypeSkill,
+				Scopes: []manifest.Scope{
+					{Kind: manifest.ScopeKindRepo, Repo: "github.com/org/repo-a"}, // duplicate — must not double
+					{Kind: manifest.ScopeKindRepo, Repo: "github.com/org/repo-b"},
+				},
+			},
+		},
+	}
+	if err := manifest.Save(vaultRoot, m); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	v3 := &lockfile.Asset{Name: "dup-skill", Version: "3", Type: asset.TypeSkill}
+	if err := upsertAssetInheritingScopes(vaultRoot, v3); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	m2, err := loadManifest(vaultRoot)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var rows []manifest.Asset
+	for _, a := range m2.Assets {
+		if a.Name == "dup-skill" {
+			rows = append(rows, a)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1 (duplicates collapsed)", len(rows))
+	}
+	got := rows[0]
+	if got.Version != "3" {
+		t.Errorf("version = %q, want 3", got.Version)
+	}
+	if len(got.Scopes) != 2 ||
+		got.Scopes[0].Repo != "github.com/org/repo-a" ||
+		got.Scopes[1].Repo != "github.com/org/repo-b" {
+		t.Errorf("scopes = %+v, want deduped union of repo-a + repo-b", got.Scopes)
+	}
+}
+
 // TestUpsertAssetInheritingScopes_PreservesAllScopeKinds covers the
 // republish path (issue #190): publishing a new version of an existing
 // asset must update the row in place — one row per name — and carry every

--- a/internal/vault/manifest_assets_test.go
+++ b/internal/vault/manifest_assets_test.go
@@ -107,6 +107,64 @@ func TestUpsertAssetInManifest_NewVersionDoesNotInherit(t *testing.T) {
 	}
 }
 
+// TestUpsertAssetInheritingScopes_PreservesAllScopeKinds covers the
+// republish path (issue #190): publishing a new version of an existing
+// asset must update the row in place — one row per name — and carry every
+// scope kind through verbatim, including team/user scopes that the
+// lockfile.Scope shape cannot express.
+func TestUpsertAssetInheritingScopes_PreservesAllScopeKinds(t *testing.T) {
+	vaultRoot := t.TempDir()
+
+	m := &manifest.Manifest{}
+	m.UpsertAsset(manifest.Asset{
+		Name:    "shared-skill",
+		Version: "1",
+		Type:    asset.TypeSkill,
+		Scopes: []manifest.Scope{
+			{Kind: manifest.ScopeKindRepo, Repo: "github.com/org/consumer"},
+			{Kind: manifest.ScopeKindTeam, Team: "core"},
+			{Kind: manifest.ScopeKindUser, User: "alice@example.com"},
+		},
+	})
+	if err := manifest.Save(vaultRoot, m); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	v2 := &lockfile.Asset{
+		Name:       "shared-skill",
+		Version:    "2",
+		Type:       asset.TypeSkill,
+		SourcePath: &lockfile.SourcePath{Path: ".sx/versions/shared-skill/2"},
+	}
+	if err := upsertAssetInheritingScopes(vaultRoot, v2); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	m2, err := loadManifest(vaultRoot)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var rows []manifest.Asset
+	for _, a := range m2.Assets {
+		if a.Name == "shared-skill" {
+			rows = append(rows, a)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want exactly 1 (no duplicate blocks)", len(rows))
+	}
+	got := rows[0]
+	if got.Version != "2" {
+		t.Errorf("version = %q, want 2", got.Version)
+	}
+	if len(got.Scopes) != 3 ||
+		got.Scopes[0].Kind != manifest.ScopeKindRepo ||
+		got.Scopes[1].Kind != manifest.ScopeKindTeam || got.Scopes[1].Team != "core" ||
+		got.Scopes[2].Kind != manifest.ScopeKindUser || got.Scopes[2].User != "alice@example.com" {
+		t.Errorf("scopes = %+v, want repo+team+user preserved verbatim", got.Scopes)
+	}
+}
+
 // TestUpsertAssetInManifest_IncomingClientsWins covers the inverse: when
 // the incoming asset *does* carry Clients (the addNewAsset path now does
 // this), the upsert should write that value rather than inherit from the

--- a/internal/vault/mgmt_bulk_install_test.go
+++ b/internal/vault/mgmt_bulk_install_test.go
@@ -5,10 +5,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
 )
@@ -306,5 +311,168 @@ func TestSleuthOrgInstallAlwaysReplaces(t *testing.T) {
 	}
 	if gotAppend == nil || *gotAppend {
 		t.Fatalf("org install sent append=%v, want explicit false (replace)", gotAppend)
+	}
+}
+
+// TestPathVault_SetPublishedAssetInstallations_AdvancesRow pins issue #191's
+// single-transaction fix: applying scopes for a just-published version must
+// advance the manifest row to that version in the same write, carrying
+// existing scopes through and then applying the new targets.
+func TestPathVault_SetPublishedAssetInstallations_AdvancesRow(t *testing.T) {
+	v, dir := seedBulkInstallVault(t)
+	ctx := context.Background()
+
+	published := &lockfile.Asset{
+		Name: "my-skill", Version: "2.0.0", Type: asset.TypeSkill,
+		SourcePath: &lockfile.SourcePath{Path: ".sx/versions/my-skill/2.0.0"},
+	}
+	skipped, err := v.SetPublishedAssetInstallations(ctx, published, []InstallTarget{
+		{Kind: InstallKindRepo, Repo: "github.com/acme/extra"},
+	}, true)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("SetPublishedAssetInstallations: skipped=%v err=%v", skipped, err)
+	}
+
+	m, _, err := manifest.LoadOrMigrate(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := m.FindAsset("my-skill")
+	if a == nil || a.Version != "2.0.0" {
+		t.Fatalf("row = %+v, want version 2.0.0", a)
+	}
+	if a.SourcePath == nil || a.SourcePath.Path != ".sx/versions/my-skill/2.0.0" {
+		t.Errorf("source path = %+v, want the published archive path", a.SourcePath)
+	}
+	if len(a.Scopes) != 2 {
+		t.Errorf("scopes = %+v, want baseline repo scope + appended repo scope", a.Scopes)
+	}
+}
+
+// TestPathVault_SetPublishedAssetInstallations_AllSkippedLeavesRow pins the
+// atomicity half of the fix: when every requested target is skipped, the
+// version must NOT advance either — the manifest stays exactly as it was,
+// rather than committing a version bump whose scope change never landed.
+func TestPathVault_SetPublishedAssetInstallations_AllSkippedLeavesRow(t *testing.T) {
+	v, dir := seedBulkInstallVault(t)
+	ctx := context.Background()
+
+	published := &lockfile.Asset{
+		Name: "my-skill", Version: "2.0.0", Type: asset.TypeSkill,
+		SourcePath: &lockfile.SourcePath{Path: ".sx/versions/my-skill/2.0.0"},
+	}
+	skipped, err := v.SetPublishedAssetInstallations(ctx, published, []InstallTarget{
+		{Kind: InstallKindTeam, Team: "ghost-team"},
+	}, false)
+	if err != nil {
+		t.Fatalf("SetPublishedAssetInstallations: %v", err)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %+v, want the unknown team reported", skipped)
+	}
+
+	m, _, err := manifest.LoadOrMigrate(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := m.FindAsset("my-skill")
+	if a == nil || a.Version != "1.0.0" {
+		t.Fatalf("row = %+v, want version still 1.0.0 (nothing applied, nothing advanced)", a)
+	}
+	if len(a.Scopes) != 1 || a.Scopes[0].Kind != manifest.ScopeKindRepo {
+		t.Errorf("scopes = %+v, want the baseline repo scope untouched", a.Scopes)
+	}
+}
+
+// TestGitVault_SetPublishedAssetInstallations_OneCommit pins the other half
+// of the issue #191 review feedback: a scoped republish must land the version
+// advance and the scope change as ONE commit on git vaults, not a version
+// commit followed by a separate scope commit.
+func TestGitVault_SetPublishedAssetInstallations_OneCommit(t *testing.T) {
+	mgmt.ResetActorCache()
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	remoteDir := filepath.Join(t.TempDir(), "vault.git")
+	gitRun(t, "", "init", "--bare", "-b", "main", remoteDir)
+
+	seedDir := filepath.Join(t.TempDir(), "seed")
+	gitRun(t, "", "init", "-b", "main", seedDir)
+	gitRun(t, seedDir, "config", "user.email", "seed@example.com")
+	gitRun(t, seedDir, "config", "user.name", "Seed")
+	for _, rel := range []string{
+		".sx/versions/my-skill/1/SKILL.md",
+		"assets/my-skill/SKILL.md",
+	} {
+		path := filepath.Join(seedDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("# my-skill"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(seedDir, ".sx", "versions", "my-skill", "list.txt"), []byte("1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.Save(seedDir, &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{{
+			Name: "my-skill", Version: "1", Type: asset.TypeSkill,
+			SourcePath: &manifest.SourcePath{Path: ".sx/versions/my-skill/1"},
+			Scopes: []manifest.Scope{
+				{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/baseline"},
+			},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, seedDir, "add", ".")
+	gitRun(t, seedDir, "commit", "-m", "seed v2 vault")
+	gitRun(t, seedDir, "remote", "add", "origin", remoteDir)
+	gitRun(t, seedDir, "push", "origin", "main")
+
+	v, err := NewGitVault("file://" + remoteDir)
+	if err != nil {
+		t.Fatalf("NewGitVault: %v", err)
+	}
+	if _, _, _, err := v.GetLockFile(context.Background(), ""); err != nil {
+		t.Fatalf("GetLockFile (forces clone): %v", err)
+	}
+	gitRun(t, v.repoPath, "config", "user.email", "alice@example.com")
+	gitRun(t, v.repoPath, "config", "user.name", "Alice")
+	mgmt.ResetActorCache()
+
+	before := strings.TrimSpace(gitOut(t, "", "--git-dir", remoteDir, "rev-list", "--count", "main"))
+
+	published := &lockfile.Asset{
+		Name: "my-skill", Version: "2", Type: asset.TypeSkill,
+		SourcePath: &lockfile.SourcePath{Path: ".sx/versions/my-skill/2"},
+	}
+	skipped, err := v.SetPublishedAssetInstallations(context.Background(), published,
+		[]InstallTarget{{Kind: InstallKindOrg}}, false)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("SetPublishedAssetInstallations: skipped=%v err=%v", skipped, err)
+	}
+
+	after := strings.TrimSpace(gitOut(t, "", "--git-dir", remoteDir, "rev-list", "--count", "main"))
+	beforeN, _ := strconv.Atoi(before)
+	afterN, _ := strconv.Atoi(after)
+	if afterN != beforeN+1 {
+		log := gitOut(t, "", "--git-dir", remoteDir, "log", "--format=%s", "main")
+		t.Fatalf("commits: before=%d after=%d, want exactly one new commit; log:\n%s", beforeN, afterN, log)
+	}
+
+	verify := filepath.Join(t.TempDir(), "verify")
+	gitRun(t, "", "clone", remoteDir, verify)
+	m, _, err := manifest.Load(verify)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := m.FindAsset("my-skill")
+	if a == nil || a.Version != "2" {
+		t.Fatalf("row = %+v, want version 2 on the remote", a)
+	}
+	if len(a.Scopes) != 0 {
+		t.Errorf("scopes = %+v, want none (org-wide replace)", a.Scopes)
 	}
 }

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -955,9 +955,8 @@ func commonRemoveAssetInstallation(vaultRoot string, actor mgmt.Actor, assetName
 			}
 		}
 		// Walk every entry for assetName, not just FindAsset's first match:
-		// repo/path scopes are inherited onto each new version row
-		// (inheritAssetScopesFromManifest), so the same scope can live on
-		// multiple same-name rows and all must be cleared. A row left with
+		// manifests written by older builds can carry duplicate same-name
+		// rows sharing a scope, and all must be cleared. A row left with
 		// no scopes is dropped rather than reinterpreted as global.
 		changed := false
 		kept := m.Assets[:0]

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -1022,7 +1022,14 @@ func commonClearAssetInstallations(vaultRoot string, actor mgmt.Actor, assetName
 // caller to surface — it never aborts the whole batch on one bad target. If
 // NOTHING resolves, the asset is left untouched rather than cleared, so a
 // REPLACE whose targets all fail can't silently globalize the asset.
-func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget, appendMode bool) ([]SkippedTarget, error) {
+//
+// published, when non-nil, is a just-published asset version whose manifest
+// row must advance as part of the same transaction (scopes carried through
+// before the targets apply). Folding the advance in here keeps a scoped
+// republish to ONE manifest write — one commit/push on git vaults — and
+// makes it atomic: when every target is skipped, neither the version nor
+// the scopes change.
+func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget, appendMode bool, published *lockfile.Asset) ([]SkippedTarget, error) {
 	if len(targets) == 0 {
 		return nil, nil
 	}
@@ -1077,9 +1084,16 @@ func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mg
 			}
 		}
 
-		asset := m.FindAsset(assetName)
+		// Past the early returns: at least one target will apply, so the
+		// just-published version (when given) advances in the same write.
+		// Its upsert inserts or replaces the row and carries existing
+		// scopes through, so the storage-recovery path below is only for
+		// scope-only callers.
+		var asset *manifest.Asset
 		var recoveredAuditData map[string]any
-		if asset == nil {
+		if published != nil {
+			asset = upsertAssetInheritingScopesTx(m, published)
+		} else if asset = m.FindAsset(assetName); asset == nil {
 			recovered, ok, err := assetFromStorage(vaultRoot, assetName)
 			if err != nil {
 				return nil, err

--- a/internal/vault/pathrepo.go
+++ b/internal/vault/pathrepo.go
@@ -266,17 +266,14 @@ func (p *PathVault) SetInstallations(ctx context.Context, asset *lockfile.Asset,
 	return commonSetInstallations(p.repoPath, actor, asset)
 }
 
-// InheritInstallations copies scopes from any existing entry of this
-// asset in the manifest, then upserts. Used when adding a new version of
-// an asset so its install scopes are preserved.
+// InheritInstallations upserts the asset into the manifest, carrying any
+// existing entry's scopes through verbatim. Used when adding a new version
+// of an asset so its install scopes are preserved.
 func (p *PathVault) InheritInstallations(ctx context.Context, asset *lockfile.Asset) error {
 	if err := p.ensureMigrated(ctx); err != nil {
 		return err
 	}
-	if err := inheritAssetScopesFromManifest(p.repoPath, asset); err != nil {
-		return err
-	}
-	return upsertAssetInManifest(p.repoPath, asset)
+	return upsertAssetInheritingScopes(p.repoPath, asset)
 }
 
 // RemoveAsset removes an asset from the manifest. If delete is true, the

--- a/internal/vault/pathrepo_mgmt.go
+++ b/internal/vault/pathrepo_mgmt.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gofrs/flock"
 
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/mgmt"
 )
 
@@ -230,7 +231,20 @@ func (p *PathVault) ClearAssetInstallations(ctx context.Context, assetName strin
 // the unified scope flow works against path vaults, not just the Sleuth vault.
 func (p *PathVault) SetAssetInstallations(ctx context.Context, assetName string, targets []InstallTarget, appendMode bool) (skipped []SkippedTarget, err error) {
 	err = p.withLock(ctx, func(actor mgmt.Actor) error {
-		skipped, err = commonSetAssetInstallations(ctx, p.repoPath, actor, assetName, targets, appendMode)
+		skipped, err = commonSetAssetInstallations(ctx, p.repoPath, actor, assetName, targets, appendMode, nil)
+		return err
+	})
+	return skipped, err
+}
+
+// SetPublishedAssetInstallations is SetAssetInstallations for a just-published
+// asset version: the manifest row advances to asset's version (existing scopes
+// carried through) in the SAME transaction the targets apply in, so a scoped
+// republish is atomic — the version and scopes change together or not at all.
+// Satisfies publishedInstallSetter.
+func (p *PathVault) SetPublishedAssetInstallations(ctx context.Context, asset *lockfile.Asset, targets []InstallTarget, appendMode bool) (skipped []SkippedTarget, err error) {
+	err = p.withLock(ctx, func(actor mgmt.Actor) error {
+		skipped, err = commonSetAssetInstallations(ctx, p.repoPath, actor, asset.Name, targets, appendMode, asset)
 		return err
 	})
 	return skipped, err


### PR DESCRIPTION
## Summary
- `Manifest.UpsertAsset` now keeps one `[[assets]]` block per asset name: a republish updates the existing row in place (version, source path) instead of appending a duplicate block; legacy duplicate rows are pruned on write
- A plain `--no-install` republish with no scope flags inherits the asset's existing scopes instead of silently re-scoping it to global
- `InheritInstallations` preserves scope rows verbatim at the manifest level — the previous `lockfile.Scope` round-trip silently dropped team/user/bot scopes, which would have globalized a team-scoped asset on every republish

## PR Stack
1. **This PR** - Update manifest row in place on republish
2. #197 - Advance manifest row on scoped republish (SK-672)

Fixes #190

**Security implications of changes have been considered**