### PR TITLE
SK-681: Add quality storage across vault types

### DIFF
--- a/app/frontend/src/plugins/api.ts
+++ b/app/frontend/src/plugins/api.ts
@@ -3,7 +3,7 @@
 // extension needs something this file doesn't offer, the answer is an API
 // addition, never an escape hatch to app internals.
 
-export const SX_API_VERSION = "1.11.0";
+export const SX_API_VERSION = "1.12.0";
 
 /** Capabilities an extension may declare. Undeclared calls throw.
  * `net:<host>` is a parameterized family (API 1.4.0): each declared
@@ -29,6 +29,7 @@ export type Permission =
   | "llm:use"
   | "assets:consolidate"
   | "benchmarks"
+  | "quality"
   | `net:${string}`;
 
 /** plugin.json — the extension manifest. */
@@ -156,6 +157,59 @@ export interface BenchmarkRecord {
    * the asset's current one — the staleness signal. */
   skill_version?: string | null;
   is_current_version?: boolean | null;
+}
+
+// ---- Quality (API 1.12.0) ----
+
+/** One quality evaluation in the interchange shape shared with
+ * skills.new (docs/quality-spec.md). File vaults hold these at
+ * .sx/quality/<asset>.json; skills.new keeps its own evaluation document
+ * per asset, so records with source "server" are evaluations skills.new
+ * ran itself (and the only kind that vault ever returns). */
+export interface QualityRecord {
+  /** RFC3339 timestamp of the evaluation (server records: approximated
+   * from the asset's update time). */
+  at?: string;
+  source: "app" | "server";
+  /** Who ran it (vault identity or skills.new user). */
+  by?: string;
+  /** App records: which provider/model evaluated. */
+  executor?: { provider: string; model: string };
+  /** Overall score, 0-100. */
+  overall: number;
+  /** Category scores, 0-100 each. */
+  categories: {
+    structure?: number;
+    actionability?: number;
+    content?: number;
+    completeness?: number;
+  };
+  /** Per-factor breakdown ({score, tier, justification} each). */
+  factors?: Record<string, { score: number; tier: string; justification?: string }>;
+  /** One-paragraph assessment. */
+  summary?: string;
+  insights?: {
+    strengths: string[];
+    improvements: string[];
+    recommendations: string[];
+  };
+  stats?: { file_count?: number; word_count?: number };
+  /** App records: the content hash evaluated — the staleness signal. */
+  skill_hash?: string;
+}
+
+/** What sx.quality.get returns: the record history plus whether the
+ * vault backend is evaluating right now (skills.new only — poll get()
+ * until it flips false, then read the fresh record). */
+export interface QualityDoc {
+  evaluating: boolean;
+  records: QualityRecord[];
+}
+
+/** Who runs a requested re-evaluation: the vault backend ("server",
+ * poll get()) or the extension itself ("local", evaluate then add()). */
+export interface QualityReevaluateResult {
+  mode: "server" | "local";
 }
 
 // ---- LLM (API 1.9.0) ----
