### PR TITLE
SK-672: Advance manifest row on scoped republish (PR 2 of 2)

### DIFF
--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -115,6 +115,16 @@ type installSetter interface {
 	SetAssetInstallations(ctx context.Context, assetName string, targets []vault.InstallTarget, appendMode bool) (skipped []vault.SkippedTarget, err error)
 }
 
+// publishedInstallSetter is implemented by vaults whose manifest row must
+// advance when scopes are applied right after a publish (the file-backed
+// git/path vaults). The version bump and the scope apply happen in ONE
+// transaction — one commit on git vaults — so they land together or not at
+// all. The Sleuth vault doesn't implement it: the server registers versions
+// at upload, so its name-only installSetter path is already correct.
+type publishedInstallSetter interface {
+	SetPublishedAssetInstallations(ctx context.Context, asset *lockfile.Asset, targets []vault.InstallTarget, appendMode bool) (skipped []vault.SkippedTarget, err error)
+}
+
 // targetUninstaller is implemented by vaults that can remove specific
 // installations by server GID in one best-effort call (the Sleuth/skills.new
 // vault). It returns how many installs were removed and a per-target failure
@@ -132,22 +142,21 @@ func updateLockFile(ctx context.Context, out *outputHelper, repo vault.Vault, as
 		return applyScopeEdit(ctx, out, repo, asset.Name, result.Added, result.Removed)
 	}
 	if result.ApplyTargets || result.Append || hasIdentityScope(result.Targets) {
-		// The bulk installer keys on the asset NAME only, so it adjusts
-		// scopes on whatever version the manifest already pins. When this
-		// call follows a fresh publish, the manifest row must first advance
-		// to the just-published version (preserving its scopes) or the
-		// vault desyncs: archive and root view at the new version, manifest
-		// still resolving the old one. File-backed vaults upsert the row
-		// here; the Sleuth vault registers versions at upload and its
-		// InheritInstallations is a no-op. Scope-only callers (`sx install
-		// --repo X asset`) pass a bare name with no version — nothing was
-		// published, so there is no row to advance.
+		// The plain bulk installer keys on the asset NAME only, so it
+		// adjusts scopes on whatever version the manifest already pins.
+		// When this call follows a fresh publish, the manifest row must
+		// also advance to the just-published version (preserving its
+		// scopes) or the vault desyncs: archive and root view at the new
+		// version, manifest still resolving the old one. Passing the asset
+		// through lets file-backed vaults fold that advance into the same
+		// transaction as the scope apply. Scope-only callers (`sx install
+		// --repo X asset`) carry no version — nothing was published, so
+		// there is no row to advance.
+		var published *lockfile.Asset
 		if asset.Version != "" {
-			if err := repo.InheritInstallations(ctx, asset); err != nil {
-				return fmt.Errorf("failed to update asset version in manifest: %w", err)
-			}
+			published = asset
 		}
-		return bulkSetInstallTargets(ctx, out, repo, asset.Name, result.Targets, result.Append)
+		return bulkSetInstallTargets(ctx, out, repo, asset.Name, published, result.Targets, result.Append)
 	}
 
 	// SetInstallations updates the vault's lock file with the installation configuration
