### PR TITLE
SK-678: Fix app event-write race flaking releases

### DIFF
--- a/app/apptest_test.go
+++ b/app/apptest_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+// newTestApp is the one way tests construct an App. It registers the
+// event-writer drain with t.Cleanup: cleanups run LIFO, so the Wait always
+// runs before any earlier t.TempDir is removed, and a still-running
+// fire-and-forget audit/usage writer can never race a temp vault's
+// cleanup (the flake that failed the v2.2.6 release). A bare &App{} in a
+// test would quietly reintroduce that class.
+func newTestApp(t *testing.T) *App {
+	t.Helper()
+	a := &App{}
+	t.Cleanup(a.eventWrites.Wait)
+	return a
+}
+
+// newTestAppWithVault is newTestApp for the common vault-backed shape.
+func newTestAppWithVault(t *testing.T, v vaultpkg.Vault) *App {
+	t.Helper()
+	a := newTestApp(t)
+	a.ctx = context.Background()
+	a.vault = v
+	return a
+}

--- a/app/bridge.go
+++ b/app/bridge.go
@@ -54,6 +54,18 @@ type App struct {
 	// updateMu serializes update checks (startup + menu) so two
 	// tryAutoUpdate runs can never interleave the bundle swap.
 	updateMu sync.Mutex
+
+	// eventWrites tracks in-flight fire-and-forget audit/usage writers
+	// (goEvent). Tests wait on it so a still-running writer can't race
+	// the temp vault's cleanup — a long-standing CI flake.
+	eventWrites sync.WaitGroup
+}
+
+// goEvent runs a fire-and-forget vault event write on its own goroutine,
+// tracked by eventWrites. Production behavior is unchanged (nothing
+// waits); tests drain the group before their temp vaults are removed.
+func (a *App) goEvent(fn func()) {
+	a.eventWrites.Go(fn)
 }
 
 func NewApp() *App {

--- a/app/consolidate.go
+++ b/app/consolidate.go
@@ -209,11 +209,11 @@ func (a *App) retireSources(v vaultpkg.Vault, id, into string, sources []string,
 	}
 	// One fire-and-forget writer for all events, not one goroutine per
 	// retire — sequential appends can't interleave in the audit log.
-	go func() {
+	a.goEvent(func() {
 		for _, event := range audits {
 			a.appendPluginAudit(event)
 		}
-	}()
+	})
 	return retireErr
 }
 

