### PR TITLE
SK-675: App draft diffs, highlighting, and bots

### DIFF
--- a/app/bots.go
+++ b/app/bots.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/sleuth-io/sx/internal/mgmt"
+)
+
+// Bots are non-human identities skills can be installed into. Like
+// repositories, they're a technical concept behind the same per-library
+// opt-in (Profile.TrackRepos): people who run bots see them in the
+// sidebar; everyone else never pays for the concept.
+
+// BotInfo is the frontend view of a bot. Skills is the bot's resolved
+// skill set (direct installs plus team and org-wide installs), which
+// drives the sidebar count and the bot scope's asset list.
+type BotInfo struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Teams       []string `json:"teams"`
+	Skills      []string `json:"skills"`
+}
+
+// BotCreated reports a new bot plus the API token Sleuth vaults auto-issue
+// with it. The token is shown exactly once — file-based vaults are
+// identity-only and return "".
+type BotCreated struct {
+	Bot   BotInfo `json:"bot"`
+	Token string  `json:"token"`
+}
+
+// botManager is the slice of the vault interface bot operations need.
+type botManager interface {
+	ListBots(ctx context.Context) ([]mgmt.Bot, error)
+	GetBot(ctx context.Context, name string) (*mgmt.Bot, error)
+	CreateBot(ctx context.Context, bot mgmt.Bot) (string, error)
+	UpdateBot(ctx context.Context, bot mgmt.Bot) error
+	DeleteBot(ctx context.Context, name string) error
+	AddBotTeam(ctx context.Context, bot, team string) error
+	RemoveBotTeam(ctx context.Context, bot, team string) error
+}
+
+func (a *App) botVault() (botManager, error) {
+	v, err := a.currentVault()
+	if err != nil {
+		return nil, err
+	}
+	bm, ok := v.(botManager)
+	if !ok {
+		return nil, errors.New("this library doesn't support bots")
+	}
+	return bm, nil
+}
+
+// ListBots returns the vault's bots with their resolved skills. Vaults
+// without bot support list none rather than erroring — the sidebar
+// section simply stays empty, mirroring RepoAssets.
+func (a *App) ListBots() ([]BotInfo, error) {
+	bm, err := a.botVault()
+	if err != nil {
+		return []BotInfo{}, nil
+	}
+	bots, err := bm.ListBots(a.ctx)
+	if err != nil {
+		return nil, friendlyVaultError(err)
+	}
+	out := make([]BotInfo, 0, len(bots))
+	for _, b := range bots {
+		skills := make([]string, 0, len(b.InstalledSkills))
+		for _, s := range b.InstalledSkills {
+			skills = append(skills, s.Name)
+		}
+		sort.Strings(skills)
+		out = append(out, BotInfo{
+			Name:        b.Name,
+			Description: b.Description,
+			Teams:       append([]string{}, b.Teams...),
+			Skills:      skills,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// CreateBot makes a new bot. The returned token is non-empty only on
+// Sleuth vaults (an auto-issued API key, shown once).
+func (a *App) CreateBot(name, description string) (BotCreated, error) {
+	name = slugify(name)
+	if name == "" {
+		return BotCreated{}, errors.New("give the bot a name")
+	}
+	bm, err := a.botVault()
+	if err != nil {
+		return BotCreated{}, err
+	}
+	token, err := bm.CreateBot(a.ctx, mgmt.Bot{Name: name, Description: description})
+	if err != nil {
+		return BotCreated{}, friendlyVaultError(err)
+	}
+	return BotCreated{
+		Bot:   BotInfo{Name: name, Description: description, Teams: []string{}, Skills: []string{}},
+		Token: token,
+	}, nil
+}
+
+// DeleteBot removes a bot. Bot-scoped installs referencing it stop
+// resolving; assets themselves are untouched. Callers confirm first.
+func (a *App) DeleteBot(name string) error {
+	bm, err := a.botVault()
+	if err != nil {
+		return err
+	}
+	if err := bm.DeleteBot(a.ctx, name); err != nil {
+		return friendlyVaultError(err)
+	}
+	return nil
+}
+
+// UpdateBotDescription changes a bot's description, leaving teams and
+// installs untouched.
+func (a *App) UpdateBotDescription(name, description string) error {
+	bm, err := a.botVault()
+	if err != nil {
+		return err
+	}
+	bot, err := bm.GetBot(a.ctx, name)
+	if err != nil {
+		return friendlyVaultError(err)
+	}
+	bot.Description = description
+	if err := bm.UpdateBot(a.ctx, *bot); err != nil {
+		return friendlyVaultError(err)
+	}
+	return nil
+}
+
+// SetBotTeam adds (member=true) or removes a bot from a team. Team
+// membership gives the bot the team's skills and repo context.
+func (a *App) SetBotTeam(bot, team string, member bool) error {
+	bm, err := a.botVault()
+	if err != nil {
+		return err
+	}
+	if member {
+		err = bm.AddBotTeam(a.ctx, bot, team)
+	} else {
+		err = bm.RemoveBotTeam(a.ctx, bot, team)
+	}
+	if err != nil {
+		return friendlyVaultError(err)
+	}
+	return nil
+}

--- a/app/bots_test.go
+++ b/app/bots_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"testing"
+)
+
+// botTestApp returns an App backed by a fresh path vault (which supports
+// bot and team management) with a configured identity.
+func botTestApp(t *testing.T) *App {
+	t.Helper()
+	a, _, _ := scopedExtensionApp(t, "alice@example.com")
+	return a
+}
+
+func TestBots_CreateListDelete(t *testing.T) {
+	a := botTestApp(t)
+
+	created, err := a.CreateBot("CI Bot", "runs in CI")
+	if err != nil {
+		t.Fatalf("CreateBot: %v", err)
+	}
+	if created.Bot.Name != "ci-bot" {
+		t.Fatalf("name = %q, want slugified ci-bot", created.Bot.Name)
+	}
+	// File-based vaults are identity-only: no auto-issued token.
+	if created.Token != "" {
+		t.Fatalf("token = %q, want empty on a path vault", created.Token)
+	}
+
+	bots, err := a.ListBots()
+	if err != nil {
+		t.Fatalf("ListBots: %v", err)
+	}
+	if len(bots) != 1 || bots[0].Name != "ci-bot" || bots[0].Description != "runs in CI" {
+		t.Fatalf("bots = %+v", bots)
+	}
+	if bots[0].Skills == nil || bots[0].Teams == nil {
+		t.Fatalf("Skills/Teams must be non-nil for the frontend: %+v", bots[0])
+	}
+
+	if err := a.DeleteBot("ci-bot"); err != nil {
+		t.Fatalf("DeleteBot: %v", err)
+	}
+	bots, err = a.ListBots()
+	if err != nil {
+		t.Fatalf("ListBots after delete: %v", err)
+	}
+	if len(bots) != 0 {
+		t.Fatalf("bots after delete = %+v", bots)
+	}
+}
+
+func TestBots_UpdateDescription(t *testing.T) {
+	a := botTestApp(t)
+	if _, err := a.CreateBot("deploy-bot", ""); err != nil {
+		t.Fatalf("CreateBot: %v", err)
+	}
+	if err := a.UpdateBotDescription("deploy-bot", "ships releases"); err != nil {
+		t.Fatalf("UpdateBotDescription: %v", err)
+	}
+	bots, err := a.ListBots()
+	if err != nil {
+		t.Fatalf("ListBots: %v", err)
+	}
+	if len(bots) != 1 || bots[0].Description != "ships releases" {
+		t.Fatalf("bots = %+v", bots)
+	}
+}
+
+func TestBots_TeamMembership(t *testing.T) {
+	a := botTestApp(t)
+	if _, err := a.CreateTeam("platform"); err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	if _, err := a.CreateBot("ci-bot", ""); err != nil {
+		t.Fatalf("CreateBot: %v", err)
+	}
+
+	if err := a.SetBotTeam("ci-bot", "platform", true); err != nil {
+		t.Fatalf("SetBotTeam add: %v", err)
+	}
+	bots, err := a.ListBots()
+	if err != nil {
+		t.Fatalf("ListBots: %v", err)
+	}
+	if len(bots) != 1 || len(bots[0].Teams) != 1 || bots[0].Teams[0] != "platform" {
+		t.Fatalf("bots = %+v", bots)
+	}
+
+	if err := a.SetBotTeam("ci-bot", "platform", false); err != nil {
+		t.Fatalf("SetBotTeam remove: %v", err)
+	}
+	bots, err = a.ListBots()
+	if err != nil {
+		t.Fatalf("ListBots: %v", err)
+	}
+	if len(bots[0].Teams) != 0 {
+		t.Fatalf("teams after remove = %+v", bots[0].Teams)
+	}
+}
+
+func TestBots_CreateValidation(t *testing.T) {
+	a := botTestApp(t)
+	if _, err := a.CreateBot("   ", ""); err == nil {
+		t.Fatalf("want error for empty bot name")
+	}
+}

--- a/app/diff.go
+++ b/app/diff.go
@@ -135,10 +135,10 @@ func splitLines(s string) []string {
 	return strings.Split(s, "\n")
 }
 
-// maxDiffCells caps the LCS table. Beyond it (two ~2000-line files that
-// share nothing) the whole middle renders as delete-then-add — still
-// correct, just less minimal.
-const maxDiffCells = 4_000_000
+// maxDiffCells caps the LCS table at ~4MB (int32 cells). Beyond it (two
+// ~1000-line files sharing no prefix or suffix) the whole middle renders
+// as delete-then-add — still correct, just less minimal.
+const maxDiffCells = 1_000_000
 
 // diffLines produces a full (context-inclusive) line diff of old → new
 // using longest-common-subsequence on the middle after trimming the common
@@ -202,22 +202,20 @@ type diffStep struct {
 }
 
 // lcsDiff walks a longest-common-subsequence table to produce the minimal
-// del/add/context sequence for two line slices.
+// del/add/context sequence for two line slices. The table is one flat
+// int32 slice — a single allocation, half the memory of int cells, and
+// line counts can't overflow int32 under maxDiffCells anyway.
 func lcsDiff(a, b []string) []diffStep {
 	m, n := len(a), len(b)
-	// lcs[i][j] = LCS length of a[i:] and b[j:].
-	lcs := make([][]int, m+1)
-	for i := range lcs {
-		lcs[i] = make([]int, n+1)
-	}
+	// lcs[i*(n+1)+j] = LCS length of a[i:] and b[j:].
+	w := n + 1
+	lcs := make([]int32, (m+1)*w)
 	for i := m - 1; i >= 0; i-- {
 		for j := n - 1; j >= 0; j-- {
 			if a[i] == b[j] {
-				lcs[i][j] = lcs[i+1][j+1] + 1
-			} else if lcs[i+1][j] >= lcs[i][j+1] {
-				lcs[i][j] = lcs[i+1][j]
+				lcs[i*w+j] = lcs[(i+1)*w+j+1] + 1
 			} else {
-				lcs[i][j] = lcs[i][j+1]
+				lcs[i*w+j] = max(lcs[(i+1)*w+j], lcs[i*w+j+1])
 			}
 		}
 	}
@@ -230,7 +228,7 @@ func lcsDiff(a, b []string) []diffStep {
 			steps = append(steps, diffStep{"context", a[i]})
 			i++
 			j++
-		case lcs[i+1][j] >= lcs[i][j+1]:
+		case lcs[(i+1)*w+j] >= lcs[i*w+j+1]:
 			steps = append(steps, diffStep{"del", a[i]})
 			i++
 		default:

--- a/app/diff.go
+++ b/app/diff.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"sort"
+	"strings"
+)
+
+// The draft sheet's "Changes" view: what publishing this draft would change
+// relative to the latest published revision of its target asset. Diffs are
+// computed here (not in the frontend) so the same engine can serve future
+// surfaces (revision history, CLI) and stay under test.
+
+// DiffLine is one row of a rendered diff. Kind is "context", "add" or
+// "del"; OldNo/NewNo are 1-based line numbers, 0 on the side the line
+// doesn't exist.
+type DiffLine struct {
+	Kind  string `json:"kind"`
+	OldNo int    `json:"oldNo"`
+	NewNo int    `json:"newNo"`
+	Text  string `json:"text"`
+}
+
+// DiffHunk is a contiguous run of changed lines plus surrounding context,
+// mirroring a unified-diff @@ header.
+type DiffHunk struct {
+	OldStart int        `json:"oldStart"`
+	OldLines int        `json:"oldLines"`
+	NewStart int        `json:"newStart"`
+	NewLines int        `json:"newLines"`
+	Lines    []DiffLine `json:"lines"`
+}
+
+// FileDiff is one file's changes. Status is "added", "modified" or
+// "deleted".
+type FileDiff struct {
+	Path      string     `json:"path"`
+	Status    string     `json:"status"`
+	Additions int        `json:"additions"`
+	Deletions int        `json:"deletions"`
+	Hunks     []DiffHunk `json:"hunks"`
+}
+
+// DraftDiff is everything the Changes view renders: per-file diffs plus
+// whole-draft totals.
+type DraftDiff struct {
+	Files     []FileDiff `json:"files"`
+	Additions int        `json:"additions"`
+	Deletions int        `json:"deletions"`
+}
+
+// DiffDraft diffs a draft (as currently held by the sheet, saved or not)
+// against the latest published files of its target asset. A draft that
+// creates a new asset diffs against nothing: every file shows as added.
+func (a *App) DiffDraft(d Draft) (DraftDiff, error) {
+	base := map[string]string{}
+	if d.TargetAsset != "" {
+		detail, err := a.GetAsset(d.TargetAsset, "")
+		if err != nil {
+			return DraftDiff{}, err
+		}
+		for _, f := range detail.Files {
+			if f.Path == "metadata.toml" {
+				continue // regenerated on publish; never a user-visible change
+			}
+			base[f.Path] = f.Content
+		}
+	}
+	return diffFiles(base, d.Files), nil
+}
+
+// diffFiles pairs base and draft files by path and diffs each pair.
+func diffFiles(base map[string]string, files []AssetFile) DraftDiff {
+	draft := map[string]string{}
+	for _, f := range files {
+		if f.Path == "metadata.toml" {
+			continue
+		}
+		draft[f.Path] = f.Content
+	}
+
+	paths := make([]string, 0, len(base)+len(draft))
+	for p := range draft {
+		paths = append(paths, p)
+	}
+	for p := range base {
+		if _, ok := draft[p]; !ok && p != "metadata.toml" {
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+
+	var out DraftDiff
+	for _, p := range paths {
+		before, inBase := base[p]
+		after, inDraft := draft[p]
+		var fd FileDiff
+		switch {
+		case !inBase:
+			fd = fileDiff(p, "added", "", after)
+		case !inDraft:
+			fd = fileDiff(p, "deleted", before, "")
+		case before != after:
+			fd = fileDiff(p, "modified", before, after)
+		default:
+			continue // unchanged files stay out of the view entirely
+		}
+		out.Files = append(out.Files, fd)
+		out.Additions += fd.Additions
+		out.Deletions += fd.Deletions
+	}
+	return out
+}
+
+func fileDiff(path, status, before, after string) FileDiff {
+	lines := diffLines(splitLines(before), splitLines(after))
+	fd := FileDiff{Path: path, Status: status, Hunks: hunksFrom(lines)}
+	for _, l := range lines {
+		switch l.Kind {
+		case "add":
+			fd.Additions++
+		case "del":
+			fd.Deletions++
+		}
+	}
+	return fd
+}
+
+// splitLines splits content into lines without a phantom empty line for a
+// trailing newline.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.TrimSuffix(s, "\n")
+	return strings.Split(s, "\n")
+}
+
+// maxDiffCells caps the LCS table. Beyond it (two ~2000-line files that
+// share nothing) the whole middle renders as delete-then-add — still
+// correct, just less minimal.
+const maxDiffCells = 4_000_000
+
+// diffLines produces a full (context-inclusive) line diff of old → new
+// using longest-common-subsequence on the middle after trimming the common
+// prefix and suffix.
+func diffLines(oldLines, newLines []string) []DiffLine {
+	// Common prefix.
+	prefix := 0
+	for prefix < len(oldLines) && prefix < len(newLines) && oldLines[prefix] == newLines[prefix] {
+		prefix++
+	}
+	// Common suffix (of what remains).
+	suffix := 0
+	for suffix < len(oldLines)-prefix && suffix < len(newLines)-prefix &&
+		oldLines[len(oldLines)-1-suffix] == newLines[len(newLines)-1-suffix] {
+		suffix++
+	}
+
+	var out []DiffLine
+	oldNo, newNo := 1, 1
+	emit := func(kind, text string) {
+		l := DiffLine{Kind: kind, Text: text}
+		if kind != "add" {
+			l.OldNo = oldNo
+			oldNo++
+		}
+		if kind != "del" {
+			l.NewNo = newNo
+			newNo++
+		}
+		out = append(out, l)
+	}
+
+	for i := range prefix {
+		emit("context", oldLines[i])
+	}
+
+	midOld := oldLines[prefix : len(oldLines)-suffix]
+	midNew := newLines[prefix : len(newLines)-suffix]
+	if len(midOld)*len(midNew) > maxDiffCells {
+		for _, l := range midOld {
+			emit("del", l)
+		}
+		for _, l := range midNew {
+			emit("add", l)
+		}
+	} else {
+		for _, step := range lcsDiff(midOld, midNew) {
+			emit(step.kind, step.text)
+		}
+	}
+
+	for i := len(oldLines) - suffix; i < len(oldLines); i++ {
+		emit("context", oldLines[i])
+	}
+	return out
+}
+
+type diffStep struct {
+	kind string
+	text string
+}
+
+// lcsDiff walks a longest-common-subsequence table to produce the minimal
+// del/add/context sequence for two line slices.
+func lcsDiff(a, b []string) []diffStep {
+	m, n := len(a), len(b)
+	// lcs[i][j] = LCS length of a[i:] and b[j:].
+	lcs := make([][]int, m+1)
+	for i := range lcs {
+		lcs[i] = make([]int, n+1)
+	}
+	for i := m - 1; i >= 0; i-- {
+		for j := n - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	steps := make([]diffStep, 0, m+n)
+	i, j := 0, 0
+	for i < m && j < n {
+		switch {
+		case a[i] == b[j]:
+			steps = append(steps, diffStep{"context", a[i]})
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			steps = append(steps, diffStep{"del", a[i]})
+			i++
+		default:
+			steps = append(steps, diffStep{"add", b[j]})
+			j++
+		}
+	}
+	for ; i < m; i++ {
+		steps = append(steps, diffStep{"del", a[i]})
+	}
+	for ; j < n; j++ {
+		steps = append(steps, diffStep{"add", b[j]})
+	}
+	return steps
+}
+
+// hunkContext is how many unchanged lines surround each run of changes;
+// runs closer than 2*hunkContext merge into one hunk, as in git.
+const hunkContext = 3
+
+// hunksFrom groups a full line diff into unified-diff style hunks.
+func hunksFrom(lines []DiffLine) []DiffHunk {
+	var hunks []DiffHunk
+	i := 0
+	for i < len(lines) {
+		if lines[i].Kind == "context" {
+			i++
+			continue
+		}
+		// Found a change; open a hunk hunkContext lines back.
+		start := max(i-hunkContext, 0)
+		// Extend to the last change whose gap to the next change is small
+		// enough that the hunks would overlap.
+		end := i // exclusive index just past the last change so far
+		for j := i; j < len(lines); j++ {
+			if lines[j].Kind != "context" {
+				end = j + 1
+			} else if j-end >= 2*hunkContext {
+				break
+			}
+		}
+		stop := min(end+hunkContext, len(lines))
+
+		hunk := DiffHunk{Lines: lines[start:stop]}
+		for _, l := range hunk.Lines {
+			if l.Kind != "add" {
+				if hunk.OldStart == 0 {
+					hunk.OldStart = l.OldNo
+				}
+				hunk.OldLines++
+			}
+			if l.Kind != "del" {
+				if hunk.NewStart == 0 {
+					hunk.NewStart = l.NewNo
+				}
+				hunk.NewLines++
+			}
+		}
+		hunks = append(hunks, hunk)
+		i = stop
+	}
+	return hunks
+}

--- a/app/diff_test.go
+++ b/app/diff_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/asset"
+	"github.com/sleuth-io/sx/internal/lockfile"
+	"github.com/sleuth-io/sx/internal/mgmt"
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+func TestDiffLines_MinimalEdits(t *testing.T) {
+	lines := diffLines(
+		[]string{"a", "b", "c", "d"},
+		[]string{"a", "x", "c", "d", "e"},
+	)
+	var got []string
+	for _, l := range lines {
+		got = append(got, l.Kind+":"+l.Text)
+	}
+	want := []string{"context:a", "del:b", "add:x", "context:c", "context:d", "add:e"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("diff = %v, want %v", got, want)
+	}
+}
+
+func TestDiffLines_LineNumbers(t *testing.T) {
+	lines := diffLines([]string{"a", "b"}, []string{"a", "c"})
+	// context a: old 1 / new 1; del b: old 2; add c: new 2.
+	if lines[0].OldNo != 1 || lines[0].NewNo != 1 {
+		t.Fatalf("context numbering = %+v", lines[0])
+	}
+	if lines[1].Kind != "del" || lines[1].OldNo != 2 || lines[1].NewNo != 0 {
+		t.Fatalf("del numbering = %+v", lines[1])
+	}
+	if lines[2].Kind != "add" || lines[2].NewNo != 2 || lines[2].OldNo != 0 {
+		t.Fatalf("add numbering = %+v", lines[2])
+	}
+}
+
+// Whatever the shape of the edit, every old line must appear as context or
+// del and every new line as context or add, in order.
+func TestDiffLines_Reconstructs(t *testing.T) {
+	oldLines := []string{"one", "two", "three", "four", "five"}
+	newLines := []string{"zero", "one", "three", "3.5", "five", "six"}
+	var gotOld, gotNew []string
+	for _, l := range diffLines(oldLines, newLines) {
+		if l.Kind != "add" {
+			gotOld = append(gotOld, l.Text)
+		}
+		if l.Kind != "del" {
+			gotNew = append(gotNew, l.Text)
+		}
+	}
+	if strings.Join(gotOld, ",") != strings.Join(oldLines, ",") {
+		t.Fatalf("old side = %v", gotOld)
+	}
+	if strings.Join(gotNew, ",") != strings.Join(newLines, ",") {
+		t.Fatalf("new side = %v", gotNew)
+	}
+}
+
+func TestSplitLines_NoPhantomTrailingLine(t *testing.T) {
+	if got := splitLines("a\nb\n"); len(got) != 2 {
+		t.Fatalf("splitLines with trailing newline = %v", got)
+	}
+	if got := splitLines(""); got != nil {
+		t.Fatalf("splitLines(\"\") = %v, want nil", got)
+	}
+}
+
+func TestHunksFrom_GroupsAndMerges(t *testing.T) {
+	// 20 identical lines with changes at 5 and 9 (0-based): close enough
+	// (gap of 3 < 2*hunkContext) that they must share one hunk.
+	oldLines := make([]string, 20)
+	newLines := make([]string, 20)
+	for i := range oldLines {
+		oldLines[i] = fmt.Sprintf("line %d", i)
+		newLines[i] = oldLines[i]
+	}
+	newLines[5] = "changed 5"
+	newLines[9] = "changed 9"
+
+	hunks := hunksFrom(diffLines(oldLines, newLines))
+	if len(hunks) != 1 {
+		t.Fatalf("hunks = %d, want 1 (merged)", len(hunks))
+	}
+	h := hunks[0]
+	// 3 context above line 5 (old line numbers are 1-based → starts at 3).
+	if h.OldStart != 3 || h.NewStart != 3 {
+		t.Fatalf("hunk starts at %d/%d, want 3/3", h.OldStart, h.NewStart)
+	}
+	if h.OldLines != h.NewLines {
+		t.Fatalf("hunk sides differ: %d vs %d", h.OldLines, h.NewLines)
+	}
+
+	// Push the second change out of merge range: two hunks.
+	newLines[9] = oldLines[9]
+	newLines[15] = "changed 15"
+	if hunks := hunksFrom(diffLines(oldLines, newLines)); len(hunks) != 2 {
+		t.Fatalf("hunks = %d, want 2 (split)", len(hunks))
+	}
+}
+
+func TestDiffFiles_StatusesAndTotals(t *testing.T) {
+	base := map[string]string{
+		"SKILL.md":      "# title\nold line\n",
+		"gone.md":       "bye\n",
+		"same.md":       "unchanged\n",
+		"metadata.toml": "[asset]\n",
+	}
+	files := []AssetFile{
+		{Path: "SKILL.md", Content: "# title\nnew line\n"},
+		{Path: "same.md", Content: "unchanged\n"},
+		{Path: "fresh.md", Content: "hi\nthere\n"},
+		{Path: "metadata.toml", Content: "[asset]\nchanged\n"},
+	}
+
+	d := diffFiles(base, files)
+	byPath := map[string]FileDiff{}
+	for _, f := range d.Files {
+		byPath[f.Path] = f
+	}
+	if len(d.Files) != 3 {
+		t.Fatalf("files = %v", byPath)
+	}
+	if byPath["SKILL.md"].Status != "modified" {
+		t.Fatalf("SKILL.md status = %q", byPath["SKILL.md"].Status)
+	}
+	if byPath["fresh.md"].Status != "added" || byPath["fresh.md"].Additions != 2 {
+		t.Fatalf("fresh.md = %+v", byPath["fresh.md"])
+	}
+	if byPath["gone.md"].Status != "deleted" || byPath["gone.md"].Deletions != 1 {
+		t.Fatalf("gone.md = %+v", byPath["gone.md"])
+	}
+	// metadata.toml is regenerated on publish and must never show up.
+	if _, ok := byPath["metadata.toml"]; ok {
+		t.Fatalf("metadata.toml leaked into the diff")
+	}
+	if d.Additions != 3 || d.Deletions != 2 {
+		t.Fatalf("totals = +%d -%d, want +3 -2", d.Additions, d.Deletions)
+	}
+	// Deterministic order for the file list.
+	if d.Files[0].Path != "SKILL.md" || d.Files[1].Path != "fresh.md" {
+		t.Fatalf("order = %v", d.Files)
+	}
+}
+
+// A draft with no target asset diffs against nothing — every file is added
+// and no vault access happens.
+func TestDiffDraft_NewAsset(t *testing.T) {
+	a := &App{}
+	d, err := a.DiffDraft(Draft{
+		Name:  "brand-new",
+		Files: []AssetFile{{Path: "SKILL.md", Content: "one\ntwo\n"}},
+	})
+	if err != nil {
+		t.Fatalf("DiffDraft: %v", err)
+	}
+	if len(d.Files) != 1 || d.Files[0].Status != "added" || d.Additions != 2 {
+		t.Fatalf("diff = %+v", d)
+	}
+	if len(d.Files[0].Hunks) != 1 || d.Files[0].Hunks[0].NewStart != 1 {
+		t.Fatalf("hunks = %+v", d.Files[0].Hunks)
+	}
+}
+
+// An update draft diffs against the latest published revision of its
+// target asset.
+func TestDiffDraft_AgainstPublishedAsset(t *testing.T) {
+	t.Setenv("SX_CONFIG_DIR", t.TempDir())
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+	runGitCmd(t, dir, "init")
+	runGitCmd(t, dir, "config", "user.email", "alice@example.com")
+	runGitCmd(t, dir, "config", "user.name", "Alice")
+
+	v, err := vaultpkg.NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	a := &App{ctx: context.Background(), vault: v}
+
+	skillZip := zipOf(t, map[string]string{
+		"SKILL.md":      "---\nname: docs-tone\n---\n\n# docs-tone\nold body\n",
+		"metadata.toml": "[asset]\nname = \"docs-tone\"\nversion = \"1\"\ntype = \"skill\"\ndescription = \"Tone.\"\n\n[skill]\nprompt-file = \"SKILL.md\"\n",
+	})
+	if err := v.AddAsset(a.ctx, &lockfile.Asset{
+		Name: "docs-tone", Version: "1", Type: asset.TypeSkill,
+	}, skillZip); err != nil {
+		t.Fatalf("AddAsset: %v", err)
+	}
+
+	d, err := a.DiffDraft(Draft{
+		Name:        "docs-tone",
+		TargetAsset: "docs-tone",
+		Files: []AssetFile{
+			{Path: "SKILL.md", Content: "---\nname: docs-tone\n---\n\n# docs-tone\nnew body\n"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DiffDraft: %v", err)
+	}
+	if len(d.Files) != 1 || d.Files[0].Status != "modified" {
+		t.Fatalf("diff = %+v", d)
+	}
+	if d.Additions != 1 || d.Deletions != 1 {
+		t.Fatalf("totals = +%d -%d, want +1 -1", d.Additions, d.Deletions)
+	}
+}

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language-data": "^6.5.2",
         "@uiw/react-codemirror": "^4.25.10",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-markdown": "^9.0.3"
+        "react-markdown": "^9.0.3",
+        "rehype-highlight": "^7.0.2"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.0",
@@ -339,6 +341,30 @@
         "@lezer/common": "^1.1.0"
       }
     },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-css": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
@@ -350,6 +376,19 @@
         "@codemirror/state": "^6.0.0",
         "@lezer/common": "^1.0.2",
         "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-html": {
@@ -369,6 +408,16 @@
         "@lezer/html": "^1.3.12"
       }
     },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
@@ -382,6 +431,61 @@
         "@codemirror/view": "^6.17.0",
         "@lezer/common": "^1.0.0",
         "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
       }
     },
     "node_modules/@codemirror/lang-markdown": {
@@ -399,6 +503,124 @@
         "@lezer/markdown": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.12.4",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
@@ -411,6 +633,46 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
+      "integrity": "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -966,10 +1228,32 @@
       "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
       "license": "MIT"
     },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.6.tgz",
+      "integrity": "sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/css": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
       "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -997,6 +1281,17 @@
         "@lezer/lr": "^1.0.0"
       }
     },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/javascript": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
@@ -1006,6 +1301,17 @@
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
@@ -1025,6 +1331,72 @@
       "dependencies": {
         "@lezer/common": "^1.5.0",
         "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+      "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
       }
     },
     "node_modules/@marijn/find-cluster-break": {
@@ -2240,6 +2612,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2267,6 +2652,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -2278,6 +2679,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-url-attributes": {
@@ -2675,6 +3085,21 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -3473,6 +3898,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -3713,6 +4155,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -10,10 +10,12 @@
   },
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language-data": "^6.5.2",
     "@uiw/react-codemirror": "^4.25.10",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^9.0.3"
+    "react-markdown": "^9.0.3",
+    "rehype-highlight": "^7.0.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.0",

--- a/app/frontend/src/components/AssetDetail.tsx
+++ b/app/frontend/src/components/AssetDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
 import { BrowserOpenURL } from "../../wailsjs/runtime/runtime";
 import {
   AddAssetInstallation,
@@ -608,7 +609,12 @@ function FileView({ file }: { file: main.AssetFile }) {
           </div>
         )}
         <article className="prose-sx">
-          <ReactMarkdown components={markdownComponents}>{body}</ReactMarkdown>
+          <ReactMarkdown
+            components={markdownComponents}
+            rehypePlugins={[rehypeHighlight]}
+          >
+            {body}
+          </ReactMarkdown>
         </article>
       </div>
     );