@@ -429,6 +483,20 @@ export interface SxAPI {
     list(assetName: string): Promise<BenchmarkRecord[]>;
     add(assetName: string, record: BenchmarkRecord): Promise<void>;
     latest(): Promise<Record<string, BenchmarkRecord>>;
+  };
+
+  /** Requires quality (API 1.12.0). Per-asset quality evaluations,
+   * unified across vault types: .sx/quality/<asset>.json on file vaults
+   * (extension-run, stored via `add`), the server's own evaluation
+   * document on skills.new (read-only there — `add` rejects).
+   * `reevaluate` dispatches: "server" means the backend is evaluating
+   * (poll `get` until evaluating flips false); "local" means the
+   * extension must evaluate via sx.llm and store the record itself. */
+  readonly quality: {
+    get(assetName: string): Promise<QualityDoc>;
+    add(assetName: string, record: QualityRecord): Promise<void>;
+    latest(): Promise<Record<string, QualityRecord>>;
+    reevaluate(assetName: string): Promise<QualityReevaluateResult>;
   };
 
   /** Requires llm:use (API 1.9.0). One completion against whatever LLM

--- a/app/frontend/src/plugins/host.ts
+++ b/app/frontend/src/plugins/host.ts
@@ -127,6 +127,7 @@ const KNOWN_PERMISSIONS = new Set([
   "export",
   "llm:use",
   "assets:consolidate",
+  "quality",
 ]);
 
 // net:<host> is a parameterized permission family; the host is a bare

--- a/app/frontend/src/plugins/policy.ts
+++ b/app/frontend/src/plugins/policy.ts
@@ -116,6 +116,8 @@ const PERMISSION_DESCRIPTIONS: Record<FixedPermission, string> = {
     "Keep shared state in this library, visible to everyone who uses it",
   benchmarks:
     "Read and record skill benchmark results in this library (on skills.new, shared with server-run benchmarks)",
+  quality:
+    "Read and record skill quality evaluations in this library (on skills.new, surfaces the server's own scores)",
   "views:collection": "Add tabs to collection views",
   "views:team": "Add tabs to team views",
   "views:repo": "Add tabs to repository views",

--- a/app/frontend/src/plugins/sxapi.ts
+++ b/app/frontend/src/plugins/sxapi.ts
@@ -28,6 +28,10 @@ import {
   PluginBenchmarksList,
   PluginBenchmarksAdd,
   PluginBenchmarksLatest,
+  PluginQualityGet,
+  PluginQualityAdd,
+  PluginQualityLatest,
+  PluginQualityReevaluate,
   PluginUsageEvents,
   PluginUsageEventsSince,
   PluginAuditEvents,
@@ -49,6 +53,9 @@ import type {
   LLMRequest,
   LLMResult,
   MainViewSpec,
+  QualityDoc,
+  QualityRecord,
+  QualityReevaluateResult,
   RepoViewSpec,
   Permission,
   PluginManifest,
@@ -276,6 +283,45 @@ export function buildSxAPI(manifest: PluginManifest): SxAPI {
         } catch {
           return {};
         }
+      },
+    },
+
+    quality: {
+      async get(assetName: string): Promise<QualityDoc> {
+        need("quality");
+        const raw = await PluginQualityGet(assetName);
+        const empty: QualityDoc = { evaluating: false, records: [] };
+        if (!raw) return empty;
+        try {
+          const parsed = JSON.parse(raw);
+          if (!parsed || typeof parsed !== "object") return empty;
+          return {
+            evaluating: parsed.evaluating === true,
+            records: Array.isArray(parsed.records) ? (parsed.records as QualityRecord[]) : [],
+          };
+        } catch {
+          return empty;
+        }
+      },
+      async add(assetName: string, record: QualityRecord): Promise<void> {
+        need("quality");
+        await PluginQualityAdd(assetName, JSON.stringify(record));
+      },
+      async latest(): Promise<Record<string, QualityRecord>> {
+        need("quality");
+        const raw = await PluginQualityLatest();
+        if (!raw) return {};
+        try {
+          const parsed = JSON.parse(raw);
+          return parsed && typeof parsed === "object" ? (parsed as Record<string, QualityRecord>) : {};
+        } catch {
+          return {};
+        }
+      },
+      async reevaluate(assetName: string): Promise<QualityReevaluateResult> {
+        need("quality");
+        const mode = await PluginQualityReevaluate(assetName);
+        return { mode: mode === "server" ? "server" : "local" };
       },
     },
 

--- a/app/frontend/wailsjs/go/main/App.d.ts
+++ b/app/frontend/wailsjs/go/main/App.d.ts
@@ -165,6 +165,14 @@ export function PluginDecisions():Promise<Record<string, boolean>>;
 
 export function PluginLoadData(arg1:string):Promise<string>;
 
+export function PluginQualityAdd(arg1:string,arg2:string):Promise<void>;
+
+export function PluginQualityGet(arg1:string):Promise<string>;
+
+export function PluginQualityLatest():Promise<string>;
+
+export function PluginQualityReevaluate(arg1:string):Promise<string>;
+
 export function PluginSaveData(arg1:string,arg2:string):Promise<void>;
 
 export function PluginSecretGet(arg1:string,arg2:string):Promise<string>;

--- a/app/frontend/wailsjs/go/main/App.js
+++ b/app/frontend/wailsjs/go/main/App.js
@@ -326,6 +326,22 @@ export function PluginLoadData(arg1) {
   return window['go']['main']['App']['PluginLoadData'](arg1);
 }
 
+export function PluginQualityAdd(arg1, arg2) {
+  return window['go']['main']['App']['PluginQualityAdd'](arg1, arg2);
+}
+
+export function PluginQualityGet(arg1) {
+  return window['go']['main']['App']['PluginQualityGet'](arg1);
+}
+
+export function PluginQualityLatest() {
+  return window['go']['main']['App']['PluginQualityLatest']();
+}
+
+export function PluginQualityReevaluate(arg1) {
+  return window['go']['main']['App']['PluginQualityReevaluate'](arg1);
+}
+
 export function PluginSaveData(arg1, arg2) {
   return window['go']['main']['App']['PluginSaveData'](arg1, arg2);
 }

--- a/app/plugin_quality.go
+++ b/app/plugin_quality.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+// Quality storage for extensions (SxAPI 1.12.0, docs/quality-spec.md):
+// one capped, newest-first record list per asset, unified across vault
+// types — .sx/quality/<asset>.json on file vaults, the server's own
+// evaluation document on skills.new.
+
+var errQualityUnsupported = errors.New(
+	"this library's backend doesn't support quality storage yet")
+
+func (a *App) qualityStore() (vaultpkg.QualityStore, error) {
+	v, err := a.currentVault()
+	if err != nil {
+		return nil, err
+	}
+	store, ok := v.(vaultpkg.QualityStore)
+	if !ok {
+		return nil, errQualityUnsupported
+	}
+	return store, nil
+}
+
+// PluginQualityGet returns an asset's quality wrapper doc as JSON:
+// {"evaluating": bool, "records": [...]} with records newest first.
+func (a *App) PluginQualityGet(asset string) (string, error) {
+	store, err := a.qualityStore()
+	if err != nil {
+		return "", err
+	}
+	return store.GetQuality(a.ctx, asset)
+}
+
+// PluginQualityAdd records one quality evaluation for an asset.
+func (a *App) PluginQualityAdd(asset, record string) error {
+	store, err := a.qualityStore()
+	if err != nil {
+		return err
+	}
+	return store.AddQuality(a.ctx, asset, record)
+}
+
+// PluginQualityLatest returns the newest record per asset as a JSON
+// object ("" when nothing is evaluated yet).
+func (a *App) PluginQualityLatest() (string, error) {
+	store, err := a.qualityStore()
+	if err != nil {
+		return "", err
+	}
+	return store.LatestQuality(a.ctx)
+}
+
+// PluginQualityReevaluate requests a fresh evaluation and reports who
+// runs it: "server" (poll PluginQualityGet until evaluating flips false)
+// or "local" (the extension evaluates and stores via PluginQualityAdd).
+func (a *App) PluginQualityReevaluate(asset string) (string, error) {
+	store, err := a.qualityStore()
+	if err != nil {
+		return "", err
+	}
+	return store.ReevaluateQuality(a.ctx, asset)
+}

--- a/app/plugin_quality.go
+++ b/app/plugin_quality.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-
 	vaultpkg "github.com/sleuth-io/sx/internal/vault"
 )
 
@@ -11,9 +9,6 @@ import (
 // types — .sx/quality/<asset>.json on file vaults, the server's own
 // evaluation document on skills.new.
 
-var errQualityUnsupported = errors.New(
-	"this library's backend doesn't support quality storage yet")
-
 func (a *App) qualityStore() (vaultpkg.QualityStore, error) {
 	v, err := a.currentVault()
 	if err != nil {
@@ -21,7 +16,10 @@ func (a *App) qualityStore() (vaultpkg.QualityStore, error) {
 	}
 	store, ok := v.(vaultpkg.QualityStore)
 	if !ok {
-		return nil, errQualityUnsupported
+		// Same sentinel the sleuth vault uses for an old server, so the
+		// user-facing message is one string regardless of which layer
+		// noticed.
+		return nil, vaultpkg.ErrQualityUnsupported
 	}
 	return store, nil
 }

--- a/app/plugin_quality_test.go
+++ b/app/plugin_quality_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	vaultpkg "github.com/sleuth-io/sx/internal/vault"
+)
+
+func qualityTestApp(t *testing.T) *App {
+	t.Helper()
+	vdir := t.TempDir()
+	runGitCmd(t, vdir, "init")
+	runGitCmd(t, vdir, "config", "user.email", "alice@example.com")
+	runGitCmd(t, vdir, "config", "user.name", "Alice")
+	v, err := vaultpkg.NewPathVault("file://" + vdir)
+	if err != nil {
+		t.Fatalf("NewPathVault: %v", err)
+	}
+	return newTestAppWithVault(t, v)
+}
+
+// The bridge is a thin pass-through to the vault's QualityStore: records
+// round-trip, the wrapper shape holds, and reevaluate dispatches "local"
+// on a file vault.
+func TestPluginQualityBridge(t *testing.T) {
+	a := qualityTestApp(t)
+
+	raw, err := a.PluginQualityGet("commit-msgs")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var doc struct {
+		Evaluating bool             `json:"evaluating"`
+		Records    []map[string]any `json:"records"`
+	}
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("wrapper not JSON: %v\n%s", err, raw)
+	}
+	if doc.Evaluating || len(doc.Records) != 0 {
+		t.Fatalf("initial doc = %q", raw)
+	}
+
+	record := `{"at":"2026-07-14T18:00:00Z","source":"app","overall":84,` +
+		`"categories":{"structure":90,"actionability":80,"content":83,"completeness":85}}`
+	if err := a.PluginQualityAdd("commit-msgs", record); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	raw, err = a.PluginQualityGet("commit-msgs")
+	if err != nil {
+		t.Fatalf("get after add: %v", err)
+	}
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("wrapper not JSON: %v", err)
+	}
+	if len(doc.Records) != 1 || doc.Records[0]["overall"].(float64) != 84 {
+		t.Fatalf("doc after add = %q", raw)
+	}
+
+	latest, err := a.PluginQualityLatest()
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	var m map[string]map[string]any
+	if err := json.Unmarshal([]byte(latest), &m); err != nil || m["commit-msgs"] == nil {
+		t.Fatalf("latest = %q, %v", latest, err)
+	}
+
+	mode, err := a.PluginQualityReevaluate("commit-msgs")
+	if err != nil || mode != vaultpkg.QualityEvalLocal {
+		t.Fatalf("reevaluate = %q, %v; want local", mode, err)
+	}
+}

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -48,7 +48,7 @@ var knownPluginPermissions = map[string]bool{
 	"views:main": true, "assets:write-metadata": true, "secrets": true,
 	"storage:shared": true, "views:collection": true, "export": true,
 	"views:team": true, "views:repo": true, "llm:use": true,
-	"assets:consolidate": true, "benchmarks": true,
+	"assets:consolidate": true, "benchmarks": true, "quality": true,
 }
 
 // netPermissionPattern matches the host-scoped network permission

--- a/docs/app-plugins-spec.md
+++ b/docs/app-plugins-spec.md
@@ -242,6 +242,16 @@ adoption.
   does it (per-revision markdown cache, AND semantics, heading-weighted,
   excerpt highlighting in result rows).
 
+### API 1.12.0 additions (quality storage)
+
+- `quality` permission + `sx.quality.get/add/latest/reevaluate`:
+  per-asset quality evaluations (overall 0–100, category scores,
+  summary, insights) unified across vault types —
+  `.sx/quality/<asset>.json` on file vaults, the server's own
+  evaluation document on skills.new (read-only there; `reevaluate`
+  fires the server's evaluator and `get` polls its `evaluating`
+  flag). Full contract in `docs/quality-spec.md`.
+
 ### API 1.9.0 additions (the sx.llm core service)
 
 - `llm:use` permission + `sx.llm.complete({messages, schema?, model?,

--- a/docs/quality-spec.md
+++ b/docs/quality-spec.md
@@ -1,0 +1,82 @@
+# Quality storage
+
+One quality store per library, unified across vault types (SxAPI
+1.12.0, the `quality` permission). Quality is a per-asset evaluation of
+the skill itself — an overall 0–100 score, four category scores, a
+summary, and insights — matching the Quality tab on skills.new. The
+skill-quality extension surfaces it; on skills.new the store is the
+server's own evaluation, read as-is.
+
+## Where records live — and who evaluates
+
+| Vault type | Storage | Who evaluates |
+|---|---|---|
+| Local folder / synced folder / git | `.sx/quality/<asset>.json` — `{"quality": [...]}`, newest first, capped at 10 records per asset (git history keeps the rest) | The extension, through the user's AI provider (`reevaluate` returns `"local"`); it stores the record via `add` |
+| skills.new | The server's own evaluation document (`Asset.evaluation_result`), read through `vault { assets }` and normalized to the interchange shape; one record, no history | The server (`reevaluate` fires the `evaluateAsset` mutation and returns `"server"`; poll `get` until `evaluating` flips false). `add` is refused — the server document is the source of truth |
+
+File vaults enforce the same contract before anything is written: one
+JSON object per record, at most 256 KB, with a numeric `overall` in
+[0,100] and a `categories` object. Servers predating the surface yield
+"doesn't support quality storage yet" — extensions should
+feature-detect and fall back. skills.new only evaluates managed assets;
+git-sourced assets there have no quality data.
+
+## The interchange record
+
+Normalized from pulse's evaluation document
+(`asset_evaluation_tool.py`): `overall_confidence`×100 → `overall`,
+`category_scores.content_quality` → `categories.content`, `reasoning` →
+`summary`, `llm_strengths`/`llm_weaknesses`/`llm_recommendations` →
+`insights`.
+
+```json
+{
+  "at": "2026-07-14T18:00:00Z",
+  "source": "app",
+  "by": "detkin@sleuth.io",
+  "executor": { "provider": "claude-cli", "model": "claude-sonnet-4-6" },
+  "overall": 84,
+  "categories": { "structure": 90, "actionability": 80, "content": 83, "completeness": 85 },
+  "factors": {
+    "specificity": { "score": 90, "tier": "Excellent", "justification": "..." }
+  },
+  "summary": "A solid, well-structured skill that...",
+  "insights": {
+    "strengths": ["Excellent concrete examples..."],
+    "improvements": ["No troubleshooting section..."],
+    "recommendations": ["Add a Setup section..."]
+  },
+  "stats": { "file_count": 2, "word_count": 609 },
+  "skill_hash": "a1b2c3d4"
+}
+```
+
+- `source` — `"app"` for extension-run records, `"server"` for
+  evaluations skills.new ran itself (the only kind that vault returns).
+- Staleness: app records carry `skill_hash` (the sx content hash they
+  evaluated); server records carry `at` approximated from the asset's
+  update time, since pulse stores no evaluation timestamp.
+- The trend chip (score delta vs the previous record) only exists on
+  file vaults — skills.new keeps a single document, so its history has
+  at most one record.
+- Calibration note: the extension's local rubric is a port of pulse's
+  and both sides evolve independently — records are comparable in
+  shape, not calibration. Don't chart app and server scores as one
+  series.
+
+## Extension API
+
+```ts
+sx.quality.get(assetName)   // { evaluating, records: QualityRecord[] } — newest first
+sx.quality.add(assetName, record)   // file vaults only; skills.new refuses
+sx.quality.latest()         // { [assetName]: QualityRecord } — one bulk read
+sx.quality.reevaluate(assetName)    // { mode: "server" | "local" }
+```
+
+The `reevaluate` contract keeps vault-type knowledge out of extensions:
+`"server"` means the backend is evaluating (poll `get`); `"local"`
+means the extension evaluates via `sx.llm` and stores via `add`.
+
+Any library member may read and record on file vaults — the same trust
+model as `storage:shared`. On skills.new, re-evaluation runs under the
+member's own account and the server enforces edit rights.

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -3279,6 +3279,46 @@ func (v *DeleteTeamResponse) GetDeleteTeam() *DeleteTeamDeleteTeamDeleteTeamMuta
 	return v.DeleteTeam
 }
 
+// EvaluateAssetEvaluateAssetEvaluateAssetMutation includes the requested fields of the GraphQL type EvaluateAssetMutation.
+// The GraphQL type's documentation follows.
+//
+// Evaluate an asset's quality, actionability, and completeness.
+type EvaluateAssetEvaluateAssetEvaluateAssetMutation struct {
+	Errors []EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType `json:"errors"`
+}
+
+// GetErrors returns EvaluateAssetEvaluateAssetEvaluateAssetMutation.Errors, and is useful for accessing the field via an interface.
+func (v *EvaluateAssetEvaluateAssetEvaluateAssetMutation) GetErrors() []EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType {
+	return v.Errors
+}
+
+// EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType includes the requested fields of the GraphQL type ErrorType.
+type EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType struct {
+	Field    string   `json:"field"`
+	Messages []string `json:"messages"`
+}
+
+// GetField returns EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType.Field, and is useful for accessing the field via an interface.
+func (v *EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType) GetField() string {
+	return v.Field
+}
+
+// GetMessages returns EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType.Messages, and is useful for accessing the field via an interface.
+func (v *EvaluateAssetEvaluateAssetEvaluateAssetMutationErrorsErrorType) GetMessages() []string {
+	return v.Messages
+}
+
+// EvaluateAssetResponse is returned by EvaluateAsset on success.
+type EvaluateAssetResponse struct {
+	// Evaluate an asset's quality, actionability, and completeness.
+	EvaluateAsset *EvaluateAssetEvaluateAssetEvaluateAssetMutation `json:"evaluateAsset"`
+}
+
+// GetEvaluateAsset returns EvaluateAssetResponse.EvaluateAsset, and is useful for accessing the field via an interface.
+func (v *EvaluateAssetResponse) GetEvaluateAsset() *EvaluateAssetEvaluateAssetEvaluateAssetMutation {
+	return v.EvaluateAsset
+}
+
 // FindUserOrganizationOrganizationType includes the requested fields of the GraphQL type OrganizationType.
 type FindUserOrganizationOrganizationType struct {
 	Users FindUserOrganizationOrganizationTypeUsersUserConnection `json:"users"`
@@ -3400,6 +3440,1407 @@ type GetAssetBenchmarksVault struct {
 
 // GetAssetBenchmarks returns GetAssetBenchmarksVault.AssetBenchmarks, and is useful for accessing the field via an interface.
 func (v *GetAssetBenchmarksVault) GetAssetBenchmarks() *json.RawMessage { return v.AssetBenchmarks }
+
+// GetAssetQualityResponse is returned by GetAssetQuality on success.
+type GetAssetQualityResponse struct {
+	Vault GetAssetQualityVault `json:"vault"`
+}
+
+// GetVault returns GetAssetQualityResponse.Vault, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityResponse) GetVault() GetAssetQualityVault { return v.Vault }
+
+// GetAssetQualityVault includes the requested fields of the GraphQL type Vault.
+// The GraphQL type's documentation follows.
+//
+// Vault containing assets.
+type GetAssetQualityVault struct {
+	Assets GetAssetQualityVaultAssetsVaultAssetsConnection `json:"assets"`
+}
+
+// GetAssets returns GetAssetQualityVault.Assets, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVault) GetAssets() GetAssetQualityVaultAssetsVaultAssetsConnection {
+	return v.Assets
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnection includes the requested fields of the GraphQL type VaultAssetsConnection.
+// The GraphQL type's documentation follows.
+//
+// Paginated list of vault assets.
+type GetAssetQualityVaultAssetsVaultAssetsConnection struct {
+	// Pagination data for this connection.
+	PageInfo GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo          `json:"pageInfo"`
+	Nodes    []GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset `json:"-"`
+}
+
+// GetPageInfo returns GetAssetQualityVaultAssetsVaultAssetsConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnection) GetPageInfo() GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo {
+	return v.PageInfo
+}
+
+// GetNodes returns GetAssetQualityVaultAssetsVaultAssetsConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnection) GetNodes() []GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset {
+	return v.Nodes
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnection) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnection
+		Nodes []json.RawMessage `json:"nodes"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnection = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Nodes
+		src := firstPass.Nodes
+		*dst = make(
+			[]GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnection.Nodes: %w", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnection struct {
+	PageInfo GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo `json:"pageInfo"`
+
+	Nodes []json.RawMessage `json:"nodes"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnection) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnection) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnection, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnection
+
+	retval.PageInfo = v.PageInfo
+	{
+
+		dst := &retval.Nodes
+		src := v.Nodes
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnection.Nodes: %w", err)
+			}
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent includes the requested fields of the GraphQL type Agent.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) GetId() string { return v.Id }
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) GetSlug() string { return v.Slug }
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin includes the requested fields of the GraphQL type AppPlugin.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) GetId() string { return v.Id }
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) GetSlug() string {
+	return v.Slug
+}
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin includes the requested fields of the GraphQL type ClaudeCodePlugin.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetId() string {
+	return v.Id
+}
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetSlug() string {
+	return v.Slug
+}
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand includes the requested fields of the GraphQL type Command.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) GetId() string { return v.Id }
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) GetSlug() string { return v.Slug }
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook includes the requested fields of the GraphQL type Hook.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) GetId() string { return v.Id }
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) GetSlug() string { return v.Slug }
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer includes the requested fields of the GraphQL type McpServer.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) GetId() string { return v.Id }
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) GetSlug() string {
+	return v.Slug
+}
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule includes the requested fields of the GraphQL type Rule.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) GetId() string { return v.Id }
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) GetSlug() string { return v.Slug }
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill includes the requested fields of the GraphQL type Skill.
+// The GraphQL type's documentation follows.
+//
+// GraphQL type for skill.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill struct {
+	Typename  *string   `json:"__typename"`
+	Id        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Whether an evaluation is currently in progress for this asset
+	Evaluating bool `json:"evaluating"`
+	// Asset source metadata
+	Source GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource `json:"-"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) GetTypename() *string {
+	return v.Typename
+}
+
+// GetId returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.Id, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) GetId() string { return v.Id }
+
+// GetSlug returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.Slug, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) GetSlug() string { return v.Slug }
+
+// GetUpdatedAt returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.UpdatedAt, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) GetUpdatedAt() time.Time {
+	return v.UpdatedAt
+}
+
+// GetEvaluating returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.Evaluating, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) GetEvaluating() bool {
+	return v.Evaluating
+}
+
+// GetSource returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.Source, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource {
+	return v.Source
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill
+		Source json.RawMessage `json:"source"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.Source
+		src := firstPass.Source
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.Source: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill struct {
+	Typename *string `json:"__typename"`
+
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	Evaluating bool `json:"evaluating"`
+
+	Source json.RawMessage `json:"source"`
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) __premarshalJSON() (*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill, error) {
+	var retval __premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill
+
+	retval.Typename = v.Typename
+	retval.Id = v.Id
+	retval.Slug = v.Slug
+	retval.UpdatedAt = v.UpdatedAt
+	retval.Evaluating = v.Evaluating
+	{
+
+		dst := &retval.Source
+		src := v.Source
+		var err error
+		*dst, err = __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill.Source: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset includes the requested fields of the GraphQL interface VaultAsset.
+//
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset is implemented by the following types:
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill
+// The GraphQL type's documentation follows.
+//
+// Asset in the vault (Skill, MCP, Agent, etc.).
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset interface {
+	implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+	// GetId returns the interface-field "id" from its implementation.
+	GetId() string
+	// GetSlug returns the interface-field "slug" from its implementation.
+	GetSlug() string
+	// GetUpdatedAt returns the interface-field "updatedAt" from its implementation.
+	GetUpdatedAt() time.Time
+	// GetEvaluating returns the interface-field "evaluating" from its implementation.
+	// The GraphQL interface field's documentation follows.
+	//
+	// Whether an evaluation is currently in progress for this asset
+	GetEvaluating() bool
+	// GetSource returns the interface-field "source" from its implementation.
+	// The GraphQL interface field's documentation follows.
+	//
+	// Asset source metadata
+	GetSource() GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset() {
+}
+
+func __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset(b []byte, v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Agent":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent)
+		return json.Unmarshal(b, *v)
+	case "AppPlugin":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin)
+		return json.Unmarshal(b, *v)
+	case "ClaudeCodePlugin":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin)
+		return json.Unmarshal(b, *v)
+	case "Command":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand)
+		return json.Unmarshal(b, *v)
+	case "Hook":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook)
+		return json.Unmarshal(b, *v)
+	case "McpServer":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer)
+		return json.Unmarshal(b, *v)
+	case "Rule":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule)
+		return json.Unmarshal(b, *v)
+	case "Skill":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing VaultAsset.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset(v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent:
+		typename = "Agent"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAgent
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin:
+		typename = "AppPlugin"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesAppPlugin
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin:
+		typename = "ClaudeCodePlugin"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesClaudeCodePlugin
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand:
+		typename = "Command"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesCommand
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook:
+		typename = "Hook"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesHook
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer:
+		typename = "McpServer"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesMcpServer
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule:
+		typename = "Rule"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesRule
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill:
+		typename = "Skill"
+
+		premarshaled, err := v.__premarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		result := struct {
+			TypeName string `json:"__typename"`
+			*__premarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesSkill
+		}{typename, premarshaled}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset: "%T"`, v)
+	}
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource includes the requested fields of the GraphQL interface AssetSource.
+//
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource is implemented by the following types:
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource
+// The GraphQL type's documentation follows.
+//
+// Base interface for asset source metadata.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource interface {
+	implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+}
+
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource() {
+}
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource) implementsGraphQLInterfaceGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource() {
+}
+
+func __unmarshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(b []byte, v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "AssetGitSource":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource)
+		return json.Unmarshal(b, *v)
+	case "AssetManagedSource":
+		*v = new(GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing AssetSource.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalGetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource(v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource:
+		typename = "AssetGitSource"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource
+		}{typename, v}
+		return json.Marshal(result)
+	case *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource:
+		typename = "AssetManagedSource"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSource: "%T"`, v)
+	}
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource includes the requested fields of the GraphQL type AssetGitSource.
+// The GraphQL type's documentation follows.
+//
+// Source metadata for a git-sourced asset.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource struct {
+	Typename *string `json:"__typename"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetGitSource) GetTypename() *string {
+	return v.Typename
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource includes the requested fields of the GraphQL type AssetManagedSource.
+// The GraphQL type's documentation follows.
+//
+// Source metadata for a Pulse-managed asset.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource struct {
+	Typename         *string  `json:"__typename"`
+	ConfidenceScore  *float64 `json:"confidenceScore"`
+	EvaluationResult *string  `json:"evaluationResult"`
+}
+
+// GetTypename returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource.Typename, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource) GetTypename() *string {
+	return v.Typename
+}
+
+// GetConfidenceScore returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource.ConfidenceScore, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource) GetConfidenceScore() *float64 {
+	return v.ConfidenceScore
+}
+
+// GetEvaluationResult returns GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource.EvaluationResult, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource) GetEvaluationResult() *string {
+	return v.EvaluationResult
+}
+
+// GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+type GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor *string `json:"endCursor"`
+}
+
+// GetHasNextPage returns GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// GetEndCursor returns GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *GetAssetQualityVaultAssetsVaultAssetsConnectionPageInfo) GetEndCursor() *string {
+	return v.EndCursor
+}
 
 // GetLatestAssetBenchmarksResponse is returned by GetLatestAssetBenchmarks on success.
 type GetLatestAssetBenchmarksResponse struct {
@@ -7570,6 +9011,14 @@ type __DeleteTeamInput struct {
 // GetId returns __DeleteTeamInput.Id, and is useful for accessing the field via an interface.
 func (v *__DeleteTeamInput) GetId() string { return v.Id }
 
+// __EvaluateAssetInput is used internally by genqlient
+type __EvaluateAssetInput struct {
+	Id string `json:"id"`
+}
+
+// GetId returns __EvaluateAssetInput.Id, and is useful for accessing the field via an interface.
+func (v *__EvaluateAssetInput) GetId() string { return v.Id }
+
 // __FindUserInput is used internally by genqlient
 type __FindUserInput struct {
 	Term string `json:"term"`
@@ -7597,6 +9046,22 @@ func (v *__GetAssetBenchmarksInput) GetAssetName() string { return v.AssetName }
 
 // GetFirst returns __GetAssetBenchmarksInput.First, and is useful for accessing the field via an interface.
 func (v *__GetAssetBenchmarksInput) GetFirst() *int { return v.First }
+
+// __GetAssetQualityInput is used internally by genqlient
+type __GetAssetQualityInput struct {
+	Slug  *string `json:"slug"`
+	First *int    `json:"first"`
+	After *string `json:"after"`
+}
+
+// GetSlug returns __GetAssetQualityInput.Slug, and is useful for accessing the field via an interface.
+func (v *__GetAssetQualityInput) GetSlug() *string { return v.Slug }
+
+// GetFirst returns __GetAssetQualityInput.First, and is useful for accessing the field via an interface.
+func (v *__GetAssetQualityInput) GetFirst() *int { return v.First }
+
+// GetAfter returns __GetAssetQualityInput.After, and is useful for accessing the field via an interface.
+func (v *__GetAssetQualityInput) GetAfter() *string { return v.After }
 
 // __ImportAssetBenchmarkInput is used internally by genqlient
 type __ImportAssetBenchmarkInput struct {
@@ -8725,6 +10190,43 @@ func DeleteTeam(
 	return data_, err_
 }
 
+// The mutation executed by EvaluateAsset.
+const EvaluateAsset_Operation = `
+mutation EvaluateAsset ($id: ID!) {
+	evaluateAsset(id: $id) {
+		errors {
+			field
+			messages
+		}
+	}
+}
+`
+
+func EvaluateAsset(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	id string,
+) (data_ *EvaluateAssetResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "EvaluateAsset",
+		Query:  EvaluateAsset_Operation,
+		Variables: &__EvaluateAssetInput{
+			Id: id,
+		},
+	}
+
+	data_ = &EvaluateAssetResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
 // The query executed by FindUser.
 const FindUser_Operation = `
 query FindUser ($term: String!) {
@@ -8856,6 +10358,63 @@ func GetAssetBenchmarks(
 	}
 
 	data_ = &GetAssetBenchmarksResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by GetAssetQuality.
+const GetAssetQuality_Operation = `
+query GetAssetQuality ($slug: String, $first: Int, $after: String) {
+	vault {
+		assets(slug: $slug, first: $first, after: $after) {
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+			nodes {
+				__typename
+				id
+				slug
+				updatedAt
+				evaluating
+				source {
+					__typename
+					... on AssetManagedSource {
+						confidenceScore
+						evaluationResult
+					}
+				}
+			}
+		}
+	}
+}
+`
+
+func GetAssetQuality(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	slug *string,
+	first *int,
+	after *string,
+) (data_ *GetAssetQualityResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "GetAssetQuality",
+		Query:  GetAssetQuality_Operation,
+		Variables: &__GetAssetQualityInput{
+			Slug:  slug,
+			First: first,
+			After: after,
+		},
+	}
+
+	data_ = &GetAssetQualityResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/vault/graphql/operations/quality.graphql
+++ b/internal/vault/graphql/operations/quality.graphql
@@ -1,0 +1,32 @@
+query GetAssetQuality($slug: String, $first: Int, $after: String) {
+  vault {
+    assets(slug: $slug, first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        slug
+        updatedAt
+        evaluating
+        source {
+          __typename
+          ... on AssetManagedSource {
+            confidenceScore
+            evaluationResult
+          }
+        }
+      }
+    }
+  }
+}
+
+mutation EvaluateAsset($id: ID!) {
+  evaluateAsset(id: $id) {
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/internal/vault/quality.go
+++ b/internal/vault/quality.go
@@ -1,0 +1,277 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sleuth-io/sx/internal/mgmt"
+	"github.com/sleuth-io/sx/internal/utils"
+)
+
+// ---- Quality storage (API 1.12.0, docs/quality-spec.md) ----
+// One capped, newest-first list of quality evaluation records per asset:
+// .sx/quality/<asset>.json on file-backed vaults; the server's own
+// Asset.evaluation_result on skills.new. Records are the interchange
+// shape normalized from pulse's evaluation document, so a record read
+// from any vault type renders identically.
+
+// QualityStore is implemented by vaults that can hold quality records.
+type QualityStore interface {
+	// GetQuality returns a wrapper doc for the asset:
+	// {"evaluating": bool, "records": [...]} with records newest first.
+	// evaluating is only ever true on server-evaluated vaults; records
+	// is empty (never null) when the asset has no evaluations.
+	GetQuality(ctx context.Context, asset string) (string, error)
+
+	// AddQuality prepends one interchange record (a JSON object string).
+	// Server-evaluated vaults refuse this with ErrQualityReadOnly — the
+	// server's own evaluation is the source of truth there.
+	AddQuality(ctx context.Context, asset, record string) error
+
+	// LatestQuality returns a JSON object mapping asset name to its
+	// newest record, for every asset that has one.
+	LatestQuality(ctx context.Context) (string, error)
+
+	// ReevaluateQuality requests a fresh evaluation and reports who runs
+	// it: "server" when the vault backend evaluates (poll GetQuality
+	// until evaluating flips false), "local" when the caller must run
+	// the evaluation itself and store the result via AddQuality.
+	ReevaluateQuality(ctx context.Context, asset string) (string, error)
+}
+
+// Reevaluate dispatch results: who runs the evaluation.
+const (
+	QualityEvalServer = "server"
+	QualityEvalLocal  = "local"
+)
+
+// ErrQualityUnsupported is returned when the vault backend cannot store
+// quality records (a server predating the surface).
+var ErrQualityUnsupported = errors.New(
+	"this library's server doesn't support quality storage yet")
+
+// ErrQualityReadOnly is returned when a vault only surfaces its own
+// server-side evaluations and refuses client-written records.
+var ErrQualityReadOnly = errors.New(
+	"this library's quality scores are server-evaluated and read-only")
+
+const (
+	// maxQualityRecordBytes bounds one record (same cap as benchmarks).
+	maxQualityRecordBytes = 256 << 10
+	// maxQualityRecords caps each asset's retained history — enough for
+	// the trend chip; git history keeps the rest on repo-backed vaults.
+	maxQualityRecords = 10
+)
+
+func qualityPath(vaultRoot, asset string) (string, error) {
+	// Same safe-path-segment shape as benchmark files.
+	if !benchmarkAssetPattern.MatchString(asset) || strings.Contains(asset, "..") {
+		return "", fmt.Errorf("invalid asset name %q", asset)
+	}
+	return filepath.Join(vaultRoot, ".sx", "quality", asset+".json"), nil
+}
+
+// validateQualityRecord is the bounded-valid-JSON-object contract,
+// enforced identically by every backend before anything is written.
+func validateQualityRecord(record string) error {
+	if len(record) > maxQualityRecordBytes {
+		return fmt.Errorf("quality record exceeds %d bytes", maxQualityRecordBytes)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(record), &obj); err != nil {
+		return errors.New("quality record must be a JSON object")
+	}
+	// Downstream readers (the QualityRecord TS type) key everything off
+	// overall and categories; on file vaults this is the only validation
+	// gate, so a malformed score must be refused here.
+	var overall float64
+	if raw, ok := obj["overall"]; !ok || json.Unmarshal(raw, &overall) != nil ||
+		overall < 0 || overall > 100 {
+		return errors.New("quality record needs a numeric overall score in [0,100]")
+	}
+	var categories map[string]json.RawMessage
+	if raw, ok := obj["categories"]; !ok || json.Unmarshal(raw, &categories) != nil ||
+		categories == nil {
+		return errors.New("quality record needs a categories object")
+	}
+	return nil
+}
+
+type qualityFileDoc struct {
+	Quality []json.RawMessage `json:"quality"`
+}
+
+// qualityWrapperDoc is what GetQuality returns on every vault type.
+type qualityWrapperDoc struct {
+	Evaluating bool              `json:"evaluating"`
+	Records    []json.RawMessage `json:"records"`
+}
+
+func marshalQualityWrapper(evaluating bool, records []json.RawMessage) (string, error) {
+	if records == nil {
+		records = []json.RawMessage{}
+	}
+	out, err := json.Marshal(qualityWrapperDoc{Evaluating: evaluating, Records: records})
+	return string(out), err
+}
+
+func readQualityDoc(path string) (*qualityFileDoc, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is under the vault root with a validated name
+	if os.IsNotExist(err) {
+		return &qualityFileDoc{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	doc := &qualityFileDoc{}
+	if err := json.Unmarshal(data, doc); err != nil {
+		// A corrupt file must not brick the asset's quality history —
+		// treat it as an empty list. Reads never mutate; the write path
+		// preserves the corrupt bytes as <asset>.json.bad first.
+		return &qualityFileDoc{}, nil
+	}
+	return doc, nil
+}
+
+// preserveCorruptQuality sets aside an unparseable quality file as
+// <asset>.json.bad (best-effort) so a fresh write can't destroy the only
+// copy on vaults without git history.
+func preserveCorruptQuality(path string) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is under the vault root with a validated name
+	if err != nil {
+		return
+	}
+	if json.Unmarshal(data, &qualityFileDoc{}) == nil {
+		return // parseable — nothing to preserve
+	}
+	_ = os.Rename(path, path+".bad")
+}
+
+func commonGetQuality(vaultRoot, asset string) (string, error) {
+	path, err := qualityPath(vaultRoot, asset)
+	if err != nil {
+		return "", err
+	}
+	doc, err := readQualityDoc(path)
+	if err != nil {
+		return "", err
+	}
+	return marshalQualityWrapper(false, doc.Quality)
+}
+
+func commonAddQuality(vaultRoot, asset, record string) error {
+	if err := validateQualityRecord(record); err != nil {
+		return err
+	}
+	path, err := qualityPath(vaultRoot, asset)
+	if err != nil {
+		return err
+	}
+	preserveCorruptQuality(path)
+	doc, err := readQualityDoc(path)
+	if err != nil {
+		return err
+	}
+	doc.Quality = append([]json.RawMessage{json.RawMessage(record)}, doc.Quality...)
+	if len(doc.Quality) > maxQualityRecords {
+		doc.Quality = doc.Quality[:maxQualityRecords]
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	// Atomic write for the same reason as benchmarks: readers take no
+	// lock and synced folders can replicate mid-write.
+	return utils.WriteFileAtomic(path, data, 0o644)
+}
+
+func commonLatestQuality(vaultRoot string) (string, error) {
+	dir := filepath.Join(vaultRoot, ".sx", "quality")
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	latest := map[string]json.RawMessage{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		asset := strings.TrimSuffix(name, ".json")
+		if !benchmarkAssetPattern.MatchString(asset) {
+			continue
+		}
+		doc, err := readQualityDoc(filepath.Join(dir, name))
+		if err != nil || len(doc.Quality) == 0 {
+			continue
+		}
+		latest[asset] = doc.Quality[0]
+	}
+	if len(latest) == 0 {
+		return "", nil
+	}
+	out, err := json.Marshal(latest)
+	return string(out), err
+}
+
+// GetQuality returns the asset's quality wrapper doc.
+func (p *PathVault) GetQuality(ctx context.Context, asset string) (string, error) {
+	return commonGetQuality(p.repoPath, asset)
+}
+
+// AddQuality records one quality evaluation.
+func (p *PathVault) AddQuality(ctx context.Context, asset, record string) error {
+	return p.withLock(ctx, func(actor mgmt.Actor) error {
+		return commonAddQuality(p.repoPath, asset, record)
+	})
+}
+
+// LatestQuality returns the newest record per asset.
+func (p *PathVault) LatestQuality(ctx context.Context) (string, error) {
+	return commonLatestQuality(p.repoPath)
+}
+
+// ReevaluateQuality on a path vault is the caller's job: there is no
+// backend that could run the evaluation.
+func (p *PathVault) ReevaluateQuality(ctx context.Context, asset string) (string, error) {
+	return QualityEvalLocal, nil
+}
+
+// GetQuality returns the asset's quality wrapper doc from the clone.
+func (g *GitVault) GetQuality(ctx context.Context, asset string) (string, error) {
+	if err := g.cloneOrUpdate(ctx); err != nil {
+		return "", err
+	}
+	return commonGetQuality(g.repoPath, asset)
+}
+
+// AddQuality records one quality evaluation and pushes.
+func (g *GitVault) AddQuality(ctx context.Context, asset, record string) error {
+	return g.runInVaultTx(ctx, "Record quality for "+asset, func(root string, actor mgmt.Actor) error {
+		return commonAddQuality(root, asset, record)
+	})
+}
+
+// LatestQuality returns the newest record per asset from the clone.
+func (g *GitVault) LatestQuality(ctx context.Context) (string, error) {
+	if err := g.cloneOrUpdate(ctx); err != nil {
+		return "", err
+	}
+	return commonLatestQuality(g.repoPath)
+}
+
+// ReevaluateQuality on a git vault is the caller's job, same as path.
+func (g *GitVault) ReevaluateQuality(ctx context.Context, asset string) (string, error) {
+	return QualityEvalLocal, nil
+}

--- a/internal/vault/quality_test.go
+++ b/internal/vault/quality_test.go
@@ -1,0 +1,226 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func qualityRecord(overall int) string {
+	return fmt.Sprintf(
+		`{"at":"2026-07-14T18:00:00Z","source":"app","overall":%d,`+
+			`"categories":{"structure":90,"actionability":80,"content":83,"completeness":85},`+
+			`"summary":"solid skill","insights":{"strengths":["a"],"improvements":["b"],"recommendations":["c"]}}`,
+		overall,
+	)
+}
+
+func decodeQualityWrapper(t *testing.T, raw string) (bool, []map[string]any) {
+	t.Helper()
+	var doc struct {
+		Evaluating bool             `json:"evaluating"`
+		Records    []map[string]any `json:"records"`
+	}
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("wrapper is not a JSON object: %v\n%s", err, raw)
+	}
+	if doc.Records == nil {
+		t.Fatalf("records must be an array, never null:\n%s", raw)
+	}
+	return doc.Evaluating, doc.Records
+}
+
+// Records round-trip through .sx/quality/<asset>.json, newest first,
+// wrapped in {evaluating, records}; junk names and malformed records
+// are refused.
+func TestQualityRoundTrip(t *testing.T) {
+	v := appPluginTestVault(t, nil)
+	ctx := context.Background()
+
+	raw, err := v.GetQuality(ctx, "commit-msgs")
+	if err != nil {
+		t.Fatalf("initial get: %v", err)
+	}
+	if evaluating, records := decodeQualityWrapper(t, raw); evaluating || len(records) != 0 {
+		t.Fatalf("initial wrapper = %q; want evaluating=false, no records", raw)
+	}
+
+	if err := v.AddQuality(ctx, "commit-msgs", qualityRecord(60)); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := v.AddQuality(ctx, "commit-msgs", qualityRecord(84)); err != nil {
+		t.Fatalf("add second: %v", err)
+	}
+
+	raw, err = v.GetQuality(ctx, "commit-msgs")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_, records := decodeQualityWrapper(t, raw)
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2", len(records))
+	}
+	if newest := records[0]["overall"].(float64); newest != 84 {
+		t.Fatalf("newest first violated: overall = %v", newest)
+	}
+
+	// Another asset's history is invisible.
+	raw, _ = v.GetQuality(ctx, "other-skill")
+	if _, records := decodeQualityWrapper(t, raw); len(records) != 0 {
+		t.Fatalf("cross-asset read = %q", raw)
+	}
+
+	if err := v.AddQuality(ctx, "../evil", qualityRecord(50)); err == nil {
+		t.Fatalf("path-shaped asset name accepted")
+	}
+	if err := v.AddQuality(ctx, "commit-msgs", "not json"); err == nil {
+		t.Fatalf("non-JSON record accepted")
+	}
+	if err := v.AddQuality(ctx, "commit-msgs", `{"categories":{}}`); err == nil {
+		t.Fatalf("overall-less record accepted")
+	}
+	if err := v.AddQuality(ctx, "commit-msgs", `{"overall":"high","categories":{}}`); err == nil {
+		t.Fatalf("non-numeric overall accepted")
+	}
+	if err := v.AddQuality(ctx, "commit-msgs", `{"overall":140,"categories":{}}`); err == nil {
+		t.Fatalf("out-of-range overall accepted")
+	}
+	if err := v.AddQuality(ctx, "commit-msgs", `{"overall":84}`); err == nil {
+		t.Fatalf("categories-less record accepted")
+	}
+	if err := v.AddQuality(ctx, "commit-msgs", `{"overall":84,"categories":null}`); err == nil {
+		t.Fatalf("null categories accepted")
+	}
+	fat := `{"overall":84,"categories":{},"pad":"` + strings.Repeat("x", maxQualityRecordBytes) + `"}`
+	if err := v.AddQuality(ctx, "commit-msgs", fat); err == nil {
+		t.Fatalf("oversized record accepted")
+	}
+}
+
+// History is capped at maxQualityRecords, dropping the oldest.
+func TestQualityCapRetention(t *testing.T) {
+	v := appPluginTestVault(t, nil)
+	ctx := context.Background()
+
+	for i := range maxQualityRecords + 5 {
+		if err := v.AddQuality(ctx, "busy-skill", qualityRecord(i)); err != nil {
+			t.Fatalf("add %d: %v", i, err)
+		}
+	}
+	raw, err := v.GetQuality(ctx, "busy-skill")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_, records := decodeQualityWrapper(t, raw)
+	if len(records) != maxQualityRecords {
+		t.Fatalf("got %d records, want cap %d", len(records), maxQualityRecords)
+	}
+	if newest := records[0]["overall"].(float64); newest != float64(maxQualityRecords+4) {
+		t.Fatalf("newest record wrong after cap: %v", newest)
+	}
+}
+
+// LatestQuality maps every evaluated asset to its newest record only.
+func TestLatestQuality(t *testing.T) {
+	v := appPluginTestVault(t, nil)
+	ctx := context.Background()
+
+	if got, err := v.LatestQuality(ctx); err != nil || got != "" {
+		t.Fatalf("initial latest = %q, %v; want empty", got, err)
+	}
+	for _, add := range []struct {
+		asset   string
+		overall int
+	}{{"skill-a", 40}, {"skill-a", 70}, {"skill-b", 55}} {
+		if err := v.AddQuality(ctx, add.asset, qualityRecord(add.overall)); err != nil {
+			t.Fatalf("add: %v", err)
+		}
+	}
+
+	raw, err := v.LatestQuality(ctx)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	var latest map[string]map[string]any
+	if err := json.Unmarshal([]byte(raw), &latest); err != nil {
+		t.Fatalf("latest is not an object: %v", err)
+	}
+	if len(latest) != 2 {
+		t.Fatalf("got %d assets, want 2", len(latest))
+	}
+	if got := latest["skill-a"]["overall"].(float64); got != 70 {
+		t.Fatalf("skill-a latest overall = %v, want 70", got)
+	}
+}
+
+// File vaults never evaluate themselves: reevaluate always dispatches to
+// the caller ("local").
+func TestQualityReevaluateIsLocal(t *testing.T) {
+	v := appPluginTestVault(t, nil)
+	mode, err := v.ReevaluateQuality(context.Background(), "commit-msgs")
+	if err != nil || mode != QualityEvalLocal {
+		t.Fatalf("reevaluate = %q, %v; want %q", mode, err, QualityEvalLocal)
+	}
+}
+
+// A corrupt quality file starts a fresh list instead of bricking the
+// asset, and the write path preserves the corrupt bytes as .bad first —
+// plain and synced folders have no git history to fall back on.
+func TestQualityCorruptFileRecovers(t *testing.T) {
+	v := appPluginTestVault(t, nil)
+	ctx := context.Background()
+	if err := v.AddQuality(ctx, "flaky", qualityRecord(30)); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	path, err := qualityPath(v.repoPath, "flaky")
+	if err != nil {
+		t.Fatalf("path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{{corrupt"), 0o644); err != nil {
+		t.Fatalf("corrupt: %v", err)
+	}
+	// Reads are non-destructive: empty records, corrupt bytes untouched.
+	raw, err := v.GetQuality(ctx, "flaky")
+	if err != nil {
+		t.Fatalf("corrupt get: %v", err)
+	}
+	if _, records := decodeQualityWrapper(t, raw); len(records) != 0 {
+		t.Fatalf("corrupt get = %q; want empty records", raw)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("read destroyed the corrupt file: %v", err)
+	}
+
+	if err := v.AddQuality(ctx, "flaky", qualityRecord(65)); err != nil {
+		t.Fatalf("add after corrupt: %v", err)
+	}
+	raw, err = v.GetQuality(ctx, "flaky")
+	if err != nil {
+		t.Fatalf("get after recovery: %v", err)
+	}
+	if _, records := decodeQualityWrapper(t, raw); len(records) != 1 {
+		t.Fatalf("got %d records after recovery, want 1", len(records))
+	}
+	bad, err := os.ReadFile(path + ".bad")
+	if err != nil {
+		t.Fatalf("corrupt bytes not preserved as .bad: %v", err)
+	}
+	if string(bad) != "{{corrupt" {
+		t.Fatalf(".bad content = %q", bad)
+	}
+	// The .bad file is invisible to the latest-per-asset scan.
+	raw, err = v.LatestQuality(ctx)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	var latest map[string]map[string]any
+	if err := json.Unmarshal([]byte(raw), &latest); err != nil {
+		t.Fatalf("latest is not an object: %v", err)
+	}
+	if len(latest) != 1 || latest["flaky"] == nil {
+		t.Fatalf("latest after recovery = %v", latest)
+	}
+}

--- a/internal/vault/sleuth_quality.go
+++ b/internal/vault/sleuth_quality.go
@@ -1,0 +1,234 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+
+	vaultgql "github.com/sleuth-io/sx/internal/vault/graphql"
+)
+
+// Sleuth-vault quality storage (docs/quality-spec.md): the server twin of
+// .sx/quality/<asset>.json. skills.new evaluates assets itself and keeps
+// one evaluation document per asset (Asset.evaluation_result), so reads
+// normalize that document into the interchange shape and writes are
+// refused — ReevaluateQuality asks the server to run a fresh evaluation
+// instead.
+
+// GetQuality returns the asset's quality wrapper doc, normalized from the
+// server's evaluation document. Assets the server hasn't evaluated (and
+// git-sourced assets, which skills.new doesn't evaluate) yield an empty
+// records list.
+func (s *SleuthVault) GetQuality(ctx context.Context, asset string) (string, error) {
+	node, err := s.qualityAssetLookup(ctx, asset)
+	if errors.Is(err, errQualityAssetNotFound) {
+		return marshalQualityWrapper(false, nil)
+	}
+	if err != nil {
+		return "", err
+	}
+	record := normalizeServerEvaluation(node)
+	var records []json.RawMessage
+	if record != nil {
+		records = []json.RawMessage{record}
+	}
+	return marshalQualityWrapper(node.GetEvaluating(), records)
+}
+
+// AddQuality is refused: skills.new evaluates assets itself and its
+// document is the source of truth. Use ReevaluateQuality.
+func (s *SleuthVault) AddQuality(ctx context.Context, asset, record string) error {
+	return ErrQualityReadOnly
+}
+
+// LatestQuality returns the newest record per asset, paging the vault's
+// asset list.
+func (s *SleuthVault) LatestQuality(ctx context.Context) (string, error) {
+	latest := map[string]json.RawMessage{}
+	pageSize := 50
+	var after *string
+	for {
+		resp, err := vaultgql.GetAssetQuality(ctx, s.gqlClient(), nil, &pageSize, after)
+		if err != nil {
+			if isAppPluginSchemaUnknownErr(err) {
+				return "", ErrQualityUnsupported
+			}
+			return "", err
+		}
+		for _, node := range resp.Vault.Assets.Nodes {
+			if record := normalizeServerEvaluation(node); record != nil {
+				latest[node.GetSlug()] = record
+			}
+		}
+		page := resp.Vault.Assets.PageInfo
+		if !page.HasNextPage || page.EndCursor == nil {
+			break
+		}
+		after = page.EndCursor
+	}
+	if len(latest) == 0 {
+		return "", nil
+	}
+	out, err := json.Marshal(latest)
+	return string(out), err
+}
+
+// ReevaluateQuality asks the server to evaluate the asset and reports
+// "server": the caller polls GetQuality until evaluating flips false.
+func (s *SleuthVault) ReevaluateQuality(ctx context.Context, asset string) (string, error) {
+	node, err := s.qualityAssetLookup(ctx, asset)
+	if errors.Is(err, errQualityAssetNotFound) {
+		return "", fmt.Errorf("asset %q not found in this library", asset)
+	}
+	if err != nil {
+		return "", err
+	}
+	// The mutation runs the evaluation inline server-side, so it outlives
+	// the default 30s HTTP budget — use the long-request client.
+	client := graphql.NewClient(s.serverURL+"/graphql", &authDoer{
+		client:    s.streamingClient,
+		authToken: s.authToken,
+	})
+	resp, err := vaultgql.EvaluateAsset(ctx, client, node.GetId())
+	if err != nil {
+		if isAppPluginSchemaUnknownErr(err) {
+			return "", ErrQualityUnsupported
+		}
+		return "", err
+	}
+	for _, e := range resp.EvaluateAsset.Errors {
+		if len(e.Messages) > 0 {
+			return "", &mutationError{message: e.Messages[0]}
+		}
+	}
+	return QualityEvalServer, nil
+}
+
+// errQualityAssetNotFound signals a slug that doesn't resolve; callers
+// decide whether that's an empty read or a hard error.
+var errQualityAssetNotFound = errors.New("asset not found")
+
+// qualityAssetLookup fetches the asset's quality-bearing node by slug.
+func (s *SleuthVault) qualityAssetLookup(
+	ctx context.Context, asset string,
+) (vaultgql.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset, error) {
+	first := 1
+	resp, err := vaultgql.GetAssetQuality(ctx, s.gqlClient(), &asset, &first, nil)
+	if err != nil {
+		if isAppPluginSchemaUnknownErr(err) {
+			return nil, ErrQualityUnsupported
+		}
+		return nil, err
+	}
+	if len(resp.Vault.Assets.Nodes) == 0 {
+		return nil, errQualityAssetNotFound
+	}
+	return resp.Vault.Assets.Nodes[0], nil
+}
+
+// serverEvaluation is the shape pulse stores in Asset.evaluation_result
+// (sleuth/apps/issues/skills/asset_evaluation_tool.py). Only the fields
+// the interchange record needs are decoded; factors pass through raw.
+type serverEvaluation struct {
+	OverallConfidence  float64                    `json:"overall_confidence"`
+	CategoryScores     map[string]json.RawMessage `json:"category_scores"`
+	Factors            json.RawMessage            `json:"factors"`
+	Reasoning          string                     `json:"reasoning"`
+	LLMStrengths       []string                   `json:"llm_strengths"`
+	LLMWeaknesses      []string                   `json:"llm_weaknesses"`
+	LLMRecommendations []string                   `json:"llm_recommendations"`
+	FileCount          *int                       `json:"file_count"`
+	WordCount          *int                       `json:"word_count"`
+}
+
+// interchange category names, keyed by pulse's category_scores names.
+var serverCategoryNames = map[string]string{
+	"structure":       "structure",
+	"actionability":   "actionability",
+	"content_quality": "content",
+	"completeness":    "completeness",
+}
+
+// normalizeServerEvaluation converts one asset node's server evaluation
+// document into an interchange record (nil when the asset has none —
+// never evaluated, or not a managed source).
+func normalizeServerEvaluation(
+	node vaultgql.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAsset,
+) json.RawMessage {
+	managed, ok := node.GetSource().(*vaultgql.GetAssetQualityVaultAssetsVaultAssetsConnectionNodesVaultAssetSourceAssetManagedSource)
+	if !ok || managed.EvaluationResult == nil || *managed.EvaluationResult == "" {
+		return nil
+	}
+	var eval serverEvaluation
+	if err := json.Unmarshal([]byte(*managed.EvaluationResult), &eval); err != nil {
+		return nil
+	}
+
+	categories := map[string]int{}
+	for serverName, name := range serverCategoryNames {
+		raw, ok := eval.CategoryScores[serverName]
+		if !ok {
+			continue
+		}
+		// Current servers store {tier, score, weight} objects; older
+		// documents stored bare numbers. Accept both.
+		var scored struct {
+			Score *float64 `json:"score"`
+		}
+		var bare float64
+		switch {
+		case json.Unmarshal(raw, &scored) == nil && scored.Score != nil:
+			categories[name] = int(math.Round(*scored.Score))
+		case json.Unmarshal(raw, &bare) == nil:
+			categories[name] = int(math.Round(bare))
+		}
+	}
+
+	record := map[string]any{
+		"source":     "server",
+		"overall":    int(math.Round(eval.OverallConfidence * 100)),
+		"categories": categories,
+		"summary":    eval.Reasoning,
+		"insights": map[string]any{
+			"strengths":       emptyIfNil(eval.LLMStrengths),
+			"improvements":    emptyIfNil(eval.LLMWeaknesses),
+			"recommendations": emptyIfNil(eval.LLMRecommendations),
+		},
+	}
+	// Pulse stores no evaluation timestamp; the asset's updatedAt is the
+	// closest signal (an evaluation always touches the asset).
+	if at := node.GetUpdatedAt(); !at.IsZero() {
+		record["at"] = at.UTC().Format(time.RFC3339)
+	}
+	if len(eval.Factors) > 0 && string(eval.Factors) != "null" {
+		record["factors"] = eval.Factors
+	}
+	if eval.FileCount != nil || eval.WordCount != nil {
+		stats := map[string]any{}
+		if eval.FileCount != nil {
+			stats["file_count"] = *eval.FileCount
+		}
+		if eval.WordCount != nil {
+			stats["word_count"] = *eval.WordCount
+		}
+		record["stats"] = stats
+	}
+
+	out, err := json.Marshal(record)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+func emptyIfNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/internal/vault/sleuth_quality.go
+++ b/internal/vault/sleuth_quality.go
@@ -183,15 +183,23 @@ func normalizeServerEvaluation(
 		var bare float64
 		switch {
 		case json.Unmarshal(raw, &scored) == nil && scored.Score != nil:
-			categories[name] = int(math.Round(*scored.Score))
+			categories[name] = clampScore(*scored.Score)
 		case json.Unmarshal(raw, &bare) == nil:
-			categories[name] = int(math.Round(bare))
+			categories[name] = clampScore(bare)
 		}
 	}
 
+	// overall_confidence is 0-1 today, but tolerate percentage-shaped
+	// documents the same way the categories code tolerates legacy bare
+	// numbers, and clamp — file vaults enforce [0,100] via
+	// validateQualityRecord, so the server path must too.
+	overall := eval.OverallConfidence
+	if overall <= 1 {
+		overall *= 100
+	}
 	record := map[string]any{
 		"source":     "server",
-		"overall":    int(math.Round(eval.OverallConfidence * 100)),
+		"overall":    clampScore(overall),
 		"categories": categories,
 		"summary":    eval.Reasoning,
 		"insights": map[string]any{
@@ -231,4 +239,10 @@ func emptyIfNil(s []string) []string {
 		return []string{}
 	}
 	return s
+}
+
+// clampScore rounds a server-supplied score into the interchange
+// record's documented 0-100 range.
+func clampScore(score float64) int {
+	return int(math.Round(math.Max(0, math.Min(100, score))))
 }

--- a/internal/vault/sleuth_quality_test.go
+++ b/internal/vault/sleuth_quality_test.go
@@ -1,0 +1,295 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// realistic pulse evaluation_result document (asset_evaluation_tool.py
+// output), category scores in the current {tier, score, weight} shape.
+const serverEvalDoc = `{
+	"overall_confidence": 0.8246,
+	"category_scores": {
+		"structure": {"tier": "Good", "score": 78.4, "weight": 0.24},
+		"actionability": {"tier": "Excellent", "score": 90.0, "weight": 0.36},
+		"content_quality": {"tier": "Good", "score": 80.2, "weight": 0.27},
+		"completeness": {"tier": "Needs Work", "score": 0.0, "weight": 0.13}
+	},
+	"factors": {"specificity": {"score": 90, "tier": "Excellent", "justification": "clear"}},
+	"reasoning": "A solid, well-structured skill.",
+	"llm_strengths": ["concrete examples"],
+	"llm_weaknesses": ["no troubleshooting section"],
+	"llm_recommendations": ["add a setup section"],
+	"file_count": 2,
+	"word_count": 609
+}`
+
+func qualityNode(slug string, evaluating bool, evalResult *string) map[string]any {
+	source := map[string]any{"__typename": "AssetManagedSource"}
+	if evalResult != nil {
+		source["confidenceScore"] = 82.46
+		source["evaluationResult"] = *evalResult
+	}
+	return map[string]any{
+		"__typename": "Skill",
+		"id":         "gid://" + slug,
+		"slug":       slug,
+		"updatedAt":  "2026-07-14T10:00:00Z",
+		"evaluating": evaluating,
+		"source":     source,
+	}
+}
+
+func qualityAssetsResponse(nodes ...map[string]any) map[string]any {
+	if nodes == nil {
+		nodes = []map[string]any{}
+	}
+	return map[string]any{"vault": map[string]any{"assets": map[string]any{
+		"pageInfo": map[string]any{"hasNextPage": false, "endCursor": nil},
+		"nodes":    nodes,
+	}}}
+}
+
+// The server evaluation document normalizes into the interchange record:
+// confidence 0-1 becomes overall 0-100, content_quality becomes content,
+// weaknesses become improvements, and zero scores survive.
+func TestSleuthQualityGetNormalizes(t *testing.T) {
+	doc := serverEvalDoc
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(vars map[string]any) any {
+			if vars["slug"] != "commit-msgs" {
+				t.Errorf("slug var = %v", vars["slug"])
+			}
+			return qualityAssetsResponse(qualityNode("commit-msgs", false, &doc))
+		},
+	})
+	v := NewSleuthVault(srv.URL, "test-token")
+
+	raw, err := v.GetQuality(context.Background(), "commit-msgs")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	evaluating, records := decodeQualityWrapper(t, raw)
+	if evaluating || len(records) != 1 {
+		t.Fatalf("wrapper = %q", raw)
+	}
+	rec := records[0]
+	if rec["overall"].(float64) != 82 {
+		t.Fatalf("overall = %v, want 82", rec["overall"])
+	}
+	if rec["source"] != "server" {
+		t.Fatalf("source = %v", rec["source"])
+	}
+	cats := rec["categories"].(map[string]any)
+	if cats["content"].(float64) != 80 || cats["actionability"].(float64) != 90 {
+		t.Fatalf("categories = %v", cats)
+	}
+	if _, renamed := cats["content_quality"]; renamed {
+		t.Fatalf("content_quality not renamed: %v", cats)
+	}
+	if cats["completeness"].(float64) != 0 {
+		t.Fatalf("zero category score dropped: %v", cats)
+	}
+	if rec["summary"] != "A solid, well-structured skill." {
+		t.Fatalf("summary = %v", rec["summary"])
+	}
+	insights := rec["insights"].(map[string]any)
+	if got := insights["improvements"].([]any); len(got) != 1 || got[0] != "no troubleshooting section" {
+		t.Fatalf("improvements = %v", got)
+	}
+	if rec["at"] != "2026-07-14T10:00:00Z" {
+		t.Fatalf("at = %v", rec["at"])
+	}
+	stats := rec["stats"].(map[string]any)
+	if stats["file_count"].(float64) != 2 || stats["word_count"].(float64) != 609 {
+		t.Fatalf("stats = %v", stats)
+	}
+	if _, ok := rec["factors"].(map[string]any)["specificity"]; !ok {
+		t.Fatalf("factors not passed through: %v", rec["factors"])
+	}
+}
+
+// Old evaluation documents stored bare numbers for category scores.
+func TestSleuthQualityGetBareCategoryScores(t *testing.T) {
+	doc := `{"overall_confidence": 0.5, "category_scores": {"structure": 55, "content_quality": 41.6}, "reasoning": "ok"}`
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(map[string]any) any {
+			return qualityAssetsResponse(qualityNode("old-skill", false, &doc))
+		},
+	})
+	v := NewSleuthVault(srv.URL, "test-token")
+	raw, err := v.GetQuality(context.Background(), "old-skill")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_, records := decodeQualityWrapper(t, raw)
+	cats := records[0]["categories"].(map[string]any)
+	if cats["structure"].(float64) != 55 || cats["content"].(float64) != 42 {
+		t.Fatalf("categories = %v", cats)
+	}
+}
+
+// While the server evaluates, the flag surfaces so callers can poll; a
+// never-evaluated asset yields empty records, not an error.
+func TestSleuthQualityGetEvaluatingAndEmpty(t *testing.T) {
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(map[string]any) any {
+			return qualityAssetsResponse(qualityNode("fresh-skill", true, nil))
+		},
+	})
+	v := NewSleuthVault(srv.URL, "test-token")
+	raw, err := v.GetQuality(context.Background(), "fresh-skill")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	evaluating, records := decodeQualityWrapper(t, raw)
+	if !evaluating || len(records) != 0 {
+		t.Fatalf("wrapper = %q; want evaluating with no records", raw)
+	}
+
+	// Unknown slug: empty wrapper, no error.
+	srv2, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(map[string]any) any { return qualityAssetsResponse() },
+	})
+	v2 := NewSleuthVault(srv2.URL, "test-token")
+	raw, err = v2.GetQuality(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("get missing: %v", err)
+	}
+	if evaluating, records := decodeQualityWrapper(t, raw); evaluating || len(records) != 0 {
+		t.Fatalf("missing wrapper = %q", raw)
+	}
+}
+
+// skills.new evaluates assets itself: client-written records are refused.
+func TestSleuthQualityAddIsReadOnly(t *testing.T) {
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{})
+	v := NewSleuthVault(srv.URL, "test-token")
+	err := v.AddQuality(context.Background(), "commit-msgs", qualityRecord(80))
+	if !errors.Is(err, ErrQualityReadOnly) {
+		t.Fatalf("add = %v; want ErrQualityReadOnly", err)
+	}
+}
+
+// Reevaluate resolves the slug to a GID, fires the mutation, and reports
+// server-mode dispatch; mutation errors surface as Go errors.
+func TestSleuthQualityReevaluate(t *testing.T) {
+	doc := serverEvalDoc
+	srv, records := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(map[string]any) any {
+			return qualityAssetsResponse(qualityNode("commit-msgs", false, &doc))
+		},
+		"EvaluateAsset": func(vars map[string]any) any {
+			if vars["id"] != "gid://commit-msgs" {
+				t.Errorf("mutation id = %v", vars["id"])
+			}
+			return map[string]any{"evaluateAsset": map[string]any{"errors": []any{}}}
+		},
+	})
+	v := NewSleuthVault(srv.URL, "test-token")
+	mode, err := v.ReevaluateQuality(context.Background(), "commit-msgs")
+	if err != nil || mode != QualityEvalServer {
+		t.Fatalf("reevaluate = %q, %v; want %q", mode, err, QualityEvalServer)
+	}
+	var sawMutation bool
+	for _, r := range *records {
+		if r.OperationName == "EvaluateAsset" {
+			sawMutation = true
+		}
+	}
+	if !sawMutation {
+		t.Fatalf("EvaluateAsset mutation never issued: %+v", *records)
+	}
+}
+
+func TestSleuthQualityReevaluateErrors(t *testing.T) {
+	doc := serverEvalDoc
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(map[string]any) any {
+			return qualityAssetsResponse(qualityNode("commit-msgs", false, &doc))
+		},
+		"EvaluateAsset": func(map[string]any) any {
+			return map[string]any{"evaluateAsset": map[string]any{"errors": []any{
+				map[string]any{"field": "id", "messages": []string{"permission denied"}},
+			}}}
+		},
+	})
+	v := NewSleuthVault(srv.URL, "test-token")
+	if _, err := v.ReevaluateQuality(context.Background(), "commit-msgs"); err == nil {
+		t.Fatalf("mutation error not surfaced")
+	}
+
+	// Unknown slug: clear error before any mutation fires.
+	srv2, records := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(map[string]any) any { return qualityAssetsResponse() },
+	})
+	v2 := NewSleuthVault(srv2.URL, "test-token")
+	if _, err := v2.ReevaluateQuality(context.Background(), "missing"); err == nil {
+		t.Fatalf("missing asset accepted")
+	}
+	for _, r := range *records {
+		if r.OperationName == "EvaluateAsset" {
+			t.Fatalf("mutation fired for missing asset")
+		}
+	}
+}
+
+// LatestQuality pages the asset list and maps slug to normalized record,
+// skipping never-evaluated assets.
+func TestSleuthLatestQuality(t *testing.T) {
+	doc := serverEvalDoc
+	page := 0
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(vars map[string]any) any {
+			page++
+			if page == 1 {
+				if vars["slug"] != nil {
+					t.Errorf("bulk read sent slug = %v", vars["slug"])
+				}
+				return map[string]any{"vault": map[string]any{"assets": map[string]any{
+					"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "c1"},
+					"nodes": []map[string]any{
+						qualityNode("skill-a", false, &doc),
+						qualityNode("no-eval", false, nil),
+					},
+				}}}
+			}
+			if vars["after"] != "c1" {
+				t.Errorf("page 2 after = %v", vars["after"])
+			}
+			return qualityAssetsResponse(qualityNode("skill-b", false, &doc))
+		},
+	})
+	v := NewSleuthVault(srv.URL, "test-token")
+	raw, err := v.LatestQuality(context.Background())
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	var latest map[string]map[string]any
+	if err := json.Unmarshal([]byte(raw), &latest); err != nil {
+		t.Fatalf("latest is not an object: %v\n%s", err, raw)
+	}
+	if len(latest) != 2 || latest["skill-a"] == nil || latest["skill-b"] == nil {
+		t.Fatalf("latest = %v", latest)
+	}
+	if latest["no-eval"] != nil {
+		t.Fatalf("never-evaluated asset included: %v", latest)
+	}
+}
+
+// A server predating the quality surface classifies as unsupported.
+func TestSleuthQualityUnsupportedServer(t *testing.T) {
+	old := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Cannot query field \"evaluating\" on type \"Skill\""}]}`))
+	}))
+	t.Cleanup(old.Close)
+	v := NewSleuthVault(old.URL, "test-token")
+	if _, err := v.GetQuality(context.Background(), "x"); !errors.Is(err, ErrQualityUnsupported) {
+		t.Fatalf("get on old server = %v; want ErrQualityUnsupported", err)
+	}
+}

--- a/internal/vault/sleuth_quality_test.go
+++ b/internal/vault/sleuth_quality_test.go
@@ -133,6 +133,34 @@ func TestSleuthQualityGetBareCategoryScores(t *testing.T) {
 	}
 }
 
+// Malformed or percentage-shaped server documents can't emit records
+// outside the interchange contract's 0-100 range (file vaults enforce
+// it via validateQualityRecord; the server path must clamp).
+func TestSleuthQualityGetClampsOutOfRange(t *testing.T) {
+	doc := `{"overall_confidence": 82.46, "category_scores": {"structure": 105, "content_quality": -3}, "reasoning": "drifted"}`
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"GetAssetQuality": func(map[string]any) any {
+			return qualityAssetsResponse(qualityNode("drifted", false, &doc))
+		},
+	})
+	v := NewSleuthVault(srv.URL, "test-token")
+	raw, err := v.GetQuality(context.Background(), "drifted")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_, records := decodeQualityWrapper(t, raw)
+	rec := records[0]
+	// A percentage-shaped overall_confidence reads as a percentage, not
+	// as confidence×100 = 8246.
+	if rec["overall"].(float64) != 82 {
+		t.Fatalf("overall = %v, want 82", rec["overall"])
+	}
+	cats := rec["categories"].(map[string]any)
+	if cats["structure"].(float64) != 100 || cats["content"].(float64) != 0 {
+		t.Fatalf("categories not clamped: %v", cats)
+	}
+}
+
 // While the server evaluates, the flag surfaces so callers can poll; a
 // never-evaluated asset yields empty records, not an error.
 func TestSleuthQualityGetEvaluatingAndEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary
- `QualityStore` vault surface: `GetQuality` / `AddQuality` / `LatestQuality` / `ReevaluateQuality` with a `"server"`/`"local"` dispatch contract that keeps vault-type knowledge out of extensions
- Path/Git vaults: `.sx/quality/<asset>.json`, newest first, capped at 10, atomic writes, corrupt-file `.bad` preservation; git writes run in a vault transaction
- Sleuth vault: reads normalize the server's own evaluation document (`Asset.evaluation_result` via `vault { assets }`) into the interchange record; `AddQuality` is refused (the server is the source of truth); `ReevaluateQuality` fires the existing `evaluateAsset` mutation on the long-timeout client and callers poll the `evaluating` flag
- Wails bridge `PluginQualityGet/Add/Latest/Reevaluate`, new `quality` permission, SxAPI 1.12.0 `sx.quality.*` surface
- `docs/quality-spec.md` + app-plugins-spec changelog entry

Consumed by the `skill-quality` marketplace extension (sleuth-io/sx-extensions PR); ships as app v2.3.0 so the extension's `minAppVersion` gate has a released version to point at.

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)