--- a/app/diff_test.go
+++ b/app/diff_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -152,7 +151,7 @@ func TestDiffFiles_StatusesAndTotals(t *testing.T) {
 // A draft with no target asset diffs against nothing — every file is added
 // and no vault access happens.
 func TestDiffDraft_NewAsset(t *testing.T) {
-	a := &App{}
+	a := newTestApp(t)
 	d, err := a.DiffDraft(Draft{
 		Name:  "brand-new",
 		Files: []AssetFile{{Path: "SKILL.md", Content: "one\ntwo\n"}},
@@ -182,7 +181,7 @@ func TestDiffDraft_AgainstPublishedAsset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPathVault: %v", err)
 	}
-	a := &App{ctx: context.Background(), vault: v}
+	a := newTestAppWithVault(t, v)
 
 	skillZip := zipOf(t, map[string]string{
 		"SKILL.md":      "---\nname: docs-tone\n---\n\n# docs-tone\nold body\n",

--- a/app/drafts_test.go
+++ b/app/drafts_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -23,7 +22,7 @@ import (
 // publish ("unknown asset type").
 func TestLoadDraft_RepairsMissingType(t *testing.T) {
 	t.Setenv("SX_CONFIG_DIR", t.TempDir())
-	a := &App{}
+	a := newTestApp(t)
 
 	root, err := draftsRoot()
 	if err != nil {
@@ -68,7 +67,7 @@ func TestLatestAssetZip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPathVault: %v", err)
 	}
-	a := &App{ctx: context.Background(), vault: v}
+	a := newTestAppWithVault(t, v)
 
 	skillZip := zipOf(t, map[string]string{
 		"SKILL.md":      "---\nname: docs-tone\ndescription: Tone.\n---\n\n# docs-tone\n",
@@ -112,7 +111,7 @@ func TestCreateDraftFromFiles_TargetsExistingAsset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPathVault: %v", err)
 	}
-	a := &App{ctx: context.Background(), vault: v}
+	a := newTestAppWithVault(t, v)
 
 	skillZip := zipOf(t, map[string]string{
 		"SKILL.md":      "---\nname: docs-tone\ndescription: Tone.\n---\n\n# docs-tone\n",

--- a/app/extensions_install.go
+++ b/app/extensions_install.go
@@ -247,7 +247,7 @@ func (a *App) ShareExtensionWithLibrary(id string) error {
 		TargetType: mgmt.TargetTypePlugin,
 		Target:     id,
 	}
-	go a.appendPluginAudit(event)
+	a.goEvent(func() { a.appendPluginAudit(event) })
 	return nil
 }
 
@@ -335,7 +335,7 @@ func (a *App) emitExtensionInstall(id, version, scope, source string, wasUpdate 
 	if wasUpdate {
 		event.Event = mgmt.EventPluginUpdated
 	}
-	go a.appendPluginAudit(event)
+	a.goEvent(func() { a.appendPluginAudit(event) })
 	usage := mgmt.UsageEvent{
 		Timestamp:    event.Timestamp,
 		Actor:        actor,
@@ -343,7 +343,7 @@ func (a *App) emitExtensionInstall(id, version, scope, source string, wasUpdate 
 		AssetVersion: version,
 		AssetType:    asset.TypeAppPlugin.Key,
 	}
-	go a.recordPluginUsage(usage)
+	a.goEvent(func() { a.recordPluginUsage(usage) })
 }
 
 // emitExtensionRemove appends the uninstall audit event (fire-and-forget,
@@ -357,7 +357,7 @@ func (a *App) emitExtensionRemove(id, scope string) {
 		Target:     id,
 		Data:       map[string]any{"scope": scope},
 	}
-	go a.appendPluginAudit(event)
+	a.goEvent(func() { a.appendPluginAudit(event) })
 }
 
 // recordPluginUsage writes one usage event to the vault's usage stream,

--- a/app/extensions_install_test.go
+++ b/app/extensions_install_test.go
@@ -41,10 +41,7 @@ func scopedExtensionApp(t *testing.T, email string) (*App, string, string) {
 	if err != nil {
 		t.Fatalf("NewPathVault: %v", err)
 	}
-	a := &App{ctx: context.Background(), vault: v}
-	// Cleanups run LIFO: this Wait runs before the TempDir removals above,
-	// so an in-flight audit/usage writer can never race vault cleanup.
-	t.Cleanup(a.eventWrites.Wait)
+	a := newTestAppWithVault(t, v)
 	return a, cfgDir, vdir
 }
 

--- a/app/extensions_install_test.go
+++ b/app/extensions_install_test.go
@@ -42,6 +42,9 @@ func scopedExtensionApp(t *testing.T, email string) (*App, string, string) {
 		t.Fatalf("NewPathVault: %v", err)
 	}
 	a := &App{ctx: context.Background(), vault: v}
+	// Cleanups run LIFO: this Wait runs before the TempDir removals above,
+	// so an in-flight audit/usage writer can never race vault cleanup.
+	t.Cleanup(a.eventWrites.Wait)
 	return a, cfgDir, vdir
 }
 

--- a/app/marketplace_test.go
+++ b/app/marketplace_test.go
@@ -33,19 +33,23 @@ func newExtensionVault(t *testing.T, a *App, id, name, description string) strin
 	// Publish through the app pointed temporarily at this vault. In-flight
 	// event writers read a.vault via currentVault (under a.mu) — drain them
 	// around each swap and hold the lock, so a swap never races a reader
-	// and no event lands in the wrong vault.
+	// and no event lands in the wrong vault. The restore is deferred:
+	// t.Fatalf in the publish path Goexits, and the fixture vault must not
+	// leak into the rest of the test.
 	a.eventWrites.Wait()
 	a.mu.Lock()
 	prev := a.vault
 	a.vault = v
 	a.mu.Unlock()
+	defer func() {
+		a.eventWrites.Wait()
+		a.mu.Lock()
+		a.vault = prev
+		a.mu.Unlock()
+	}()
 	if _, _, err := a.addExtensionFrom(src); err != nil {
 		t.Fatalf("publish fixture extension: %v", err)
 	}
-	a.eventWrites.Wait()
-	a.mu.Lock()
-	a.vault = prev
-	a.mu.Unlock()
 	return vdir
 }
 

--- a/app/marketplace_test.go
+++ b/app/marketplace_test.go
@@ -30,13 +30,22 @@ func newExtensionVault(t *testing.T, a *App, id, name, description string) strin
 	if err := os.WriteFile(src+"/main.js", []byte("export default class { onload(sx) {} }"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Publish through the app pointed temporarily at this vault.
+	// Publish through the app pointed temporarily at this vault. In-flight
+	// event writers read a.vault via currentVault (under a.mu) — drain them
+	// around each swap and hold the lock, so a swap never races a reader
+	// and no event lands in the wrong vault.
+	a.eventWrites.Wait()
+	a.mu.Lock()
 	prev := a.vault
 	a.vault = v
+	a.mu.Unlock()
 	if _, _, err := a.addExtensionFrom(src); err != nil {
 		t.Fatalf("publish fixture extension: %v", err)
 	}
+	a.eventWrites.Wait()
+	a.mu.Lock()
 	a.vault = prev
+	a.mu.Unlock()
 	return vdir
 }
 

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -209,7 +209,7 @@ func (a *App) SetPluginDecision(id string, enabled bool) error {
 	if !enabled {
 		event.Event = mgmt.EventPluginDisabled
 	}
-	go a.appendPluginAudit(event)
+	a.goEvent(func() { a.appendPluginAudit(event) })
 	return nil
 }
 

--- a/app/plugins_test.go
+++ b/app/plugins_test.go
@@ -17,7 +17,7 @@ func pluginTestApp(t *testing.T) *App {
 	t.Setenv("SX_CONFIG_DIR", dir)
 	// pluginDataDir needs a loadable config; seed a minimal path profile.
 	seedConfig(t, dir)
-	return &App{}
+	return newTestApp(t)
 }
 
 func seedConfig(t *testing.T, dir string) {
@@ -101,7 +101,7 @@ func TestPluginConsents(t *testing.T) {
 }
 
 func TestAppVersionNonEmpty(t *testing.T) {
-	a := &App{}
+	a := newTestApp(t)
 	if a.AppVersion() == "" {
 		t.Fatalf("AppVersion must never be empty (sx.app.version contract)")
 	}


### PR DESCRIPTION
## Summary
- The v2.2.6 Release run failed on `TestOrgInstallIsLibraryWide`: fire-and-forget audit/usage goroutines were still writing into the temp vault's `.sx` dir while `t.TempDir` cleanup removed it
- Event writers now run through `App.goEvent` (WaitGroup-tracked); the shared test helper drains the group in `t.Cleanup` before temp dirs are removed
- Also fixes the latent data race the drain exposed: `newExtensionVault` swapped `a.vault` without the mutex while a writer read it via `currentVault` (reproducible with `-race -count=3`); the helper now drains and locks around both swaps
- Production behavior unchanged — nothing waits on the group outside tests

**Security implications of changes have been considered**