--- a/app/frontend/src/components/BotModal.tsx
+++ b/app/frontend/src/components/BotModal.tsx
@@ -53,9 +53,11 @@ export default function BotModal({
   // Escape/backdrop dismissal doesn't reliably blur the description
   // input first — flush an unsaved edit on the way out. A failed save
   // keeps the modal open with the error visible instead of silently
-  // losing the write.
+  // losing the write; dismissing again with that error showing is a
+  // deliberate discard, so a persistently failing save never traps the
+  // user here.
   async function close() {
-    if (await saveDescription()) onClose();
+    if (error || (await saveDescription())) onClose();
   }
 
   async function addTeam() {

--- a/app/frontend/src/components/BotModal.tsx
+++ b/app/frontend/src/components/BotModal.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { SetBotTeam, UpdateBotDescription } from "../../wailsjs/go/main/App";
+import type { main } from "../../wailsjs/go/models";
+import Modal from "./Modal";
+
+/**
+ * Manage one bot: its description and which teams it belongs to (team
+ * membership gives the bot the team's skills and repo context). Skills
+ * are installed into a bot from any asset's Share… panel, or by dragging
+ * an asset onto the bot in the sidebar.
+ */
+export default function BotModal({
+  bot,
+  teams,
+  onClose,
+  onChanged,
+}: {
+  bot: main.BotInfo;
+  teams: main.TeamInfo[];
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const [description, setDescription] = useState(bot.description ?? "");
+  const [botTeams, setBotTeams] = useState<string[]>(bot.teams ?? []);
+  const [newTeam, setNewTeam] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [savedDescription, setSavedDescription] = useState(
+    bot.description ?? "",
+  );
+
+  const joinable = teams
+    .map((t) => t.name)
+    .filter((name) => !botTeams.includes(name));
+
+  async function saveDescription() {
+    if (description === savedDescription) return;
+    setBusy(true);
+    setError("");
+    try {
+      await UpdateBotDescription(bot.name, description);
+      setSavedDescription(description);
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function addTeam() {
+    const team = newTeam.trim();
+    if (!team) return;
+    setBusy(true);
+    setError("");
+    try {
+      await SetBotTeam(bot.name, team, true);
+      setBotTeams((t) => [...new Set([...t, team])].sort());
+      setNewTeam("");
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeTeam(team: string) {
+    setBusy(true);
+    setError("");
+    try {
+      await SetBotTeam(bot.name, team, false);
+      setBotTeams((t) => t.filter((x) => x !== team));
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal title={`Bot: ${bot.name}`} onClose={onClose} width="w-[480px]">
+      <div className="mb-2 text-xs font-semibold tracking-wide text-ink-faint">
+        DESCRIPTION
+      </div>
+      <input
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        onBlur={() => void saveDescription()}
+        placeholder="What this bot does"
+        disabled={busy}
+        className="w-full rounded-lg border border-line bg-canvas px-3 py-2 text-sm outline-none focus:border-accent"
+      />
+
+      <div className="mb-2 mt-5 text-xs font-semibold tracking-wide text-ink-faint">
+        TEAMS
+      </div>
+      <p className="mb-2 text-xs text-ink-faint">
+        The bot gets every skill shared with these teams, plus anything
+        installed on it directly.
+      </p>
+      {botTeams.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-line px-3 py-3 text-sm text-ink-faint">
+          Not on any team yet.
+        </div>
+      ) : (
+        <ul className="max-h-48 space-y-1 overflow-y-auto">
+          {botTeams.map((team) => (
+            <li
+              key={team}
+              className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-canvas"
+            >
+              <span className="min-w-0 flex-1 truncate text-sm">{team}</span>
+              <button
+                onClick={() => void removeTeam(team)}
+                disabled={busy}
+                title="Remove bot from team"
+                className="shrink-0 rounded px-1.5 text-sm text-ink-faint transition hover:text-danger"
+              >
+                ✕
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {joinable.length > 0 && (
+        <form
+          className="mt-3 flex gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void addTeam();
+          }}
+        >
+          <select
+            value={newTeam}
+            onChange={(e) => setNewTeam(e.target.value)}
+            disabled={busy}
+            className="h-[38px] min-w-0 flex-1 rounded-lg border border-line bg-canvas py-0 pl-3 pr-7 text-sm outline-none focus:border-accent"
+          >
+            <option value="">Add to a team…</option>
+            {joinable.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            disabled={busy || !newTeam.trim()}
+            className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-50"
+          >
+            Add
+          </button>
+        </form>
+      )}
+
+      {error && (
+        <div className="mt-3 rounded-lg bg-danger-soft px-3 py-2 text-sm text-danger">
+          {error}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/app/frontend/src/components/BotModal.tsx
+++ b/app/frontend/src/components/BotModal.tsx
@@ -28,10 +28,11 @@ export default function BotModal({
   const [savedDescription, setSavedDescription] = useState(
     bot.description ?? "",
   );
-  // The description's own failure flag — the shared `error` banner also
-  // carries team-op failures, which must not turn a later close into a
-  // silent discard of an unsaved description.
-  const [saveFailed, setSaveFailed] = useState(false);
+  // The description's own error, rendered beside its input. Fully
+  // decoupled from the shared `error` banner (team ops): team ops can
+  // neither hide a save failure nor be mistaken for one, so the
+  // discard-on-second-dismiss gate below can trust "the user saw it".
+  const [descError, setDescError] = useState("");
 
   const joinable = teams
     .map((t) => t.name)
@@ -40,16 +41,14 @@ export default function BotModal({
   async function saveDescription(): Promise<boolean> {
     if (description === savedDescription) return true;
     setBusy(true);
-    setError("");
-    setSaveFailed(false);
+    setDescError("");
     try {
       await UpdateBotDescription(bot.name, description);
       setSavedDescription(description);
       onChanged();
       return true;
     } catch (e) {
-      setError(String(e));
-      setSaveFailed(true);
+      setDescError(String(e));
       return false;
     } finally {
       setBusy(false);
@@ -63,7 +62,7 @@ export default function BotModal({
   // deliberate discard, so a persistently failing save never traps the
   // user here.
   async function close() {
-    if (saveFailed || (await saveDescription())) onClose();
+    if (descError || (await saveDescription())) onClose();
   }
 
   async function addTeam() {
@@ -117,13 +116,19 @@ export default function BotModal({
           onChange={(e) => {
             setDescription(e.target.value);
             // A fresh edit deserves a fresh save attempt on close.
-            setSaveFailed(false);
+            setDescError("");
           }}
           onBlur={() => void saveDescription()}
           placeholder="What this bot does"
           disabled={busy}
           className="w-full rounded-lg border border-line bg-canvas px-3 py-2 text-sm outline-none focus:border-accent"
         />
+        {descError && (
+          <p className="mt-1.5 break-words text-xs text-danger">
+            Couldn't save the description: {descError} — close again to
+            discard the edit.
+          </p>
+        )}
       </form>
 
       <div className="mb-2 mt-5 text-xs font-semibold tracking-wide text-ink-faint">

--- a/app/frontend/src/components/BotModal.tsx
+++ b/app/frontend/src/components/BotModal.tsx
@@ -48,6 +48,14 @@ export default function BotModal({
     }
   }
 
+  // Escape/backdrop dismissal doesn't reliably blur the description
+  // input first — flush an unsaved edit on the way out so closing the
+  // modal never silently drops it.
+  function close() {
+    void saveDescription();
+    onClose();
+  }
+
   async function addTeam() {
     const team = newTeam.trim();
     if (!team) return;
@@ -80,18 +88,25 @@ export default function BotModal({
   }
 
   return (
-    <Modal title={`Bot: ${bot.name}`} onClose={onClose} width="w-[480px]">
+    <Modal title={`Bot: ${bot.name}`} onClose={close} width="w-[480px]">
       <div className="mb-2 text-xs font-semibold tracking-wide text-ink-faint">
         DESCRIPTION
       </div>
-      <input
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        onBlur={() => void saveDescription()}
-        placeholder="What this bot does"
-        disabled={busy}
-        className="w-full rounded-lg border border-line bg-canvas px-3 py-2 text-sm outline-none focus:border-accent"
-      />
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void saveDescription();
+        }}
+      >
+        <input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onBlur={() => void saveDescription()}
+          placeholder="What this bot does"
+          disabled={busy}
+          className="w-full rounded-lg border border-line bg-canvas px-3 py-2 text-sm outline-none focus:border-accent"
+        />
+      </form>
 
       <div className="mb-2 mt-5 text-xs font-semibold tracking-wide text-ink-faint">
         TEAMS

--- a/app/frontend/src/components/BotModal.tsx
+++ b/app/frontend/src/components/BotModal.tsx
@@ -28,6 +28,10 @@ export default function BotModal({
   const [savedDescription, setSavedDescription] = useState(
     bot.description ?? "",
   );
+  // The description's own failure flag — the shared `error` banner also
+  // carries team-op failures, which must not turn a later close into a
+  // silent discard of an unsaved description.
+  const [saveFailed, setSaveFailed] = useState(false);
 
   const joinable = teams
     .map((t) => t.name)
@@ -37,6 +41,7 @@ export default function BotModal({
     if (description === savedDescription) return true;
     setBusy(true);
     setError("");
+    setSaveFailed(false);
     try {
       await UpdateBotDescription(bot.name, description);
       setSavedDescription(description);
@@ -44,6 +49,7 @@ export default function BotModal({
       return true;
     } catch (e) {
       setError(String(e));
+      setSaveFailed(true);
       return false;
     } finally {
       setBusy(false);
@@ -53,11 +59,11 @@ export default function BotModal({
   // Escape/backdrop dismissal doesn't reliably blur the description
   // input first — flush an unsaved edit on the way out. A failed save
   // keeps the modal open with the error visible instead of silently
-  // losing the write; dismissing again with that error showing is a
+  // losing the write; dismissing again after seeing THAT failure is a
   // deliberate discard, so a persistently failing save never traps the
   // user here.
   async function close() {
-    if (error || (await saveDescription())) onClose();
+    if (saveFailed || (await saveDescription())) onClose();
   }
 
   async function addTeam() {
@@ -108,7 +114,11 @@ export default function BotModal({
       >
         <input
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={(e) => {
+            setDescription(e.target.value);
+            // A fresh edit deserves a fresh save attempt on close.
+            setSaveFailed(false);
+          }}
           onBlur={() => void saveDescription()}
           placeholder="What this bot does"
           disabled={busy}

--- a/app/frontend/src/components/BotModal.tsx
+++ b/app/frontend/src/components/BotModal.tsx
@@ -33,27 +33,29 @@ export default function BotModal({
     .map((t) => t.name)
     .filter((name) => !botTeams.includes(name));
 
-  async function saveDescription() {
-    if (description === savedDescription) return;
+  async function saveDescription(): Promise<boolean> {
+    if (description === savedDescription) return true;
     setBusy(true);
     setError("");
     try {
       await UpdateBotDescription(bot.name, description);
       setSavedDescription(description);
       onChanged();
+      return true;
     } catch (e) {
       setError(String(e));
+      return false;
     } finally {
       setBusy(false);
     }
   }
 
   // Escape/backdrop dismissal doesn't reliably blur the description
-  // input first — flush an unsaved edit on the way out so closing the
-  // modal never silently drops it.
-  function close() {
-    void saveDescription();
-    onClose();
+  // input first — flush an unsaved edit on the way out. A failed save
+  // keeps the modal open with the error visible instead of silently
+  // losing the write.
+  async function close() {
+    if (await saveDescription()) onClose();
   }
 
   async function addTeam() {
@@ -88,7 +90,11 @@ export default function BotModal({
   }
 
   return (
-    <Modal title={`Bot: ${bot.name}`} onClose={close} width="w-[480px]">
+    <Modal
+      title={`Bot: ${bot.name}`}
+      onClose={() => void close()}
+      width="w-[480px]"
+    >
       <div className="mb-2 text-xs font-semibold tracking-wide text-ink-faint">
         DESCRIPTION
       </div>

--- a/app/frontend/src/components/DraftDiffView.tsx
+++ b/app/frontend/src/components/DraftDiffView.tsx
@@ -26,9 +26,13 @@ const STATUS_STYLES: Record<string, { label: string; className: string }> = {
 export default function DraftDiffView({
   diff,
   loading,
+  error,
 }: {
   diff: main.DraftDiff | null;
   loading: boolean;
+  /** Why the diff couldn't be computed (the diff's own channel — never
+   * the sheet's shared publish/persist banner). */
+  error?: string;
 }) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
 
@@ -40,15 +44,19 @@ export default function DraftDiffView({
       </div>
     );
   }
-  // Not loading and no diff: the fetch failed (the sheet shows the error
-  // banner). A quiet panel instead of a forever-pulsing skeleton; the
-  // Edit/Changes toggle retries.
+  // Not loading and no diff: the fetch failed. A quiet panel with the
+  // reason instead of a forever-pulsing skeleton; the Edit/Changes
+  // toggle retries.
   if (!diff) {
     return (
       <div className="flex h-full items-center justify-center rounded-lg border border-line bg-canvas">
-        <p className="px-6 py-10 text-sm text-ink-faint">
-          The changes couldn't be loaded — switch to Edit and back to retry.
-        </p>
+        <div className="max-w-md px-6 py-10 text-center text-sm">
+          <p className="text-ink-soft">The changes couldn't be loaded.</p>
+          {error && <p className="mt-1 break-words text-danger">{error}</p>}
+          <p className="mt-1 text-ink-faint">
+            Switch to Edit and back to retry.
+          </p>
+        </div>
       </div>
     );
   }

--- a/app/frontend/src/components/DraftDiffView.tsx
+++ b/app/frontend/src/components/DraftDiffView.tsx
@@ -195,7 +195,7 @@ function Line({ line }: { line: main.DiffLine }) {
       <td className={`w-5 select-none text-center ${markerClass}`}>
         {line.kind === "add" ? "+" : line.kind === "del" ? "−" : ""}
       </td>
-      <td className="whitespace-pre-wrap break-all px-3 text-ink">
+      <td className="whitespace-pre-wrap break-words px-3 text-ink">
         {line.text || " "}
       </td>
     </tr>

--- a/app/frontend/src/components/DraftDiffView.tsx
+++ b/app/frontend/src/components/DraftDiffView.tsx
@@ -32,11 +32,23 @@ export default function DraftDiffView({
 }) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
 
-  if (loading || !diff) {
+  if (loading) {
     return (
       <div className="space-y-3">
         <div className="h-12 animate-pulse rounded-lg bg-canvas" />
         <div className="h-64 animate-pulse rounded-lg bg-canvas" />
+      </div>
+    );
+  }
+  // Not loading and no diff: the fetch failed (the sheet shows the error
+  // banner). A quiet panel instead of a forever-pulsing skeleton; the
+  // Edit/Changes toggle retries.
+  if (!diff) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-line bg-canvas">
+        <p className="px-6 py-10 text-sm text-ink-faint">
+          The changes couldn't be loaded — switch to Edit and back to retry.
+        </p>
       </div>
     );
   }

--- a/app/frontend/src/components/DraftDiffView.tsx
+++ b/app/frontend/src/components/DraftDiffView.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import type { main } from "../../wailsjs/go/models";
+
+const STATUS_STYLES: Record<string, { label: string; className: string }> = {
+  added: {
+    label: "ADDED",
+    className:
+      "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  },
+  modified: {
+    label: "MODIFIED",
+    className:
+      "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+  },
+  deleted: {
+    label: "DELETED",
+    className: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300",
+  },
+};
+
+/**
+ * The draft sheet's "Changes" view: what publishing would change, rendered
+ * like the skills.new PR diff — a summary strip, then one collapsible
+ * unified diff per file.
+ */
+export default function DraftDiffView({
+  diff,
+  loading,
+}: {
+  diff: main.DraftDiff | null;
+  loading: boolean;
+}) {
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+  if (loading || !diff) {
+    return (
+      <div className="space-y-3">
+        <div className="h-12 animate-pulse rounded-lg bg-canvas" />
+        <div className="h-64 animate-pulse rounded-lg bg-canvas" />
+      </div>
+    );
+  }
+
+  const files = diff.files ?? [];
+  if (files.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-line bg-canvas">
+        <p className="px-6 py-10 text-sm text-ink-faint">
+          No changes yet — this draft matches the published files.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full space-y-3 overflow-y-auto pr-1">
+      <div className="flex items-center justify-between rounded-lg border border-line bg-canvas px-4 py-2.5 text-sm">
+        <span className="text-ink-soft">
+          {files.length} file{files.length !== 1 ? "s" : ""} changed
+        </span>
+        <span className="font-mono text-xs">
+          <span className="font-medium text-emerald-600 dark:text-emerald-400">
+            +{diff.additions}
+          </span>{" "}
+          <span className="font-medium text-red-600 dark:text-red-400">
+            −{diff.deletions}
+          </span>
+        </span>
+      </div>
+
+      {files.map((f) => (
+        <FileSection
+          key={f.path}
+          file={f}
+          collapsed={!!collapsed[f.path]}
+          onToggle={() =>
+            setCollapsed((c) => ({ ...c, [f.path]: !c[f.path] }))
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+function FileSection({
+  file,
+  collapsed,
+  onToggle,
+}: {
+  file: main.FileDiff;
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  const status = STATUS_STYLES[file.status] ?? STATUS_STYLES.modified;
+  return (
+    <div className="overflow-hidden rounded-lg border border-line">
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-2.5 bg-canvas px-3 py-2 text-left transition hover:bg-accent-soft/40"
+      >
+        <span className="text-[10px] text-ink-faint">
+          {collapsed ? "▸" : "▾"}
+        </span>
+        <span
+          className={`rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${status.className}`}
+        >
+          {status.label}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-mono text-xs text-ink">
+          {file.path}
+        </span>
+        <span className="shrink-0 font-mono text-[11px]">
+          {file.additions > 0 && (
+            <span className="text-emerald-600 dark:text-emerald-400">
+              +{file.additions}
+            </span>
+          )}{" "}
+          {file.deletions > 0 && (
+            <span className="text-red-600 dark:text-red-400">
+              −{file.deletions}
+            </span>
+          )}
+        </span>
+      </button>
+
+      {!collapsed && (
+        <div className="overflow-x-auto border-t border-line bg-surface">
+          <table className="w-full border-collapse font-mono text-xs leading-relaxed">
+            <tbody>
+              {(file.hunks ?? []).map((h, hi) => (
+                <Hunk
+                  key={hi}
+                  hunk={h}
+                  withHeader={
+                    (file.hunks ?? []).length > 1 ||
+                    h.oldStart > 1 ||
+                    h.newStart > 1
+                  }
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Hunk({
+  hunk,
+  withHeader,
+}: {
+  hunk: main.DiffHunk;
+  withHeader: boolean;
+}) {
+  return (
+    <>
+      {withHeader && (
+        <tr className="bg-accent-soft/60 text-ink-faint">
+          <td colSpan={3} className="select-none px-2 py-0.5" />
+          <td className="px-3 py-0.5">
+            @@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},
+            {hunk.newLines} @@
+          </td>
+        </tr>
+      )}
+      {(hunk.lines ?? []).map((l, i) => (
+        <Line key={i} line={l} />
+      ))}
+    </>
+  );
+}
+
+function Line({ line }: { line: main.DiffLine }) {
+  const rowClass =
+    line.kind === "add"
+      ? "bg-emerald-50 dark:bg-emerald-950/50"
+      : line.kind === "del"
+        ? "bg-red-50 dark:bg-red-950/40"
+        : "";
+  const markerClass =
+    line.kind === "add"
+      ? "text-emerald-600 dark:text-emerald-400"
+      : line.kind === "del"
+        ? "text-red-600 dark:text-red-400"
+        : "";
+  return (
+    <tr className={rowClass}>
+      <td className="w-10 select-none px-2 text-right text-ink-faint">
+        {line.oldNo > 0 ? line.oldNo : ""}
+      </td>
+      <td className="w-10 select-none px-2 text-right text-ink-faint">
+        {line.newNo > 0 ? line.newNo : ""}
+      </td>
+      <td className={`w-5 select-none text-center ${markerClass}`}>
+        {line.kind === "add" ? "+" : line.kind === "del" ? "−" : ""}
+      </td>
+      <td className="whitespace-pre-wrap break-all px-3 text-ink">
+        {line.text || " "}
+      </td>
+    </tr>
+  );
+}

--- a/app/frontend/src/components/DraftSheet.tsx
+++ b/app/frontend/src/components/DraftSheet.tsx
@@ -87,6 +87,10 @@ export default function DraftSheet({
     if (view !== "changes" || lastDiffedRef.current === draft) return;
     let stale = false;
     setDiffLoading(true);
+    // Each run owns the error banner and the shown diff: a retry that
+    // succeeds must drop the old error, and a refresh that fails must
+    // drop the old diff — otherwise the two signals contradict.
+    setError("");
     DiffDraft(draft)
       .then((d) => {
         if (stale) return;
@@ -94,7 +98,9 @@ export default function DraftSheet({
         lastDiffedRef.current = draft;
       })
       .catch((e) => {
-        if (!stale) setError(String(e));
+        if (stale) return;
+        setDiff(null);
+        setError(String(e));
       })
       .finally(() => {
         if (!stale) setDiffLoading(false);

--- a/app/frontend/src/components/DraftSheet.tsx
+++ b/app/frontend/src/components/DraftSheet.tsx
@@ -76,18 +76,22 @@ export default function DraftSheet({
   const [diff, setDiff] = useState<main.DraftDiff | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
 
-  // Recomputed every time the Changes view is entered — edits since the
-  // last look must show. The draft ref keeps the effect off the keystroke
-  // path (draft changes on every edit; the diff only matters when shown).
-  const draftRef = useRef(draft);
-  draftRef.current = draft;
+  // The diff recomputes when the Changes view is showing and the draft it
+  // last reflected isn't the current one — so edits (including extension
+  // edits landing while Changes is visible) always show, while toggling
+  // back and forth over an unchanged draft never re-pays the vault
+  // round-trip. Keystrokes in the Edit view change `draft` but bail on
+  // the view check, so typing stays cheap.
+  const lastDiffedRef = useRef<main.Draft | null>(null);
   useEffect(() => {
-    if (view !== "changes") return;
+    if (view !== "changes" || lastDiffedRef.current === draft) return;
     let stale = false;
     setDiffLoading(true);
-    DiffDraft(draftRef.current)
+    DiffDraft(draft)
       .then((d) => {
-        if (!stale) setDiff(d);
+        if (stale) return;
+        setDiff(d);
+        lastDiffedRef.current = draft;
       })
       .catch((e) => {
         if (!stale) setError(String(e));
@@ -98,7 +102,7 @@ export default function DraftSheet({
     return () => {
       stale = true;
     };
-  }, [view]);
+  }, [view, draft]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/app/frontend/src/components/DraftSheet.tsx
+++ b/app/frontend/src/components/DraftSheet.tsx
@@ -75,6 +75,9 @@ export default function DraftSheet({
   const [view, setView] = useState<"changes" | "edit">(initialView);
   const [diff, setDiff] = useState<main.DraftDiff | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
+  // The diff's own error channel — the shared `error` banner belongs to
+  // publish/persist/discard, and a diff run must not stomp it.
+  const [diffError, setDiffError] = useState("");
 
   // The diff recomputes when the Changes view is showing and the draft it
   // last reflected isn't the current one — so edits (including extension
@@ -87,10 +90,10 @@ export default function DraftSheet({
     if (view !== "changes" || lastDiffedRef.current === draft) return;
     let stale = false;
     setDiffLoading(true);
-    // Each run owns the error banner and the shown diff: a retry that
+    // Each run owns the diff error and the shown diff: a retry that
     // succeeds must drop the old error, and a refresh that fails must
     // drop the old diff — otherwise the two signals contradict.
-    setError("");
+    setDiffError("");
     DiffDraft(draft)
       .then((d) => {
         if (stale) return;
@@ -100,7 +103,7 @@ export default function DraftSheet({
       .catch((e) => {
         if (stale) return;
         setDiff(null);
-        setError(String(e));
+        setDiffError(String(e));
       })
       .finally(() => {
         if (!stale) setDiffLoading(false);
@@ -352,7 +355,11 @@ export default function DraftSheet({
               )}
             </div>
             {view === "changes" && (
-              <DraftDiffView diff={diff} loading={diffLoading} />
+              <DraftDiffView
+                diff={diff}
+                loading={diffLoading}
+                error={diffError}
+              />
             )}
           </div>
         </div>

--- a/app/frontend/src/components/DraftSheet.tsx
+++ b/app/frontend/src/components/DraftSheet.tsx
@@ -53,10 +53,14 @@ const TYPE_OPTIONS = [
  */
 export default function DraftSheet({
   draft: initial,
+  initialView = "edit",
   onClose,
   onPublished,
 }: {
   draft: main.Draft;
+  /** Which tab the sheet opens on. Editing flows open on "edit"; resuming
+   * a saved draft opens on "changes" to show what publishing would do. */
+  initialView?: "changes" | "edit";
   onClose: () => void;
   onPublished: (name: string) => void;
 }) {
@@ -68,11 +72,7 @@ export default function DraftSheet({
   // Warnings from before-publish extension subscribers (the doctor hook).
   // Non-blocking: the user sees them and chooses "Publish anyway".
   const [warnings, setWarnings] = useState<PublishWarning[] | null>(null);
-  // Updates open on what changed (the skills.new PR-diff treatment); new
-  // assets open in the editor since their diff is trivially "everything".
-  const [view, setView] = useState<"changes" | "edit">(
-    initial.targetAsset ? "changes" : "edit",
-  );
+  const [view, setView] = useState<"changes" | "edit">(initialView);
   const [diff, setDiff] = useState<main.DraftDiff | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
 

--- a/app/frontend/src/components/DraftSheet.tsx
+++ b/app/frontend/src/components/DraftSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import {
+  DiffDraft,
   DiscardDraft,
   PublishDraft,
   UpdateDraft,
@@ -7,6 +8,7 @@ import {
 import type { main } from "../../wailsjs/go/models";
 import { collectPublishWarnings, emitEvent } from "../plugins/events";
 import type { PublishWarning } from "../plugins/api";
+import DraftDiffView from "./DraftDiffView";
 import FileRail from "./FileRail";
 import MarkdownEditor from "./MarkdownEditor";
 import { setPluginEditor } from "../plugins/sxapi";
@@ -66,6 +68,37 @@ export default function DraftSheet({
   // Warnings from before-publish extension subscribers (the doctor hook).
   // Non-blocking: the user sees them and chooses "Publish anyway".
   const [warnings, setWarnings] = useState<PublishWarning[] | null>(null);
+  // Updates open on what changed (the skills.new PR-diff treatment); new
+  // assets open in the editor since their diff is trivially "everything".
+  const [view, setView] = useState<"changes" | "edit">(
+    initial.targetAsset ? "changes" : "edit",
+  );
+  const [diff, setDiff] = useState<main.DraftDiff | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+
+  // Recomputed every time the Changes view is entered — edits since the
+  // last look must show. The draft ref keeps the effect off the keystroke
+  // path (draft changes on every edit; the diff only matters when shown).
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  useEffect(() => {
+    if (view !== "changes") return;
+    let stale = false;
+    setDiffLoading(true);
+    DiffDraft(draftRef.current)
+      .then((d) => {
+        if (!stale) setDiff(d);
+      })
+      .catch((e) => {
+        if (!stale) setError(String(e));
+      })
+      .finally(() => {
+        if (!stale) setDiffLoading(false);
+      });
+    return () => {
+      stale = true;
+    };
+  }, [view]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -214,6 +247,21 @@ export default function DraftSheet({
               </span>
             </div>
           </div>
+          <div className="flex rounded-lg border border-line p-0.5 text-xs font-medium">
+            {(["changes", "edit"] as const).map((v) => (
+              <button
+                key={v}
+                onClick={() => setView(v)}
+                className={`rounded-md px-2.5 py-1 transition ${
+                  view === v
+                    ? "bg-accent-soft text-accent"
+                    : "text-ink-faint hover:text-ink"
+                }`}
+              >
+                {v === "changes" ? "Changes" : "Edit"}
+              </button>
+            ))}
+          </div>
           <button
             onClick={() => void saveAndClose()}
             disabled={busy}
@@ -270,7 +318,7 @@ export default function DraftSheet({
         </div>
 
         <div className="flex min-h-0 flex-1">
-          {draft.files.length > 1 && (
+          {view === "edit" && draft.files.length > 1 && (
             <FileRail
               files={draft.files}
               active={activeFile}
@@ -278,13 +326,23 @@ export default function DraftSheet({
             />
           )}
           <div className="min-h-0 min-w-0 flex-1 p-4">
-            {draft.files[activeFile] && (
-              <MarkdownEditor
-                value={draft.files[activeFile].content}
-                onChange={(content) => updateFileContent(activeFile, content)}
-                readOnly={busy}
-                onView={registerEditorView}
-              />
+            {/* The editor stays mounted (hidden) under the Changes view so
+                the extension editor handle keeps pointing at a live
+                CodeMirror instead of a destroyed one. */}
+            <div className={view === "edit" ? "h-full" : "hidden"}>
+              {draft.files[activeFile] && (
+                <MarkdownEditor
+                  value={draft.files[activeFile].content}
+                  onChange={(content) =>
+                    updateFileContent(activeFile, content)
+                  }
+                  readOnly={busy}
+                  onView={registerEditorView}
+                />
+              )}
+            </div>
+            {view === "changes" && (
+              <DraftDiffView diff={diff} loading={diffLoading} />
             )}
           </div>
         </div>

--- a/app/frontend/src/components/MarkdownEditor.tsx
+++ b/app/frontend/src/components/MarkdownEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { markdown } from "@codemirror/lang-markdown";
+import { languages } from "@codemirror/language-data";
 import { EditorView } from "@uiw/react-codemirror";
 
 const baseTheme = EditorView.theme({
@@ -55,7 +56,13 @@ export default function MarkdownEditor({
       readOnly={readOnly}
       onCreateEditor={(view) => onView?.(view)}
       theme={dark ? "dark" : "light"}
-      extensions={[markdown(), baseTheme, EditorView.lineWrapping]}
+      extensions={[
+        // codeLanguages lights up fenced code blocks (```go, ```ts, …)
+        // with each language's own grammar while editing.
+        markdown({ codeLanguages: languages }),
+        baseTheme,
+        EditorView.lineWrapping,
+      ]}
       basicSetup={{
         lineNumbers: true,
         foldGutter: false,

--- a/app/frontend/src/components/SettingsModal.tsx
+++ b/app/frontend/src/components/SettingsModal.tsx
@@ -531,9 +531,11 @@ export default function SettingsModal({
                           {p.trackRepos ? "✓" : ""}
                         </span>
                         <span className="flex-1">
-                          <span className="block">Track repositories</span>
+                          <span className="block">
+                            Track repositories & bots
+                          </span>
                           <span className="block text-xs text-ink-faint">
-                            See which repos assets are scoped to
+                            See which repos and bots assets are scoped to
                           </span>
                         </span>
                       </button>

--- a/app/frontend/src/components/Sidebar.tsx
+++ b/app/frontend/src/components/Sidebar.tsx
@@ -12,13 +12,15 @@ export type Scope =
   | { kind: "plugin-view"; name: string }
   | { kind: "collection"; name: string }
   | { kind: "team"; name: string }
-  | { kind: "repo"; name: string };
+  | { kind: "repo"; name: string }
+  | { kind: "bot"; name: string };
 
 function scopeKey(s: Scope): string {
   if (s.kind === "plugin-view") return "plugin-view:" + s.name;
   if (s.kind === "collection") return "collection:" + s.name;
   if (s.kind === "team") return "team:" + s.name;
   if (s.kind === "repo") return "repo:" + s.name;
+  if (s.kind === "bot") return "bot:" + s.name;
   return s.kind;
 }
 
@@ -57,18 +59,23 @@ export default function Sidebar({
   teams,
   teamAssetCounts,
   repoAssets,
+  botAssets,
   pinnedCollections,
   pinnedTeams,
   pinnedRepos,
+  pinnedBots,
   onNewCollection,
   onNewTeam,
+  onNewBot,
   onBrowseCollections,
   onBrowseTeams,
   onBrowseRepos,
+  onBrowseBots,
   onSettings,
   dropCollection,
   dropTeam,
   dropRepo,
+  dropBot,
   onCollectionDragHandle,
   onRepoDragHandle,
   onUnpin,
@@ -87,21 +94,31 @@ export default function Sidebar({
   // Repo URL → asset names; null when this library doesn't track repos
   // (the section is absent entirely).
   repoAssets: Record<string, string[]> | null;
+  // Bot name → resolved asset names; null when the library doesn't track
+  // repos & bots (same opt-in as repositories).
+  botAssets: Record<string, string[]> | null;
   pinnedCollections: string[];
   pinnedTeams: string[];
   pinnedRepos: string[];
+  pinnedBots: string[];
   onNewCollection: () => void;
   onNewTeam: () => void;
+  onNewBot: () => void;
   onBrowseCollections: () => void;
   onBrowseTeams: () => void;
   onBrowseRepos: () => void;
+  onBrowseBots: () => void;
   onSettings: () => void;
   dropCollection: string;
   dropTeam: string;
   dropRepo: string;
+  dropBot: string;
   onCollectionDragHandle: (name: string, e: MouseEvent) => void;
   onRepoDragHandle: (url: string, e: MouseEvent) => void;
-  onUnpin: (kind: "collections" | "teams" | "repos", name: string) => void;
+  onUnpin: (
+    kind: "collections" | "teams" | "repos" | "bots",
+    name: string,
+  ) => void;
   width: number;
 }) {
   const active = scopeKey(scope);
@@ -118,8 +135,16 @@ export default function Sidebar({
         .filter((url) => pinnedRepos.includes(url))
         .sort((a, b) => repoLabel(a).localeCompare(repoLabel(b)))
     : [];
+  const pinnedBotRows = botAssets
+    ? Object.keys(botAssets)
+        .filter((name) => pinnedBots.includes(name))
+        .sort()
+    : [];
   const hasPins =
-    pinnedCollectionRows.length + pinnedTeamRows.length + pinnedRepoRows.length >
+    pinnedCollectionRows.length +
+      pinnedTeamRows.length +
+      pinnedRepoRows.length +
+      pinnedBotRows.length >
     0;
   const sidebarPanels = useSlot("sidebar-panel");
   const dashboardWidgets = useSlot("dashboard-widget").length;
@@ -324,14 +349,36 @@ export default function Sidebar({
                 />
               </div>
             ))}
+            {pinnedBotRows.map((name) => (
+              <div
+                key={"bot:" + name}
+                data-drop-bot={name}
+                className={`group relative ${
+                  dropBot === name ? "rounded-lg ring-2 ring-accent" : ""
+                }`}
+              >
+                <Row
+                  icon={<BotIcon />}
+                  label={name}
+                  count={(botAssets?.[name] ?? []).length}
+                  active={active === "bot:" + name}
+                  onClick={() => onScope({ kind: "bot", name })}
+                  countYieldsOnHover
+                />
+                <UnpinButton
+                  label={name}
+                  onClick={() => onUnpin("bots", name)}
+                />
+              </div>
+            ))}
           </>
         )}
 
         {/* BROWSE: one count-bearing row per catalog — the counts keep
             the "how much is there" scope cue that fully hidden
             navigation loses. An empty catalog's row becomes its own
-            create CTA. Repositories appear only when the library tracks
-            them (Settings → Track repositories). */}
+            create CTA. Repositories and bots appear only when the
+            library tracks them (Settings → Track repositories & bots). */}
         <div className="mt-4">
           <SectionLabel>BROWSE</SectionLabel>
         </div>
@@ -369,6 +416,21 @@ export default function Sidebar({
               Object.keys(repoAssets).length === 0
                 ? "Assets scoped to repositories will show up here"
                 : "Browse and pin repositories"
+            }
+          />
+        )}
+        {botAssets !== null && (
+          <CatalogRow
+            icon={<BotIcon />}
+            label="Bots"
+            count={Object.keys(botAssets).length}
+            onClick={
+              Object.keys(botAssets).length > 0 ? onBrowseBots : onNewBot
+            }
+            title={
+              Object.keys(botAssets).length === 0
+                ? "Create a bot to install skills for a non-human identity"
+                : "Browse and pin bots"
             }
           />
         )}
@@ -536,6 +598,17 @@ function RepoIcon() {
       <circle cx="11.5" cy="3.5" r="1.75" />
       <path d="M4.5 5.25v5.5" />
       <path d="M11.5 5.25c0 2.75-2.75 3.5-4.75 3.75" />
+    </>,
+  );
+}
+
+export function BotIcon() {
+  return typeIcon(
+    <>
+      <rect x="3" y="5.5" width="10" height="7.5" rx="1.5" />
+      <path d="M8 3v2.5M6 3h4" />
+      <path d="M5.75 9h.01M10.25 9h.01" strokeWidth="2" />
+      <path d="M6.25 11h3.5" />
     </>,
   );
 }

--- a/app/frontend/src/screens/Library.tsx
+++ b/app/frontend/src/screens/Library.tsx
@@ -219,6 +219,11 @@ export default function Library({
   const searchRef = useRef<HTMLInputElement>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [openDraft, setOpenDraft] = useState<main.Draft | null>(null);
+  // Resuming a saved draft opens the sheet on its Changes tab; every
+  // editing flow (Edit button, drops, new assets) opens on the editor.
+  const [openDraftView, setOpenDraftView] = useState<"changes" | "edit">(
+    "edit",
+  );
   // True while a draft is being created or fetched from the vault —
   // renders the sheet's skeleton so the click responds immediately.
   const [openingDraft, setOpeningDraft] = useState(false);
@@ -779,6 +784,7 @@ export default function Library({
       setOpeningDraft(true);
       CreateDraftFromPaths(real)
         .then((draft) => {
+          setOpenDraftView("edit");
           setOpenDraft(draft);
           load();
         })
@@ -1253,6 +1259,7 @@ export default function Library({
     try {
       const draft = await CreateDraftFromAsset(name);
       setSelected(null);
+      setOpenDraftView("edit");
       setOpenDraft(draft);
       load();
     } catch (e) {
@@ -1265,7 +1272,9 @@ export default function Library({
   async function openExistingDraft(id: string) {
     setOpeningDraft(true);
     try {
-      setOpenDraft(await GetDraft(id));
+      const draft = await GetDraft(id);
+      setOpenDraftView("changes");
+      setOpenDraft(draft);
     } catch (e) {
       setToastMessage(String(e));
     } finally {
@@ -2394,6 +2403,7 @@ export default function Library({
       {openDraft && (
         <DraftSheet
           draft={openDraft}
+          initialView={openDraftView}
           onClose={() => {
             setOpenDraft(null);
             load();
@@ -2411,6 +2421,7 @@ export default function Library({
           onClose={() => setShowAddAsset(false)}
           onDraft={(draft) => {
             setShowAddAsset(false);
+            setOpenDraftView("edit");
             setOpenDraft(draft);
             load();
           }}

--- a/app/frontend/src/screens/Library.tsx
+++ b/app/frontend/src/screens/Library.tsx
@@ -4,10 +4,12 @@ import {
   AddAssetRepoScope,
   AddCollectionInstallation,
   AddCollectionRepoScope,
+  CreateBot,
   CreateDraftFromAsset,
   CreateDraftFromPaths,
   CreateTeam,
   DeleteAssets,
+  DeleteBot,
   DeleteCollection,
   DeleteTeam,
   GetAssetInstallations,
@@ -16,6 +18,7 @@ import {
   InstalledAssets,
   ListAIClients,
   ListAssets,
+  ListBots,
   ListCollections,
   ListDrafts,
   ListTeams,
@@ -42,6 +45,7 @@ import {
 import type { main } from "../../wailsjs/go/models";
 import AddAssetModal from "../components/AddAssetModal";
 import AssetDetail from "../components/AssetDetail";
+import BotModal from "../components/BotModal";
 import BrowseModal from "../components/BrowseModal";
 import CollectionModal from "../components/CollectionModal";
 import DraftSheet, { DraftSheetSkeleton } from "../components/DraftSheet";
@@ -69,7 +73,7 @@ import TypeBadge from "../components/TypeBadge";
 
 type ViewMode = "list" | "grid";
 type SortMode = "updated" | "name";
-type PinKind = "collections" | "teams" | "repos";
+type PinKind = "collections" | "teams" | "repos" | "bots";
 
 function readPins(kind: PinKind, location: string): string[] | null {
   try {
@@ -93,6 +97,7 @@ interface BootSnapshot {
   teamAssets: Record<string, string[]>;
   personalAssets: string[];
   repoAssets: Record<string, string[]> | null;
+  bots: main.BotInfo[] | null;
 }
 
 function readBootSnapshot(location: string): BootSnapshot | null {
@@ -139,12 +144,20 @@ export default function Library({
   const [repoAssets, setRepoAssets] = useState<Record<string, string[]> | null>(
     boot?.repoAssets ?? null,
   );
+  // Bots ride the same opt-in as repositories; null while not tracking.
+  const [bots, setBots] = useState<main.BotInfo[] | null>(boot?.bots ?? null);
   const [openTeam, setOpenTeam] = useState<main.TeamInfo | null>(null);
   const [showNewTeam, setShowNewTeam] = useState(false);
   const [newTeamName, setNewTeamName] = useState("");
-  const [browse, setBrowse] = useState<"" | "collections" | "teams" | "repos">(
-    "",
-  );
+  const [openBot, setOpenBot] = useState<main.BotInfo | null>(null);
+  const [showNewBot, setShowNewBot] = useState(false);
+  const [newBotName, setNewBotName] = useState("");
+  // A Sleuth vault auto-issues an API key with a new bot; the raw token
+  // is only ever available here, so it gets its own show-once modal.
+  const [newBotToken, setNewBotToken] = useState("");
+  const [browse, setBrowse] = useState<
+    "" | "collections" | "teams" | "repos" | "bots"
+  >("");
   const [shareCollection, setShareCollection] = useState("");
   // Pins are per-library. null = the user never pinned anything, so the
   // sidebar defaults to the first few; once they pin/unpin we persist.
@@ -156,6 +169,9 @@ export default function Library({
   );
   const [pinnedRepos, setPinnedRepos] = useState<string[] | null>(() =>
     readPins("repos", vault.location),
+  );
+  const [pinnedBots, setPinnedBots] = useState<string[] | null>(() =>
+    readPins("bots", vault.location),
   );
   const [typeFilter, setTypeFilter] = useState("");
   const [installedInfo, setInstalledInfo] = useState<main.InstalledAssetInfo[]>(
@@ -249,6 +265,7 @@ export default function Library({
   const [dropCollection, setDropCollection] = useState("");
   const [dropTeam, setDropTeam] = useState("");
   const [dropRepo, setDropRepo] = useState("");
+  const [dropBot, setDropBot] = useState("");
   // names carries a multi-selection when the dragged row is part of one;
   // label overrides name in the ghost chip when the payload isn't
   // presentable as-is (a repo drag carries the full URL in name).
@@ -269,6 +286,7 @@ export default function Library({
   const dropCollectionRef = useRef("");
   const dropTeamRef = useRef("");
   const dropRepoRef = useRef("");
+  const dropBotRef = useRef("");
   const dragHappenedRef = useRef(false);
   const [toast, setToast] = useState("");
   const [busyAction, setBusyAction] = useState(false);
@@ -533,8 +551,12 @@ export default function Library({
       RepoAssets()
         .then((m) => apply(setRepoAssets)(m ?? {}))
         .catch(applyFallback(setRepoAssets, {}));
+      ListBots()
+        .then((v) => apply(setBots)(v ?? []))
+        .catch(applyFallback(setBots, []));
     } else {
       apply(setRepoAssets)(null);
+      apply(setBots)(null);
     }
   }, [vault.trackRepos]);
 
@@ -561,6 +583,7 @@ export default function Library({
         teamAssets,
         personalAssets,
         repoAssets,
+        bots,
       };
       const json = JSON.stringify(snapshot);
       try {
@@ -591,6 +614,7 @@ export default function Library({
     teamAssets,
     personalAssets,
     repoAssets,
+    bots,
     vault.location,
   ]);
 
@@ -821,10 +845,12 @@ export default function Library({
       dropCollectionRef.current = "";
       dropTeamRef.current = "";
       dropRepoRef.current = "";
+      dropBotRef.current = "";
       setAssetDrag(null);
       setDropCollection("");
       setDropTeam("");
       setDropRepo("");
+      setDropBot("");
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
     };
@@ -852,7 +878,7 @@ export default function Library({
       });
       const selector =
         drag.kind === "asset"
-          ? "[data-drop-collection], [data-drop-team], [data-drop-repo]"
+          ? "[data-drop-collection], [data-drop-team], [data-drop-repo], [data-drop-bot]"
           : drag.kind === "collection"
             ? "[data-drop-team], [data-drop-repo]"
             : "[data-drop-team]";
@@ -863,18 +889,22 @@ export default function Library({
       const collection = hit?.getAttribute("data-drop-collection") ?? "";
       const team = hit?.getAttribute("data-drop-team") ?? "";
       const repo = hit?.getAttribute("data-drop-repo") ?? "";
+      const bot = hit?.getAttribute("data-drop-bot") ?? "";
       dropCollectionRef.current = collection;
       dropTeamRef.current = team;
       dropRepoRef.current = repo;
+      dropBotRef.current = bot;
       setDropCollection(collection);
       setDropTeam(team);
       setDropRepo(repo);
+      setDropBot(bot);
     };
     const onUp = () => {
       const drag = dragRef.current;
       const collection = dropCollectionRef.current;
       const team = dropTeamRef.current;
       const repo = dropRepoRef.current;
+      const bot = dropBotRef.current;
       finish();
       // The click event (if any) fires synchronously after mouseup; clear
       // the suppress flag right after so the NEXT click isn't swallowed
@@ -966,6 +996,16 @@ export default function Library({
           (label) => `${label} now installs in ${repoLabel(repo)}`,
           (label) => `Install ${label} in ${repoLabel(repo)}`,
         );
+      } else if (drag.kind === "asset" && bot) {
+        dropAssets(
+          (n) =>
+            AddAssetInstallation(n, {
+              kind: "bot",
+              bot,
+            } as main.AssetInstallation),
+          (label) => `Installed ${label} for ${bot}`,
+          (label) => `Install ${label} for ${bot}`,
+        );
       } else if (drag.kind === "collection" && repo) {
         AddCollectionRepoScope(drag.name, repo)
           .then(() => {
@@ -1051,9 +1091,10 @@ export default function Library({
     return m;
   }, [installedInfo]);
 
-  // A repo view can't outlive repo tracking being switched off.
+  // A repo or bot view can't outlive the tracking being switched off.
   useEffect(() => {
-    if (!vault.trackRepos && scope.kind === "repo") setScope({ kind: "all" });
+    if (!vault.trackRepos && (scope.kind === "repo" || scope.kind === "bot"))
+      setScope({ kind: "all" });
   }, [vault.trackRepos, scope]);
 
   // Native menu → frontend views (Settings Cmd+,; File → New …)
@@ -1097,6 +1138,14 @@ export default function Library({
     [teams, scope],
   );
 
+  const activeBot = useMemo(
+    () =>
+      scope.kind === "bot"
+        ? ((bots ?? []).find((b) => b.name === scope.name) ?? null)
+        : null,
+    [bots, scope],
+  );
+
   // Repo URLs, sorted by their display label so the sidebar and browse
   // list read alphabetically.
   const repoUrls = useMemo(
@@ -1107,6 +1156,15 @@ export default function Library({
     [repoAssets],
   );
 
+  // Bot name → resolved asset names, in repoAssets' shape so the sidebar
+  // and scope filter treat both the same way. null while not tracking.
+  const botAssets = useMemo(() => {
+    if (bots === null) return null;
+    const out: Record<string, string[]> = {};
+    for (const b of bots) out[b.name] = b.skills ?? [];
+    return out;
+  }, [bots]);
+
   // Pins are explicit only: a never-pinned library shows no PINNED
   // section at all (the BROWSE rows are the durable path in), instead
   // of first-few defaults that read as pins the user never made.
@@ -1114,6 +1172,7 @@ export default function Library({
   const shownCollectionPins = pinnedCollections ?? [];
   const shownTeamPins = pinnedTeams ?? [];
   const shownRepoPins = pinnedRepos ?? [];
+  const shownBotPins = pinnedBots ?? [];
 
   const teamAssetCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -1125,11 +1184,13 @@ export default function Library({
     collections: shownCollectionPins,
     teams: shownTeamPins,
     repos: shownRepoPins,
+    bots: shownBotPins,
   };
   const pinSetters: Record<PinKind, (v: string[]) => void> = {
     collections: setPinnedCollections,
     teams: setPinnedTeams,
     repos: setPinnedRepos,
+    bots: setPinnedBots,
   };
 
   function setPins(kind: PinKind, next: string[]) {
@@ -1197,6 +1258,9 @@ export default function Library({
         case "repo":
           if (!(repoAssets?.[scope.name] ?? []).includes(a.name)) return false;
           break;
+        case "bot":
+          if (!(botAssets?.[scope.name] ?? []).includes(a.name)) return false;
+          break;
         case "all":
           break;
       }
@@ -1222,6 +1286,7 @@ export default function Library({
     teamAssets,
     personalAssets,
     repoAssets,
+    botAssets,
     sort,
     typeFilter,
   ]);
@@ -1303,6 +1368,8 @@ export default function Library({
         return scope.name;
       case "repo":
         return repoLabel(scope.name);
+      case "bot":
+        return scope.name;
     }
   })();
 
@@ -1317,6 +1384,25 @@ export default function Library({
       ensurePinned("teams", team.name);
       setScope({ kind: "team", name: team.name });
       setSelected(null);
+    } catch (e) {
+      setToastMessage(String(e));
+    }
+  }
+
+  async function createBot() {
+    const name = newBotName.trim();
+    if (!name) return;
+    try {
+      const created = await CreateBot(name, "");
+      setShowNewBot(false);
+      setNewBotName("");
+      load();
+      ensurePinned("bots", created.bot.name);
+      setScope({ kind: "bot", name: created.bot.name });
+      setSelected(null);
+      // Sleuth vaults auto-issue an API key; the raw token exists only
+      // now, so it gets a show-once modal instead of a toast.
+      if (created.token) setNewBotToken(created.token);
     } catch (e) {
       setToastMessage(String(e));
     }
@@ -1370,19 +1456,24 @@ export default function Library({
         teams={teams}
         teamAssetCounts={teamAssetCounts}
         repoAssets={vault.trackRepos ? (repoAssets ?? {}) : null}
+        botAssets={vault.trackRepos ? (botAssets ?? {}) : null}
         pinnedCollections={shownCollectionPins}
         pinnedTeams={shownTeamPins}
         pinnedRepos={shownRepoPins}
+        pinnedBots={shownBotPins}
         onUnpin={togglePin}
         onNewCollection={() => setShowCollectionModal(true)}
         onNewTeam={() => setShowNewTeam(true)}
+        onNewBot={() => setShowNewBot(true)}
         onBrowseCollections={() => setBrowse("collections")}
         onBrowseTeams={() => setBrowse("teams")}
         onBrowseRepos={() => setBrowse("repos")}
+        onBrowseBots={() => setBrowse("bots")}
         onSettings={() => setShowSettings(true)}
         dropCollection={dropCollection}
         dropTeam={dropTeam}
         dropRepo={dropRepo}
+        dropBot={dropBot}
         onCollectionDragHandle={(name, e) => {
           if (e.button !== 0) return;
           dragHappenedRef.current = false;
@@ -1830,6 +1921,47 @@ export default function Library({
               </span>
               <div className="flex-1" />
               {scopePinButton("repos", scope.name)}
+            </div>
+          )}
+
+          {activeBot && (
+            <div
+              className="flex items-center gap-3 border-t border-line bg-accent-soft/50 px-5 py-2 text-xs"
+              style={{ ["--wails-draggable" as never]: "no-drag" }}
+            >
+              <span className="min-w-0 truncate text-ink-soft">
+                {activeBot.description ||
+                  "Skills installed for this bot, directly or through its teams"}
+              </span>
+              <div className="flex-1" />
+              {scopePinButton("bots", activeBot.name)}
+              <button
+                onClick={() => setOpenBot(activeBot)}
+                className="rounded-md border border-line bg-surface px-2.5 py-1 font-medium text-ink-soft transition hover:border-accent hover:text-ink"
+              >
+                Manage bot…
+              </button>
+              <button
+                onClick={() => {
+                  void (async () => {
+                    const ok = await confirmAction(
+                      `Delete bot ${activeBot.name}? Assets stay in the library, but anything installed only for this bot stops resolving`,
+                      "Delete",
+                    );
+                    if (!ok) return;
+                    DeleteBot(activeBot.name)
+                      .then(() => {
+                        setScope({ kind: "all" });
+                        load();
+                        setToastMessage(`Bot ${activeBot.name} deleted`);
+                      })
+                      .catch((e) => setToastMessage(String(e)));
+                  })();
+                }}
+                className="rounded-md px-2 py-1 font-medium text-ink-faint transition hover:text-danger"
+              >
+                Delete
+              </button>
             </div>
           )}
         </header>
@@ -2534,11 +2666,47 @@ export default function Library({
         />
       )}
 
+      {browse === "bots" && (
+        <BrowseModal
+          title="All bots"
+          items={(bots ?? []).map((b) => {
+            const count = (b.skills ?? []).length;
+            return {
+              name: b.name,
+              count,
+              countLabel: count === 1 ? "asset" : "assets",
+            };
+          })}
+          pinned={shownBotPins}
+          onTogglePin={(name) => togglePin("bots", name)}
+          onSelect={(name) => {
+            setBrowse("");
+            setScope({ kind: "bot", name });
+            setSelected(null);
+          }}
+          onCreate={() => {
+            setBrowse("");
+            setShowNewBot(true);
+          }}
+          createLabel="New bot"
+          onClose={() => setBrowse("")}
+        />
+      )}
+
       {openTeam && (
         <TeamModal
           team={openTeam}
           showRepos={vault.trackRepos}
           onClose={() => setOpenTeam(null)}
+          onChanged={load}
+        />
+      )}
+
+      {openBot && (
+        <BotModal
+          bot={openBot}
+          teams={teams}
+          onClose={() => setOpenBot(null)}
           onChanged={load}
         />
       )}
@@ -2579,6 +2747,76 @@ export default function Library({
               </button>
             </div>
           </form>
+        </Modal>
+      )}
+
+      {showNewBot && (
+        <Modal title="New bot" onClose={() => setShowNewBot(false)}>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void createBot();
+            }}
+          >
+            <input
+              autoFocus
+              value={newBotName}
+              onChange={(e) => setNewBotName(e.target.value)}
+              placeholder="ci-bot, deploy-bot, support-bot…"
+              className="w-full rounded-lg border border-line bg-canvas px-3 py-2 text-sm outline-none focus:border-accent"
+            />
+            <p className="mt-2 text-xs text-ink-faint">
+              A bot is a non-human identity — install skills for it directly
+              or by adding it to teams.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setShowNewBot(false)}
+                className="rounded-lg border border-line px-4 py-2 text-sm font-medium text-ink-soft transition hover:text-ink"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={!newBotName.trim()}
+                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-50"
+              >
+                Create
+              </button>
+            </div>
+          </form>
+        </Modal>
+      )}
+
+      {newBotToken && (
+        <Modal title="Bot API key" onClose={() => setNewBotToken("")}>
+          <p className="text-sm text-ink-soft">
+            This key was issued with the bot and is shown only once — copy it
+            somewhere safe now.
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded-lg border border-line bg-canvas px-3 py-2 font-mono text-xs">
+              {newBotToken}
+            </code>
+            <button
+              onClick={() => {
+                void navigator.clipboard.writeText(newBotToken);
+                setToastMessage("Bot API key copied");
+              }}
+              className="shrink-0 rounded-lg border border-line px-3 py-2 text-sm font-medium text-ink-soft transition hover:border-accent hover:text-ink"
+            >
+              Copy
+            </button>
+          </div>
+          <div className="mt-4 flex justify-end">
+            <button
+              onClick={() => setNewBotToken("")}
+              className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition hover:opacity-90"
+            >
+              Done
+            </button>
+          </div>
         </Modal>
       )}
 
@@ -2868,6 +3106,20 @@ function EmptyState({
           Open an asset and use{" "}
           <span className="font-medium text-ink-soft">Share…</span> to send it
           to {scope.name} — it installs automatically for every member.
+        </div>
+      </Centered>
+    );
+  }
+  if (scope.kind === "bot") {
+    return (
+      <Centered>
+        <div className="text-sm font-medium">
+          Nothing installed for this bot yet
+        </div>
+        <div className="mt-1 max-w-sm text-sm text-ink-faint">
+          Drag an asset onto {scope.name} in the sidebar, or open an asset and
+          use <span className="font-medium text-ink-soft">Share…</span> and
+          pick Bot. Adding the bot to a team gives it the team's skills too.
         </div>
       </Centered>
     );

--- a/app/frontend/src/style.css
+++ b/app/frontend/src/style.css
@@ -20,6 +20,19 @@
     monospace;
 }
 
+/* Syntax token colors for highlighted code blocks in rendered markdown
+   (rehype-highlight emits hljs-* classes). Kept beside the design tokens so
+   both palettes flip together in dark mode. */
+:root {
+  --hl-keyword: #cf222e;
+  --hl-string: #0a3069;
+  --hl-comment: #6e7781;
+  --hl-number: #0550ae;
+  --hl-title: #8250df;
+  --hl-attr: #953800;
+  --hl-meta: #116329;
+}
+
 /* Dark mode: Linear-style neutral near-black — cool grays, hairline
    borders, soft (not pure-white) text. */
 @media (prefers-color-scheme: dark) {
@@ -34,6 +47,14 @@
     --color-accent-soft: #1d1f33;
     --color-danger: #f47c7c;
     --color-danger-soft: #2d1a1a;
+
+    --hl-keyword: #ff7b72;
+    --hl-string: #a5d6ff;
+    --hl-comment: #8b949e;
+    --hl-number: #79c0ff;
+    --hl-title: #d2a8ff;
+    --hl-attr: #ffa657;
+    --hl-meta: #7ee787;
   }
 }
 
@@ -101,6 +122,63 @@ body {
   background: none;
   padding: 0;
   font-size: 0.8rem;
+}
+
+/* highlight.js token classes → the theme's syntax palette. */
+.prose-sx .hljs-keyword,
+.prose-sx .hljs-selector-tag,
+.prose-sx .hljs-type,
+.prose-sx .hljs-tag,
+.prose-sx .hljs-name,
+.prose-sx .hljs-doctag {
+  color: var(--hl-keyword);
+}
+.prose-sx .hljs-string,
+.prose-sx .hljs-regexp,
+.prose-sx .hljs-char.escape_ {
+  color: var(--hl-string);
+}
+.prose-sx .hljs-comment,
+.prose-sx .hljs-quote {
+  color: var(--hl-comment);
+  font-style: italic;
+}
+.prose-sx .hljs-number,
+.prose-sx .hljs-literal,
+.prose-sx .hljs-symbol,
+.prose-sx .hljs-bullet,
+.prose-sx .hljs-built_in,
+.prose-sx .hljs-variable.constant_ {
+  color: var(--hl-number);
+}
+.prose-sx .hljs-title,
+.prose-sx .hljs-section,
+.prose-sx .hljs-title.function_,
+.prose-sx .hljs-title.class_ {
+  color: var(--hl-title);
+}
+.prose-sx .hljs-attr,
+.prose-sx .hljs-attribute,
+.prose-sx .hljs-variable,
+.prose-sx .hljs-template-variable,
+.prose-sx .hljs-property,
+.prose-sx .hljs-params {
+  color: var(--hl-attr);
+}
+.prose-sx .hljs-meta,
+.prose-sx .hljs-selector-id,
+.prose-sx .hljs-selector-class,
+.prose-sx .hljs-addition {
+  color: var(--hl-meta);
+}
+.prose-sx .hljs-deletion {
+  color: var(--color-danger);
+}
+.prose-sx .hljs-emphasis {
+  font-style: italic;
+}
+.prose-sx .hljs-strong {
+  font-weight: 600;
 }
 .prose-sx blockquote {
   border-left: 3px solid var(--color-line);

--- a/app/frontend/wailsjs/go/main/App.d.ts
+++ b/app/frontend/wailsjs/go/main/App.d.ts
@@ -63,6 +63,8 @@ export function DeleteTeam(arg1:string):Promise<void>;
 
 export function DescribeLibraryRemoval(arg1:string):Promise<main.LibraryRemoval>;
 
+export function DiffDraft(arg1:main.Draft):Promise<main.DraftDiff>;
+
 export function DiscardDraft(arg1:string):Promise<void>;
 
 export function DownloadAsset(arg1:string):Promise<string>;

--- a/app/frontend/wailsjs/go/main/App.d.ts
+++ b/app/frontend/wailsjs/go/main/App.d.ts
@@ -43,6 +43,8 @@ export function ConsolidateAssets(arg1:string,arg2:string,arg3:Array<string>):Pr
 
 export function CreateBlankDraft(arg1:string):Promise<main.Draft>;
 
+export function CreateBot(arg1:string,arg2:string):Promise<main.BotCreated>;
+
 export function CreateCollection(arg1:string):Promise<main.Collection>;
 
 export function CreateDraftFromAsset(arg1:string):Promise<main.Draft>;
@@ -56,6 +58,8 @@ export function CreateGitRepo(arg1:string):Promise<main.GitRepoOption>;
 export function CreateTeam(arg1:string):Promise<main.TeamInfo>;
 
 export function DeleteAssets(arg1:Array<string>):Promise<void>;
+
+export function DeleteBot(arg1:string):Promise<void>;
 
 export function DeleteCollection(arg1:string):Promise<void>;
 
@@ -114,6 +118,8 @@ export function LLMTest():Promise<string>;
 export function ListAIClients():Promise<Array<main.AIClient>>;
 
 export function ListAssets():Promise<Array<main.AssetCard>>;
+
+export function ListBots():Promise<Array<main.BotInfo>>;
 
 export function ListCollections():Promise<Array<main.Collection>>;
 
@@ -209,6 +215,8 @@ export function SetAssetPersonal(arg1:string,arg2:boolean):Promise<string>;
 
 export function SetAssetTeamSharing(arg1:string,arg2:string,arg3:boolean):Promise<void>;
 
+export function SetBotTeam(arg1:string,arg2:string,arg3:boolean):Promise<void>;
+
 export function SetCollectionMembership(arg1:string,arg2:string,arg3:boolean):Promise<void>;
 
 export function SetCollectionMembershipBulk(arg1:string,arg2:Array<string>,arg3:boolean):Promise<void>;
@@ -246,6 +254,8 @@ export function SwitchProfile(arg1:string):Promise<main.VaultInfo>;
 export function SyncAITools():Promise<string>;
 
 export function TeamAssets():Promise<Record<string, Array<string>>>;
+
+export function UpdateBotDescription(arg1:string,arg2:string):Promise<void>;
 
 export function UpdateDraft(arg1:main.Draft):Promise<main.Draft>;
 

--- a/app/frontend/wailsjs/go/main/App.js
+++ b/app/frontend/wailsjs/go/main/App.js
@@ -122,6 +122,10 @@ export function DescribeLibraryRemoval(arg1) {
   return window['go']['main']['App']['DescribeLibraryRemoval'](arg1);
 }
 
+export function DiffDraft(arg1) {
+  return window['go']['main']['App']['DiffDraft'](arg1);
+}
+
 export function DiscardDraft(arg1) {
   return window['go']['main']['App']['DiscardDraft'](arg1);
 }

--- a/app/frontend/wailsjs/go/main/App.js
+++ b/app/frontend/wailsjs/go/main/App.js
@@ -82,6 +82,10 @@ export function CreateBlankDraft(arg1) {
   return window['go']['main']['App']['CreateBlankDraft'](arg1);
 }
 
+export function CreateBot(arg1, arg2) {
+  return window['go']['main']['App']['CreateBot'](arg1, arg2);
+}
+
 export function CreateCollection(arg1) {
   return window['go']['main']['App']['CreateCollection'](arg1);
 }
@@ -108,6 +112,10 @@ export function CreateTeam(arg1) {
 
 export function DeleteAssets(arg1) {
   return window['go']['main']['App']['DeleteAssets'](arg1);
+}
+
+export function DeleteBot(arg1) {
+  return window['go']['main']['App']['DeleteBot'](arg1);
 }
 
 export function DeleteCollection(arg1) {
@@ -224,6 +232,10 @@ export function ListAIClients() {
 
 export function ListAssets() {
   return window['go']['main']['App']['ListAssets']();
+}
+
+export function ListBots() {
+  return window['go']['main']['App']['ListBots']();
 }
 
 export function ListCollections() {
@@ -414,6 +426,10 @@ export function SetAssetTeamSharing(arg1, arg2, arg3) {
   return window['go']['main']['App']['SetAssetTeamSharing'](arg1, arg2, arg3);
 }
 
+export function SetBotTeam(arg1, arg2, arg3) {
+  return window['go']['main']['App']['SetBotTeam'](arg1, arg2, arg3);
+}
+
 export function SetCollectionMembership(arg1, arg2, arg3) {
   return window['go']['main']['App']['SetCollectionMembership'](arg1, arg2, arg3);
 }
@@ -488,6 +504,10 @@ export function SyncAITools() {
 
 export function TeamAssets() {
   return window['go']['main']['App']['TeamAssets']();
+}
+
+export function UpdateBotDescription(arg1, arg2) {
+  return window['go']['main']['App']['UpdateBotDescription'](arg1, arg2);
 }
 
 export function UpdateDraft(arg1) {

--- a/app/frontend/wailsjs/go/models.ts
+++ b/app/frontend/wailsjs/go/models.ts
@@ -222,6 +222,63 @@ export namespace main {
 	        this.after = source["after"];
 	    }
 	}
+	export class DiffLine {
+	    kind: string;
+	    oldNo: number;
+	    newNo: number;
+	    text: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new DiffLine(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.kind = source["kind"];
+	        this.oldNo = source["oldNo"];
+	        this.newNo = source["newNo"];
+	        this.text = source["text"];
+	    }
+	}
+	export class DiffHunk {
+	    oldStart: number;
+	    oldLines: number;
+	    newStart: number;
+	    newLines: number;
+	    lines: DiffLine[];
+	
+	    static createFrom(source: any = {}) {
+	        return new DiffHunk(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.oldStart = source["oldStart"];
+	        this.oldLines = source["oldLines"];
+	        this.newStart = source["newStart"];
+	        this.newLines = source["newLines"];
+	        this.lines = this.convertValues(source["lines"], DiffLine);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
 	export class Draft {
 	    id: string;
 	    name: string;
@@ -264,6 +321,78 @@ export namespace main {
 		    return a;
 		}
 	}
+	export class FileDiff {
+	    path: string;
+	    status: string;
+	    additions: number;
+	    deletions: number;
+	    hunks: DiffHunk[];
+	
+	    static createFrom(source: any = {}) {
+	        return new FileDiff(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.status = source["status"];
+	        this.additions = source["additions"];
+	        this.deletions = source["deletions"];
+	        this.hunks = this.convertValues(source["hunks"], DiffHunk);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class DraftDiff {
+	    files: FileDiff[];
+	    additions: number;
+	    deletions: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new DraftDiff(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.files = this.convertValues(source["files"], FileDiff);
+	        this.additions = source["additions"];
+	        this.deletions = source["deletions"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class ExtensionScope {
 	    shared: boolean;
 	    personal: boolean;
@@ -280,6 +409,7 @@ export namespace main {
 	        this.label = source["label"];
 	    }
 	}
+	
 	export class GitRepoOption {
 	    name: string;
 	    url: string;

--- a/app/frontend/wailsjs/go/models.ts
+++ b/app/frontend/wailsjs/go/models.ts
@@ -168,6 +168,57 @@ export namespace main {
 	        this.monoRepoConfigId = source["monoRepoConfigId"];
 	    }
 	}
+	export class BotInfo {
+	    name: string;
+	    description: string;
+	    teams: string[];
+	    skills: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new BotInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
+	        this.description = source["description"];
+	        this.teams = source["teams"];
+	        this.skills = source["skills"];
+	    }
+	}
+	export class BotCreated {
+	    bot: BotInfo;
+	    token: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new BotCreated(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.bot = this.convertValues(source["bot"], BotInfo);
+	        this.token = source["token"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
 	export class Collection {
 	    name: string;
 	    description: string;

--- a/app/repos.go
+++ b/app/repos.go
@@ -10,7 +10,7 @@ import (
 
 // Repository views are a per-library opt-in (Profile.TrackRepos): technical
 // users see which repositories assets are scoped to; everyone else never
-// pays for the concept.
+// pays for the concept. Bots ride the same opt-in (app/bots.go).
 
 // RepoAssets maps repository URL → asset names scoped to it, for the
 // sidebar's REPOSITORIES section. Vaults that can't report this return an
@@ -37,8 +37,8 @@ func (a *App) RepoAssets() (map[string][]string, error) {
 	return out, nil
 }
 
-// SetLibraryRepoTracking turns repository views on or off for one library.
-// An empty name means the active library.
+// SetLibraryRepoTracking turns repository and bot views on or off for one
+// library. An empty name means the active library.
 func (a *App) SetLibraryRepoTracking(name string, enabled bool) (VaultInfo, error) {
 	mpc, err := config.LoadMultiProfile()
 	if err != nil {

--- a/app/settings.go
+++ b/app/settings.go
@@ -37,7 +37,7 @@ type ProfileInfo struct {
 	// Active: part of the active set — Sync installs this library's assets
 	// too. More than one library can be active at a time (sx multi-profile).
 	Active bool `json:"active"`
-	// TrackRepos: repository views are enabled for this library.
+	// TrackRepos: repository and bot views are enabled for this library.
 	TrackRepos bool `json:"trackRepos"`
 	// Icon is the library's uploaded icon as a data URL ("" = none).
 	Icon string `json:"icon"`


### PR DESCRIPTION
## Summary
- Add a Changes tab to the app's draft sheet showing what publishing would change, rendered as a unified diff (per-file sections, ADDED/MODIFIED/DELETED badges, hunk headers, line numbers)
- New `DiffDraft` bridge method diffs draft files against the target asset's latest published revision (LCS line diff, git-style hunk grouping, `metadata.toml` excluded)
- Sheet opens on Edit for editing flows; resuming a saved draft from the Drafts list opens on Changes
- Syntax-highlight fenced code blocks in rendered markdown (rehype-highlight, theme-aware palette) and in the draft editor (@codemirror/language-data)
- Show bots like repositories: behind the same per-library opt-in (now "Track repositories & bots"), with a Bots browse row, pins, a bot scope view, drag-an-asset-to-install, create/delete, and a BotModal for description + team membership
- New bot bridge methods (list/create/delete/description/teams) over the existing vault bot interface; Sleuth's auto-issued API key gets a show-once modal

**Security implications of changes have been considered**