@@ -161,8 +170,11 @@ func updateLockFile(ctx context.Context, out *outputHelper, repo vault.Vault, as
 
 // bulkSetInstallTargets resolves the "me" alias and persists targets via the
 // vault's bulk installer. appendMode merges with the asset's existing
-// installations server-side; otherwise the set is replaced.
-func bulkSetInstallTargets(ctx context.Context, out *outputHelper, repo vault.Vault, assetName string, targets []vault.InstallTarget, appendMode bool) error {
+// installations server-side; otherwise the set is replaced. A non-nil
+// published asset routes through the vault's published-aware installer when
+// it has one, advancing the manifest row to that version in the same
+// transaction (see publishedInstallSetter).
+func bulkSetInstallTargets(ctx context.Context, out *outputHelper, repo vault.Vault, assetName string, published *lockfile.Asset, targets []vault.InstallTarget, appendMode bool) error {
 	setter, ok := repo.(installSetter)
 	if !ok {
 		return errors.New("this vault does not support team/user/bot scopes")
@@ -171,7 +183,12 @@ func bulkSetInstallTargets(ctx context.Context, out *outputHelper, repo vault.Va
 	if err != nil {
 		return err
 	}
-	skipped, err := setter.SetAssetInstallations(ctx, assetName, resolved, appendMode)
+	var skipped []vault.SkippedTarget
+	if ps, isPublished := repo.(publishedInstallSetter); isPublished && published != nil {
+		skipped, err = ps.SetPublishedAssetInstallations(ctx, published, resolved, appendMode)
+	} else {
+		skipped, err = setter.SetAssetInstallations(ctx, assetName, resolved, appendMode)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to set installations: %w", err)
 	}
@@ -222,7 +239,9 @@ func applyScopeEdit(ctx context.Context, out *outputHelper, repo vault.Vault, as
 	if len(added) > 0 {
 		// Append the new targets; resolveSelfUserScopes ("me") and entity
 		// resolution happen inside bulkSetInstallTargets.
-		if err := bulkSetInstallTargets(ctx, out, repo, assetName, added, true); err != nil {
+		// Scope edits adjust an existing installation; no publish precedes
+		// them, so there is no version row to advance (published = nil).
+		if err := bulkSetInstallTargets(ctx, out, repo, assetName, nil, added, true); err != nil {
 			return err
 		}
 	}

--- a/internal/commands/add_lockfile.go
+++ b/internal/commands/add_lockfile.go
@@ -132,6 +132,21 @@ func updateLockFile(ctx context.Context, out *outputHelper, repo vault.Vault, as
 		return applyScopeEdit(ctx, out, repo, asset.Name, result.Added, result.Removed)
 	}
 	if result.ApplyTargets || result.Append || hasIdentityScope(result.Targets) {
+		// The bulk installer keys on the asset NAME only, so it adjusts
+		// scopes on whatever version the manifest already pins. When this
+		// call follows a fresh publish, the manifest row must first advance
+		// to the just-published version (preserving its scopes) or the
+		// vault desyncs: archive and root view at the new version, manifest
+		// still resolving the old one. File-backed vaults upsert the row
+		// here; the Sleuth vault registers versions at upload and its
+		// InheritInstallations is a no-op. Scope-only callers (`sx install
+		// --repo X asset`) pass a bare name with no version — nothing was
+		// published, so there is no row to advance.
+		if asset.Version != "" {
+			if err := repo.InheritInstallations(ctx, asset); err != nil {
+				return fmt.Errorf("failed to update asset version in manifest: %w", err)
+			}
+		}
 		return bulkSetInstallTargets(ctx, out, repo, asset.Name, result.Targets, result.Append)
 	}
 

--- a/internal/commands/add_republish_test.go
+++ b/internal/commands/add_republish_test.go
@@ -52,3 +52,79 @@ func TestRepublishUpdatesManifestRowInPlace(t *testing.T) {
 		t.Fatalf("scopes = %+v, want the original repo scope preserved", row.Scopes)
 	}
 }
+
+// republishedRow loads the vault manifest and returns the single row for
+// name, failing the test on duplicates or absence.
+func republishedRow(t *testing.T, vaultDir, name string) manifest.Asset {
+	t.Helper()
+	m, ok, err := manifest.Load(vaultDir)
+	if err != nil || !ok {
+		t.Fatalf("load vault manifest: ok=%v err=%v", ok, err)
+	}
+	var rows []manifest.Asset
+	for _, a := range m.Assets {
+		if a.Name == name {
+			rows = append(rows, a)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("manifest rows for %s = %d, want exactly 1", name, len(rows))
+	}
+	return rows[0]
+}
+
+// TestRepublishWithReplaceScopeAdvancesManifest covers issue #191: a
+// republish routed through the bulk scope installer (--org --replace-scope)
+// must advance the manifest row to the just-published version. Before the
+// fix, the archive and root view moved to v2 while sx.toml stayed pinned at
+// v1 — a silent desync where authors ship a version consumers never receive.
+func TestRepublishWithReplaceScopeAdvancesManifest(t *testing.T) {
+	env := NewTestEnv(t)
+	vaultDir := env.SetupPathVault()
+	sourceDir := createSourceSkill(env, "resc-skill")
+
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--repo", "git@github.com:org/consumer.git"); err != nil {
+		t.Fatalf("add v1: %v\n%s", err, out)
+	}
+	env.WriteFile(filepath.Join(sourceDir, "SKILL.md"), "You are resc-skill (edited)")
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--org", "--replace-scope"); err != nil {
+		t.Fatalf("republish --org --replace-scope: %v\n%s", err, out)
+	}
+
+	row := republishedRow(t, vaultDir, "resc-skill")
+	if row.Version != "2" {
+		t.Errorf("manifest pins version %q, want \"2\" (archive advanced without the manifest)", row.Version)
+	}
+	if row.SourcePath == nil || row.SourcePath.Path != ".sx/versions/resc-skill/2" {
+		t.Errorf("source path = %+v, want .sx/versions/resc-skill/2", row.SourcePath)
+	}
+	// --org is the empty scope set: the repo scope is replaced, org-wide.
+	if len(row.Scopes) != 0 {
+		t.Errorf("scopes = %+v, want none (org-wide)", row.Scopes)
+	}
+}
+
+// TestRepublishWithAppendScopeAdvancesManifest is the append-mode variant of
+// issue #191: `sx add --repo Y` on a new version must bump the row AND end up
+// with both the inherited and the newly appended scope.
+func TestRepublishWithAppendScopeAdvancesManifest(t *testing.T) {
+	env := NewTestEnv(t)
+	vaultDir := env.SetupPathVault()
+	sourceDir := createSourceSkill(env, "appd-skill")
+
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--repo", "git@github.com:org/one.git"); err != nil {
+		t.Fatalf("add v1: %v\n%s", err, out)
+	}
+	env.WriteFile(filepath.Join(sourceDir, "SKILL.md"), "You are appd-skill (edited)")
+	if out, err := execAdd(sourceDir, "--yes", "--no-install", "--repo", "git@github.com:org/two.git"); err != nil {
+		t.Fatalf("republish --repo two: %v\n%s", err, out)
+	}
+
+	row := republishedRow(t, vaultDir, "appd-skill")
+	if row.Version != "2" {
+		t.Errorf("manifest pins version %q, want \"2\"", row.Version)
+	}
+	if len(row.Scopes) != 2 {
+		t.Fatalf("scopes = %+v, want inherited repo one + appended repo two", row.Scopes)
+	}
+}

--- a/internal/vault/gitrepo_mgmt.go
+++ b/internal/vault/gitrepo_mgmt.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sleuth-io/sx/internal/cache"
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/logger"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
@@ -355,7 +356,22 @@ func (g *GitVault) SetAssetInstallations(ctx context.Context, assetName string, 
 	}
 	msg := verb + assetName
 	err = g.runInVaultTx(ctx, msg, func(root string, actor mgmt.Actor) error {
-		skipped, err = commonSetAssetInstallations(ctx, root, actor, assetName, targets, appendMode)
+		skipped, err = commonSetAssetInstallations(ctx, root, actor, assetName, targets, appendMode, nil)
+		return err
+	})
+	return skipped, err
+}
+
+// SetPublishedAssetInstallations is SetAssetInstallations for a just-published
+// asset version: the manifest row advances to asset's version (existing scopes
+// carried through) in the SAME transaction — and so the same commit/push — the
+// targets apply in. A scoped republish therefore lands as one commit, and the
+// version and scopes change together or not at all. Satisfies
+// publishedInstallSetter.
+func (g *GitVault) SetPublishedAssetInstallations(ctx context.Context, asset *lockfile.Asset, targets []InstallTarget, appendMode bool) (skipped []SkippedTarget, err error) {
+	msg := fmt.Sprintf("Set %s %s installations", asset.Name, asset.Version)
+	err = g.runInVaultTx(ctx, msg, func(root string, actor mgmt.Actor) error {
+		skipped, err = commonSetAssetInstallations(ctx, root, actor, asset.Name, targets, appendMode, asset)
 		return err
 	})
 	return skipped, err

--- a/internal/vault/manifest_assets.go
+++ b/internal/vault/manifest_assets.go
@@ -81,6 +81,16 @@ func upsertAssetInheritingScopes(vaultRoot string, asset *lockfile.Asset) error 
 	if err != nil {
 		return err
 	}
+	upsertAssetInheritingScopesTx(m, asset)
+	return manifest.Save(vaultRoot, m)
+}
+
+// upsertAssetInheritingScopesTx is upsertAssetInheritingScopes against an
+// already-loaded manifest, for callers composing it into a larger
+// transaction (commonSetAssetInstallations folds the version advance and
+// the scope apply into one manifest write — and one commit on git vaults).
+// Returns the upserted row.
+func upsertAssetInheritingScopesTx(m *manifest.Manifest, asset *lockfile.Asset) *manifest.Asset {
 	// Gather scopes from EVERY same-name row, not just FindAsset's first
 	// match: the rest of the system treats an asset's effective scopes as
 	// the union across legacy duplicate rows (see commonCurrentInstallTargets),
@@ -120,7 +130,7 @@ func upsertAssetInheritingScopes(vaultRoot string, asset *lockfile.Asset) error 
 	if inherit {
 		row.Scopes = preserved
 	}
-	return manifest.Save(vaultRoot, m)
+	return row
 }
 
 // removeAssetFromManifest deletes every entry for the named asset, or

--- a/internal/vault/mgmt_bulk_install_test.go
+++ b/internal/vault/mgmt_bulk_install_test.go
@@ -5,10 +5,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/manifest"
 	"github.com/sleuth-io/sx/internal/mgmt"
 )
@@ -306,5 +311,168 @@ func TestSleuthOrgInstallAlwaysReplaces(t *testing.T) {
 	}
 	if gotAppend == nil || *gotAppend {
 		t.Fatalf("org install sent append=%v, want explicit false (replace)", gotAppend)
+	}
+}
+
+// TestPathVault_SetPublishedAssetInstallations_AdvancesRow pins issue #191's
+// single-transaction fix: applying scopes for a just-published version must
+// advance the manifest row to that version in the same write, carrying
+// existing scopes through and then applying the new targets.
+func TestPathVault_SetPublishedAssetInstallations_AdvancesRow(t *testing.T) {
+	v, dir := seedBulkInstallVault(t)
+	ctx := context.Background()
+
+	published := &lockfile.Asset{
+		Name: "my-skill", Version: "2.0.0", Type: asset.TypeSkill,
+		SourcePath: &lockfile.SourcePath{Path: ".sx/versions/my-skill/2.0.0"},
+	}
+	skipped, err := v.SetPublishedAssetInstallations(ctx, published, []InstallTarget{
+		{Kind: InstallKindRepo, Repo: "github.com/acme/extra"},
+	}, true)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("SetPublishedAssetInstallations: skipped=%v err=%v", skipped, err)
+	}
+
+	m, _, err := manifest.LoadOrMigrate(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := m.FindAsset("my-skill")
+	if a == nil || a.Version != "2.0.0" {
+		t.Fatalf("row = %+v, want version 2.0.0", a)
+	}
+	if a.SourcePath == nil || a.SourcePath.Path != ".sx/versions/my-skill/2.0.0" {
+		t.Errorf("source path = %+v, want the published archive path", a.SourcePath)
+	}
+	if len(a.Scopes) != 2 {
+		t.Errorf("scopes = %+v, want baseline repo scope + appended repo scope", a.Scopes)
+	}
+}
+
+// TestPathVault_SetPublishedAssetInstallations_AllSkippedLeavesRow pins the
+// atomicity half of the fix: when every requested target is skipped, the
+// version must NOT advance either — the manifest stays exactly as it was,
+// rather than committing a version bump whose scope change never landed.
+func TestPathVault_SetPublishedAssetInstallations_AllSkippedLeavesRow(t *testing.T) {
+	v, dir := seedBulkInstallVault(t)
+	ctx := context.Background()
+
+	published := &lockfile.Asset{
+		Name: "my-skill", Version: "2.0.0", Type: asset.TypeSkill,
+		SourcePath: &lockfile.SourcePath{Path: ".sx/versions/my-skill/2.0.0"},
+	}
+	skipped, err := v.SetPublishedAssetInstallations(ctx, published, []InstallTarget{
+		{Kind: InstallKindTeam, Team: "ghost-team"},
+	}, false)
+	if err != nil {
+		t.Fatalf("SetPublishedAssetInstallations: %v", err)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %+v, want the unknown team reported", skipped)
+	}
+
+	m, _, err := manifest.LoadOrMigrate(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := m.FindAsset("my-skill")
+	if a == nil || a.Version != "1.0.0" {
+		t.Fatalf("row = %+v, want version still 1.0.0 (nothing applied, nothing advanced)", a)
+	}
+	if len(a.Scopes) != 1 || a.Scopes[0].Kind != manifest.ScopeKindRepo {
+		t.Errorf("scopes = %+v, want the baseline repo scope untouched", a.Scopes)
+	}
+}
+
+// TestGitVault_SetPublishedAssetInstallations_OneCommit pins the other half
+// of the issue #191 review feedback: a scoped republish must land the version
+// advance and the scope change as ONE commit on git vaults, not a version
+// commit followed by a separate scope commit.
+func TestGitVault_SetPublishedAssetInstallations_OneCommit(t *testing.T) {
+	mgmt.ResetActorCache()
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	remoteDir := filepath.Join(t.TempDir(), "vault.git")
+	gitRun(t, "", "init", "--bare", "-b", "main", remoteDir)
+
+	seedDir := filepath.Join(t.TempDir(), "seed")
+	gitRun(t, "", "init", "-b", "main", seedDir)
+	gitRun(t, seedDir, "config", "user.email", "seed@example.com")
+	gitRun(t, seedDir, "config", "user.name", "Seed")
+	for _, rel := range []string{
+		".sx/versions/my-skill/1/SKILL.md",
+		"assets/my-skill/SKILL.md",
+	} {
+		path := filepath.Join(seedDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("# my-skill"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(seedDir, ".sx", "versions", "my-skill", "list.txt"), []byte("1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.Save(seedDir, &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{{
+			Name: "my-skill", Version: "1", Type: asset.TypeSkill,
+			SourcePath: &manifest.SourcePath{Path: ".sx/versions/my-skill/1"},
+			Scopes: []manifest.Scope{
+				{Kind: manifest.ScopeKindRepo, Repo: "github.com/acme/baseline"},
+			},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, seedDir, "add", ".")
+	gitRun(t, seedDir, "commit", "-m", "seed v2 vault")
+	gitRun(t, seedDir, "remote", "add", "origin", remoteDir)
+	gitRun(t, seedDir, "push", "origin", "main")
+
+	v, err := NewGitVault("file://" + remoteDir)
+	if err != nil {
+		t.Fatalf("NewGitVault: %v", err)
+	}
+	if _, _, _, err := v.GetLockFile(context.Background(), ""); err != nil {
+		t.Fatalf("GetLockFile (forces clone): %v", err)
+	}
+	gitRun(t, v.repoPath, "config", "user.email", "alice@example.com")
+	gitRun(t, v.repoPath, "config", "user.name", "Alice")
+	mgmt.ResetActorCache()
+
+	before := strings.TrimSpace(gitOut(t, "", "--git-dir", remoteDir, "rev-list", "--count", "main"))
+
+	published := &lockfile.Asset{
+		Name: "my-skill", Version: "2", Type: asset.TypeSkill,
+		SourcePath: &lockfile.SourcePath{Path: ".sx/versions/my-skill/2"},
+	}
+	skipped, err := v.SetPublishedAssetInstallations(context.Background(), published,
+		[]InstallTarget{{Kind: InstallKindOrg}}, false)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("SetPublishedAssetInstallations: skipped=%v err=%v", skipped, err)
+	}
+
+	after := strings.TrimSpace(gitOut(t, "", "--git-dir", remoteDir, "rev-list", "--count", "main"))
+	beforeN, _ := strconv.Atoi(before)
+	afterN, _ := strconv.Atoi(after)
+	if afterN != beforeN+1 {
+		log := gitOut(t, "", "--git-dir", remoteDir, "log", "--format=%s", "main")
+		t.Fatalf("commits: before=%d after=%d, want exactly one new commit; log:\n%s", beforeN, afterN, log)
+	}
+
+	verify := filepath.Join(t.TempDir(), "verify")
+	gitRun(t, "", "clone", remoteDir, verify)
+	m, _, err := manifest.Load(verify)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := m.FindAsset("my-skill")
+	if a == nil || a.Version != "2" {
+		t.Fatalf("row = %+v, want version 2 on the remote", a)
+	}
+	if len(a.Scopes) != 0 {
+		t.Errorf("scopes = %+v, want none (org-wide replace)", a.Scopes)
 	}
 }

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -1022,7 +1022,14 @@ func commonClearAssetInstallations(vaultRoot string, actor mgmt.Actor, assetName
 // caller to surface — it never aborts the whole batch on one bad target. If
 // NOTHING resolves, the asset is left untouched rather than cleared, so a
 // REPLACE whose targets all fail can't silently globalize the asset.
-func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget, appendMode bool) ([]SkippedTarget, error) {
+//
+// published, when non-nil, is a just-published asset version whose manifest
+// row must advance as part of the same transaction (scopes carried through
+// before the targets apply). Folding the advance in here keeps a scoped
+// republish to ONE manifest write — one commit/push on git vaults — and
+// makes it atomic: when every target is skipped, neither the version nor
+// the scopes change.
+func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mgmt.Actor, assetName string, targets []InstallTarget, appendMode bool, published *lockfile.Asset) ([]SkippedTarget, error) {
 	if len(targets) == 0 {
 		return nil, nil
 	}
@@ -1077,9 +1084,16 @@ func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mg
 			}
 		}
 
-		asset := m.FindAsset(assetName)
+		// Past the early returns: at least one target will apply, so the
+		// just-published version (when given) advances in the same write.
+		// Its upsert inserts or replaces the row and carries existing
+		// scopes through, so the storage-recovery path below is only for
+		// scope-only callers.
+		var asset *manifest.Asset
 		var recoveredAuditData map[string]any
-		if asset == nil {
+		if published != nil {
+			asset = upsertAssetInheritingScopesTx(m, published)
+		} else if asset = m.FindAsset(assetName); asset == nil {
 			recovered, ok, err := assetFromStorage(vaultRoot, assetName)
 			if err != nil {
 				return nil, err

--- a/internal/vault/pathrepo_mgmt.go
+++ b/internal/vault/pathrepo_mgmt.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gofrs/flock"
 
+	"github.com/sleuth-io/sx/internal/lockfile"
 	"github.com/sleuth-io/sx/internal/mgmt"
 )
 
@@ -230,7 +231,20 @@ func (p *PathVault) ClearAssetInstallations(ctx context.Context, assetName strin
 // the unified scope flow works against path vaults, not just the Sleuth vault.
 func (p *PathVault) SetAssetInstallations(ctx context.Context, assetName string, targets []InstallTarget, appendMode bool) (skipped []SkippedTarget, err error) {
 	err = p.withLock(ctx, func(actor mgmt.Actor) error {
-		skipped, err = commonSetAssetInstallations(ctx, p.repoPath, actor, assetName, targets, appendMode)
+		skipped, err = commonSetAssetInstallations(ctx, p.repoPath, actor, assetName, targets, appendMode, nil)
+		return err
+	})
+	return skipped, err
+}
+
+// SetPublishedAssetInstallations is SetAssetInstallations for a just-published
+// asset version: the manifest row advances to asset's version (existing scopes
+// carried through) in the SAME transaction the targets apply in, so a scoped
+// republish is atomic — the version and scopes change together or not at all.
+// Satisfies publishedInstallSetter.
+func (p *PathVault) SetPublishedAssetInstallations(ctx context.Context, asset *lockfile.Asset, targets []InstallTarget, appendMode bool) (skipped []SkippedTarget, err error) {
+	err = p.withLock(ctx, func(actor mgmt.Actor) error {
+		skipped, err = commonSetAssetInstallations(ctx, p.repoPath, actor, asset.Name, targets, appendMode, asset)
 		return err
 	})
 	return skipped, err


### PR DESCRIPTION
## Summary
- The bulk scope path (`--org`/`--repo`/`--team`/... with or without `--replace-scope`) keys on the asset name only, so after a fresh publish it adjusted scopes on the old version row and never advanced it — archive and root view at v2, `sx.toml` still resolving v1
- `updateLockFile` now syncs the manifest row to the just-published version (scopes preserved) before applying scope targets
- Scope-only callers (`sx install --repo X asset`) pass no version and skip the sync

## PR Stack
1. #196 - Update manifest row in place on republish (SK-671)
2. **This PR** - Advance manifest row on scoped republish

Stacked on #196 (uses its scope-preserving upsert); merge that first, then retarget this to `main`.

Fixes #191

**Security implications of changes have been considered**