### PR TITLE
SK-697 Add agent asset support for Kiro client

### DIFF
--- a/docs/kiro.md
+++ b/docs/kiro.md
@@ -2,6 +2,62 @@
 
 sx installs hooks to both Kiro IDE and Kiro CLI, which use different formats and locations.
 
+## Agents
+
+> **Upstream docs**: [Kiro IDE custom agents](https://kiro.dev/docs/custom-agents/) · [Kiro CLI v3 agent config](https://kiro.dev/docs/cli/v3/agent-config/)
+
+sx installs agent assets to `.kiro/agents/` in **two formats simultaneously**:
+
+| File | Format | Used by |
+|------|--------|---------|
+| `{name}.md` | Markdown with YAML frontmatter | Kiro IDE, Kiro CLI v3 (`--v3`) |
+| `{name}.json` | JSON config | Kiro CLI v2 (default) |
+
+The body of `AGENT.md` becomes the system prompt in both formats.
+
+### Kiro-Specific Fields (`[agent.kiro]`)
+
+Add a `[agent.kiro]` section to `metadata.toml` to set agent configuration fields:
+
+```toml
+[agent]
+prompt-file = "AGENT.md"
+
+[agent.kiro]
+model = "claude-sonnet-4"
+tools = ["read", "write", "shell"]
+```
+
+Fields route to output formats based on compatibility:
+
+| Field | `.md` (IDE / CLI v3) | `.json` (CLI v2) | Notes |
+|-------|----------------------|------------------|-------|
+| `model` | ✅ | ✅ | |
+| `tools` | ✅ | ✅ | |
+| `mcpServers` | ✅ | ✅ | |
+| `resources` | ✅ | ✅ | |
+| `welcomeMessage` | ✅ | ✅ | |
+| `permissions` | ✅ | ❌ | CLI v2 has no permissions model |
+| `allowedTools` | ❌ | ✅ | v2-only; silently dropped from `.md` |
+| `toolAliases` | ❌ | ✅ | v2-only; silently dropped from `.md` |
+| `toolsSettings` | ❌ | ✅ | v2-only; silently dropped from `.md` |
+| `hooks` | ❌ | ✅ | v2-only; silently dropped from `.md` |
+| `includeMcpJson` | ❌ | ✅ | v2-only; silently dropped from `.md` |
+| `keyboardShortcut` | ❌ | ✅ | v2-only; excluded from `.md` |
+| *(unknown)* | ✅ | ✅ | Passed through for forward compat |
+
+Valid `permissions` capability values — see [Kiro permissions reference](https://kiro.dev/docs/cli/v3/permissions/#available-capabilities): `fs_read`, `fs_write`, `filesystem` (shorthand for both), `shell`, `web_fetch`, `web_search`, `mcp`, `subagent`, `skill`, `diagnostics`, `context`, `builtin`, `all`.
+
+> **Design decision**: sx dual-writes `.md` (IDE + CLI v3) and `.json` (CLI v2 default) so the agent works regardless of which version is active. Known v2-only fields are excluded from `.md`; `permissions` is excluded from `.json` (CLI v2 has no permissions model). Unknown fields pass through to both formats — both the Kiro IDE and CLI engines tolerate extra keys, preserving forward compatibility with future Kiro schema additions. Note: `kiro-cli agent validate` only parses JSON; it will reject `.md` files — this is expected and not a bug in sx output.
+
+### CLI Setup for Agents
+
+Installed CLI agents (`.json`) are not activated automatically. To use one as the default:
+
+```bash
+kiro-cli agent set-default <name>
+```
+
 ## What sx Installs
 
 | Location                       | Hooks Installed                                            |
@@ -41,3 +97,25 @@ cat .kiro/agents/default.json
 # IDE
 ls .kiro/hooks/
 ```
+
+Verify installed agents (file listing):
+
+```bash
+ls ~/.kiro/agents/
+# Expect: {name}.md and {name}.json for each installed agent
+```
+
+Verify agents are registered in the runtime chat harness:
+
+```bash
+# v2 engine (default) — requires --trust-all-tools for the subagent enumeration tool
+kiro-cli chat --no-interactive --trust-all-tools \
+  "What agents do you have available - list their name and description in a table"
+
+# v3 engine
+kiro-cli chat --no-interactive --v3 \
+  "What agents do you have available - list their name and description in a table"
+```
+
+Note: `kiro-cli agent validate --path <file>.md` will error with a JSON parse failure — this is
+expected. The `validate` subcommand only understands the v2 JSON format regardless of `--v3`.

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -182,6 +182,89 @@ description = "Agent for API development and testing"
 prompt-file = "AGENT.md"
 ```
 
+**Client-Specific Configuration**:
+
+Agents can have client-specific settings in `[agent.<client>]` sections:
+
+- `[agent.kiro]`: Kiro-specific fields (see below)
+
+**`[agent.kiro]` Fields**:
+
+Any field in `[agent.kiro]` is accepted. Unknown fields are preserved and passed to the output format(s), enabling forward compatibility with future Kiro schema additions. Known fields and their routing:
+
+| Field | `.md` (IDE / CLI v3) | `.json` (CLI v2) | Notes |
+|-------|----------------------|------------------|-------|
+| `model` | ✅ | ✅ | |
+| `tools` | ✅ | ✅ | |
+| `mcpServers` | ✅ | ✅ | |
+| `resources` | ✅ | ✅ | File/skill URIs loaded into context |
+| `welcomeMessage` | ✅ | ✅ | Shown when agent starts |
+| `permissions` | ✅ | ❌ | CLI v2 has no permissions model |
+| `allowedTools` | ❌ | ✅ | v2-only; tools that skip confirmation |
+| `toolAliases` | ❌ | ✅ | v2-only; name remappings |
+| `toolsSettings` | ❌ | ✅ | v2-only; per-tool configuration |
+| `hooks` | ❌ | ✅ | v2-only; lifecycle trigger commands |
+| `includeMcpJson` | ❌ | ✅ | v2-only; inherit from `mcp.json` |
+| `keyboardShortcut` | ❌ | ✅ | v2-only; agent launch shortcut |
+| *(unknown)* | ✅ | ✅ | Passed through for forward compat |
+
+**`permissions` object fields**: `capability` (string), `effect` (`"allow"` / `"deny"` / `"ask"`), `match` (optional list of glob strings).
+
+**Available `capability` values**:
+
+| Capability | Controls |
+|------------|----------|
+| `fs_read` | Reading files, listing directories, searching |
+| `fs_write` | Writing, editing, deleting files |
+| `filesystem` | Shorthand for both `fs_read` and `fs_write` |
+| `shell` | Executing commands |
+| `web_fetch` | Fetching URLs |
+| `web_search` | Web search |
+| `mcp` | MCP server tool calls (pattern: `server/tool`) |
+| `subagent` | Subagent delegation |
+| `skill` | Skills activation |
+| `diagnostics` | Diagnostics tools |
+| `context` | Context and steering tools |
+| `builtin` | All built-in tools |
+| `all` | Every capability |
+
+> **Output format note**: In `metadata.toml`, permissions are declared as a TOML array-of-tables (`[[agent.kiro.permissions]]`). sx transforms this into the structure Kiro expects in the installed `.md` file: `permissions: { rules: [...] }`. The TOML input format and the YAML output format differ — this is handled automatically.
+
+```toml
+[[agent.kiro.permissions]]
+capability = "filesystem"
+effect = "allow"
+match = ["src/**"]
+
+[[agent.kiro.permissions]]
+capability = "shell"
+effect = "deny"
+```
+
+> **Note**: Kiro supports two CLI agent formats: v2 (`.json`, default) and v3 (`.md`, opt-in). sx dual-writes both so the agent works regardless of which version is active. v2-only fields are excluded from `.md`; `permissions` is excluded from `.json` (CLI v2 has no permissions model). Unknown fields pass through to both formats — both the Kiro IDE and CLI v2/v3 tolerate extra keys, enabling forward compatibility.
+
+**Example with Kiro fields**:
+
+```toml
+[asset]
+name = "api-helper"
+version = "0.5.0"
+type = "agent"
+description = "Agent for API development and testing"
+
+[agent]
+prompt-file = "AGENT.md"
+
+[agent.kiro]
+model = "claude-sonnet-4"
+tools = ["read", "write", "web"]
+
+[[agent.kiro.permissions]]
+capability = "filesystem"
+effect = "allow"
+match = ["src/**"]
+```
+
 **Package Structure**:
 
 ```

--- a/internal/clients/kiro/client.go
+++ b/internal/clients/kiro/client.go
@@ -32,6 +32,7 @@ func NewClient() *Client {
 			[]asset.Type{
 				asset.TypeMCP,
 				asset.TypeSkill,
+				asset.TypeAgent,
 				asset.TypeRule,
 				asset.TypeCommand,
 				asset.TypeHook,
@@ -104,6 +105,9 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 
 		var err error
 		switch bundle.Metadata.Asset.Type {
+		case asset.TypeAgent:
+			handler := handlers.NewAgentHandler(bundle.Metadata)
+			err = handler.Install(ctx, bundle.ZipData, targetBase)
 		case asset.TypeMCP:
 			handler := handlers.NewMCPHandler(bundle.Metadata)
 			err = handler.Install(ctx, bundle.ZipData, targetBase)
@@ -159,6 +163,9 @@ func (c *Client) UninstallAssets(ctx context.Context, req clients.UninstallReque
 
 		var err error
 		switch a.Type {
+		case asset.TypeAgent:
+			handler := handlers.NewAgentHandler(meta)
+			err = handler.Remove(ctx, targetBase)
 		case asset.TypeMCP:
 			handler := handlers.NewMCPHandler(meta)
 			err = handler.Remove(ctx, targetBase)

--- a/internal/clients/kiro/handlers/agent.go
+++ b/internal/clients/kiro/handlers/agent.go
@@ -36,6 +36,20 @@ type AgentHandler struct {
 	metadata *metadata.Metadata
 }
 
+// v2Only lists fields that only apply to the CLI v2 JSON format and must be
+// excluded from the .md frontmatter (which targets both the IDE and CLI v3).
+var v2Only = map[string]bool{
+	"allowedTools": true, "toolAliases": true, "toolsSettings": true,
+	"hooks": true, "includeMcpJson": true, "keyboardShortcut": true,
+}
+
+// knownHandled lists fields given explicit handling earlier in writeIDEFormat;
+// they must not be emitted again by the generic pass-through loop.
+var knownHandled = map[string]bool{
+	"model": true, "tools": true, "resources": true,
+	"mcpServers": true, "welcomeMessage": true, "permissions": true,
+}
+
 // NewAgentHandler creates a new agent handler
 func NewAgentHandler(meta *metadata.Metadata) *AgentHandler {
 	return &AgentHandler{metadata: meta}
@@ -103,13 +117,13 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 	kiro := h.getKiroFields()
 
 	if model, ok := kiro["model"].(string); ok && model != "" {
-		fmt.Fprintf(&sb, "model: %s\n", model)
+		fmt.Fprintf(&sb, "model: %q\n", model)
 	}
 
 	// Known collection fields — skip if empty to avoid no-op keys
 	for _, key := range []string{"tools", "resources"} {
 		if val, ok := kiro[key]; ok {
-			if sl, isList := val.([]any); !isList || len(sl) > 0 {
+			if sl, isList := val.([]any); isList && len(sl) > 0 {
 				if out, err := yaml.Marshal(map[string]any{key: val}); err == nil {
 					sb.Write(out)
 				}
@@ -118,7 +132,7 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 	}
 
 	if mcpServers, ok := kiro["mcpServers"]; ok {
-		if m, isMap := mcpServers.(map[string]any); !isMap || len(m) > 0 {
+		if m, isMap := mcpServers.(map[string]any); isMap && len(m) > 0 {
 			if out, err := yaml.Marshal(map[string]any{"mcpServers": mcpServers}); err == nil {
 				sb.Write(out)
 			}
@@ -132,7 +146,10 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 	}
 
 	if permissions, ok := kiro["permissions"]; ok {
-		if sl, isList := permissions.([]any); !isList || len(sl) > 0 {
+		// Only wrap a non-empty []any — a TOML table ([agent.kiro.permissions]) decodes
+		// as map[string]any and must not be passed through: it would produce the wrong
+		// schema shape {rules:{key:val}} instead of {rules:[...]}.
+		if sl, isList := permissions.([]any); isList && len(sl) > 0 {
 			// Kiro expects permissions as an object with a "rules" key: { rules: [...] }
 			if out, err := yaml.Marshal(map[string]any{"permissions": map[string]any{"rules": permissions}}); err == nil {
 				sb.Write(out)
@@ -142,14 +159,6 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 
 	// Pass through unknown fields for forward compatibility; exclude v2-only fields
 	// that have no meaning in the IDE / v3 format.
-	v2Only := map[string]bool{
-		"allowedTools": true, "toolAliases": true, "toolsSettings": true,
-		"hooks": true, "includeMcpJson": true, "keyboardShortcut": true,
-	}
-	knownHandled := map[string]bool{
-		"model": true, "tools": true, "resources": true,
-		"mcpServers": true, "welcomeMessage": true, "permissions": true,
-	}
 	for _, key := range sortedKeys(kiro) {
 		if knownHandled[key] || v2Only[key] {
 			continue
@@ -173,9 +182,11 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 
 // writeCLIFormat writes the Kiro CLI v2 agent JSON file.
 // All [agent.kiro] fields pass through to JSON except permissions (CLI v2 has no
-// permissions model). Unknown fields are preserved for forward compatibility —
-// CLI v2 JSON tolerates extra keys (verified by live harness test).
-// CLI v3 (kiro-cli --v3) reads the .md file written by writeIDEFormat directly.
+// permissions model) and the reserved top-level keys (name, prompt, description)
+// which are set from Asset metadata and zip content. Unknown fields are preserved
+// for forward compatibility — CLI v2 JSON tolerates extra keys (verified by live
+// harness test). CLI v3 (kiro-cli --v3) reads the .md file written by writeIDEFormat
+// directly.
 func (h *AgentHandler) writeCLIFormat(agentsDir string, content string) error {
 	config := map[string]any{
 		"name":   h.metadata.Asset.Name,
@@ -186,11 +197,12 @@ func (h *AgentHandler) writeCLIFormat(agentsDir string, content string) error {
 		config["description"] = desc
 	}
 
-	// Pass all [agent.kiro] fields through to v2 JSON except permissions.
-	// Unknown fields are preserved (sx forward-compat principle).
+	// Pass all [agent.kiro] fields through to v2 JSON except the reserved top-level
+	// keys (name, prompt, description) set above, and permissions (no v2 permissions
+	// model). Unknown fields are preserved (sx forward-compat principle).
 	kiro := h.getKiroFields()
 	for key, val := range kiro {
-		if key == "permissions" {
+		if key == "permissions" || key == "name" || key == "prompt" || key == "description" {
 			continue
 		}
 		if isEmptyValue(val) {
@@ -252,9 +264,13 @@ func (h *AgentHandler) readAgentContent(zipData []byte) (string, error) {
 
 	content, err := utils.ReadZipFile(zipData, promptFile)
 	if err != nil {
-		content, err = utils.ReadZipFile(zipData, "agent.md")
+		// Fall back to the canonical default name. Use the same casing as
+		// getPromptFile's default so the fallback is consistent on case-sensitive
+		// archives. Mirror the error format from opencode/handlers/rule.go.
+		const fallback = "AGENT.md"
+		content, err = utils.ReadZipFile(zipData, fallback)
 		if err != nil {
-			return "", fmt.Errorf("prompt file not found: %s", promptFile)
+			return "", fmt.Errorf("prompt file not found (tried %q and %q)", promptFile, fallback)
 		}
 	}
 

--- a/internal/clients/kiro/handlers/agent.go
+++ b/internal/clients/kiro/handlers/agent.go
@@ -9,9 +9,10 @@ import (
 	"sort"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/sleuth-io/sx/internal/metadata"
 	"github.com/sleuth-io/sx/internal/utils"
-	"gopkg.in/yaml.v3"
 )
 
 // AgentHandler handles agent asset installation for Kiro.
@@ -110,7 +111,7 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 		if val, ok := kiro[key]; ok {
 			if sl, isList := val.([]any); !isList || len(sl) > 0 {
 				if out, err := yaml.Marshal(map[string]any{key: val}); err == nil {
-					sb.WriteString(string(out))
+					sb.Write(out)
 				}
 			}
 		}
@@ -119,14 +120,14 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 	if mcpServers, ok := kiro["mcpServers"]; ok {
 		if m, isMap := mcpServers.(map[string]any); !isMap || len(m) > 0 {
 			if out, err := yaml.Marshal(map[string]any{"mcpServers": mcpServers}); err == nil {
-				sb.WriteString(string(out))
+				sb.Write(out)
 			}
 		}
 	}
 
 	if wm, ok := kiro["welcomeMessage"].(string); ok && wm != "" {
 		if out, err := yaml.Marshal(map[string]any{"welcomeMessage": wm}); err == nil {
-			sb.WriteString(string(out))
+			sb.Write(out)
 		}
 	}
 
@@ -134,7 +135,7 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 		if sl, isList := permissions.([]any); !isList || len(sl) > 0 {
 			// Kiro expects permissions as an object with a "rules" key: { rules: [...] }
 			if out, err := yaml.Marshal(map[string]any{"permissions": map[string]any{"rules": permissions}}); err == nil {
-				sb.WriteString(string(out))
+				sb.Write(out)
 			}
 		}
 	}
@@ -158,7 +159,7 @@ func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
 			continue
 		}
 		if out, err := yaml.Marshal(map[string]any{key: val}); err == nil {
-			sb.WriteString(string(out))
+			sb.Write(out)
 		}
 	}
 

--- a/internal/clients/kiro/handlers/agent.go
+++ b/internal/clients/kiro/handlers/agent.go
@@ -1,0 +1,261 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sleuth-io/sx/internal/metadata"
+	"github.com/sleuth-io/sx/internal/utils"
+	"gopkg.in/yaml.v3"
+)
+
+// AgentHandler handles agent asset installation for Kiro.
+// Agents are installed in two formats to .kiro/agents/:
+//
+//   - {name}.md  — IDE + CLI v3 format (YAML frontmatter + system prompt body)
+//     Known fields: model, tools, mcpServers, resources, welcomeMessage, permissions.
+//     permissions is wrapped as {rules:[...]} per the Kiro schema.
+//     Unknown [agent.kiro] fields pass through to frontmatter — both the IDE and v3
+//     engine tolerate extra keys (verified by live harness test).
+//
+//   - {name}.json — CLI v2 format (JSON config with prompt field)
+//     Known fields: model, tools, mcpServers, resources, welcomeMessage, allowedTools,
+//     toolAliases, toolsSettings, hooks, includeMcpJson, keyboardShortcut.
+//     Unknown [agent.kiro] fields pass through — CLI v2 JSON also tolerates extra keys.
+//     permissions is excluded — CLI v2 has no permissions model.
+//
+// Forward compatibility: unknown fields are preserved in both output formats so vault
+// assets remain compatible with future Kiro schema additions without requiring sx updates.
+type AgentHandler struct {
+	metadata *metadata.Metadata
+}
+
+// NewAgentHandler creates a new agent handler
+func NewAgentHandler(meta *metadata.Metadata) *AgentHandler {
+	return &AgentHandler{metadata: meta}
+}
+
+// Install writes both IDE (.md) and CLI (.json) agent files to {targetBase}/agents/
+func (h *AgentHandler) Install(ctx context.Context, zipData []byte, targetBase string) error {
+	content, err := h.readAgentContent(zipData)
+	if err != nil {
+		return fmt.Errorf("failed to read agent content: %w", err)
+	}
+
+	agentsDir := filepath.Join(targetBase, DirAgents)
+	if err := utils.EnsureDir(agentsDir); err != nil {
+		return fmt.Errorf("failed to create agents directory: %w", err)
+	}
+
+	if err := h.writeIDEFormat(agentsDir, content); err != nil {
+		return fmt.Errorf("failed to write IDE agent file: %w", err)
+	}
+
+	if err := h.writeCLIFormat(agentsDir, content); err != nil {
+		return fmt.Errorf("failed to write CLI agent file: %w", err)
+	}
+
+	return nil
+}
+
+// Remove removes both IDE and CLI agent files
+func (h *AgentHandler) Remove(ctx context.Context, targetBase string) error {
+	for _, filename := range []string{
+		filepath.Join(targetBase, DirAgents, h.metadata.Asset.Name+".md"),
+		filepath.Join(targetBase, DirAgents, h.metadata.Asset.Name+".json"),
+	} {
+		if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove agent file %s: %w", filename, err)
+		}
+	}
+	return nil
+}
+
+// VerifyInstalled checks if the IDE agent file exists (canonical format)
+func (h *AgentHandler) VerifyInstalled(targetBase string) (bool, string) {
+	filePath := filepath.Join(targetBase, DirAgents, h.metadata.Asset.Name+".md")
+	if _, err := os.Stat(filePath); err == nil {
+		return true, "Found at " + filePath
+	}
+	return false, "Agent file not found"
+}
+
+// writeIDEFormat writes the Kiro IDE / CLI v3 agent markdown file with YAML frontmatter.
+// Known fields are written with field-specific handling (e.g. permissions wrapping).
+// Unknown [agent.kiro] fields pass through to frontmatter for forward compatibility.
+// v2-only fields (allowedTools, toolAliases, toolsSettings, hooks, includeMcpJson,
+// keyboardShortcut) are excluded — they have no meaning in the IDE / v3 format.
+func (h *AgentHandler) writeIDEFormat(agentsDir string, content string) error {
+	var sb strings.Builder
+
+	sb.WriteString("---\n")
+
+	if desc := h.getDescription(); desc != "" {
+		fmt.Fprintf(&sb, "description: %q\n", desc)
+	}
+
+	kiro := h.getKiroFields()
+
+	if model, ok := kiro["model"].(string); ok && model != "" {
+		fmt.Fprintf(&sb, "model: %s\n", model)
+	}
+
+	// Known collection fields — skip if empty to avoid no-op keys
+	for _, key := range []string{"tools", "resources"} {
+		if val, ok := kiro[key]; ok {
+			if sl, isList := val.([]any); !isList || len(sl) > 0 {
+				if out, err := yaml.Marshal(map[string]any{key: val}); err == nil {
+					sb.WriteString(string(out))
+				}
+			}
+		}
+	}
+
+	if mcpServers, ok := kiro["mcpServers"]; ok {
+		if m, isMap := mcpServers.(map[string]any); !isMap || len(m) > 0 {
+			if out, err := yaml.Marshal(map[string]any{"mcpServers": mcpServers}); err == nil {
+				sb.WriteString(string(out))
+			}
+		}
+	}
+
+	if wm, ok := kiro["welcomeMessage"].(string); ok && wm != "" {
+		if out, err := yaml.Marshal(map[string]any{"welcomeMessage": wm}); err == nil {
+			sb.WriteString(string(out))
+		}
+	}
+
+	if permissions, ok := kiro["permissions"]; ok {
+		if sl, isList := permissions.([]any); !isList || len(sl) > 0 {
+			// Kiro expects permissions as an object with a "rules" key: { rules: [...] }
+			if out, err := yaml.Marshal(map[string]any{"permissions": map[string]any{"rules": permissions}}); err == nil {
+				sb.WriteString(string(out))
+			}
+		}
+	}
+
+	// Pass through unknown fields for forward compatibility; exclude v2-only fields
+	// that have no meaning in the IDE / v3 format.
+	v2Only := map[string]bool{
+		"allowedTools": true, "toolAliases": true, "toolsSettings": true,
+		"hooks": true, "includeMcpJson": true, "keyboardShortcut": true,
+	}
+	knownHandled := map[string]bool{
+		"model": true, "tools": true, "resources": true,
+		"mcpServers": true, "welcomeMessage": true, "permissions": true,
+	}
+	for _, key := range sortedKeys(kiro) {
+		if knownHandled[key] || v2Only[key] {
+			continue
+		}
+		val := kiro[key]
+		if isEmptyValue(val) {
+			continue
+		}
+		if out, err := yaml.Marshal(map[string]any{key: val}); err == nil {
+			sb.WriteString(string(out))
+		}
+	}
+
+	sb.WriteString("---\n\n")
+	sb.WriteString(strings.TrimSpace(content))
+	sb.WriteString("\n")
+
+	filePath := filepath.Join(agentsDir, h.metadata.Asset.Name+".md")
+	return os.WriteFile(filePath, []byte(sb.String()), 0644)
+}
+
+// writeCLIFormat writes the Kiro CLI v2 agent JSON file.
+// All [agent.kiro] fields pass through to JSON except permissions (CLI v2 has no
+// permissions model). Unknown fields are preserved for forward compatibility —
+// CLI v2 JSON tolerates extra keys (verified by live harness test).
+// CLI v3 (kiro-cli --v3) reads the .md file written by writeIDEFormat directly.
+func (h *AgentHandler) writeCLIFormat(agentsDir string, content string) error {
+	config := map[string]any{
+		"name":   h.metadata.Asset.Name,
+		"prompt": strings.TrimSpace(content),
+	}
+
+	if desc := h.getDescription(); desc != "" {
+		config["description"] = desc
+	}
+
+	// Pass all [agent.kiro] fields through to v2 JSON except permissions.
+	// Unknown fields are preserved (sx forward-compat principle).
+	kiro := h.getKiroFields()
+	for key, val := range kiro {
+		if key == "permissions" {
+			continue
+		}
+		if isEmptyValue(val) {
+			continue
+		}
+		config[key] = val
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal CLI agent JSON: %w", err)
+	}
+
+	filePath := filepath.Join(agentsDir, h.metadata.Asset.Name+".json")
+	return os.WriteFile(filePath, append(data, '\n'), 0644)
+}
+
+func (h *AgentHandler) getPromptFile() string {
+	if h.metadata.Agent != nil && h.metadata.Agent.PromptFile != "" {
+		return h.metadata.Agent.PromptFile
+	}
+	return "AGENT.md"
+}
+
+func (h *AgentHandler) getDescription() string {
+	return h.metadata.Asset.Description
+}
+
+func (h *AgentHandler) getKiroFields() map[string]any {
+	if h.metadata.Agent != nil && h.metadata.Agent.Kiro != nil {
+		return h.metadata.Agent.Kiro
+	}
+	return map[string]any{}
+}
+
+func isEmptyValue(val any) bool {
+	switch v := val.(type) {
+	case []any:
+		return len(v) == 0
+	case map[string]any:
+		return len(v) == 0
+	case string:
+		return v == ""
+	}
+	return false
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (h *AgentHandler) readAgentContent(zipData []byte) (string, error) {
+	promptFile := h.getPromptFile()
+
+	content, err := utils.ReadZipFile(zipData, promptFile)
+	if err != nil {
+		content, err = utils.ReadZipFile(zipData, "agent.md")
+		if err != nil {
+			return "", fmt.Errorf("prompt file not found: %s", promptFile)
+		}
+	}
+
+	return string(content), nil
+}

--- a/internal/clients/kiro/handlers/agent_test.go
+++ b/internal/clients/kiro/handlers/agent_test.go
@@ -1,0 +1,415 @@
+package handlers
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/internal/metadata"
+)
+
+func createTestAgentZip(t *testing.T, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.Create("AGENT.md")
+	if err != nil {
+		t.Fatalf("Failed to create zip entry: %v", err)
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		t.Fatalf("Failed to write zip content: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Failed to close zip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestAgentHandler_Install_WritesIDEFormat(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "test-agent", Description: "A test agent"},
+		Agent: &metadata.AgentConfig{PromptFile: "AGENT.md"},
+	}
+	handler := NewAgentHandler(meta)
+	zipData := createTestAgentZip(t, "You are a helpful assistant.")
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	filePath := filepath.Join(targetBase, DirAgents, "test-agent.md")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read IDE agent file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, `description: "A test agent"`) {
+		t.Errorf("expected description in frontmatter, got:\n%s", content)
+	}
+	if !strings.Contains(content, "---") {
+		t.Errorf("expected YAML frontmatter delimiters, got:\n%s", content)
+	}
+	if !strings.Contains(content, "You are a helpful assistant.") {
+		t.Errorf("expected agent body, got:\n%s", content)
+	}
+}
+
+func TestAgentHandler_Install_WritesCLIFormat(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "test-agent", Description: "A test agent"},
+		Agent: &metadata.AgentConfig{PromptFile: "AGENT.md"},
+	}
+	handler := NewAgentHandler(meta)
+	zipData := createTestAgentZip(t, "You are a helpful assistant.")
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	filePath := filepath.Join(targetBase, DirAgents, "test-agent.json")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read CLI agent file: %v", err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse CLI agent JSON: %v", err)
+	}
+
+	if config["name"] != "test-agent" {
+		t.Errorf("expected name=test-agent, got %v", config["name"])
+	}
+	if config["description"] != "A test agent" {
+		t.Errorf("expected description in CLI JSON, got %v", config["description"])
+	}
+	if config["prompt"] != "You are a helpful assistant." {
+		t.Errorf("expected prompt in CLI JSON, got %v", config["prompt"])
+	}
+}
+
+func TestAgentHandler_Install_WithKiroFields(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "smart-agent", Description: "Agent with config"},
+		Agent: &metadata.AgentConfig{
+			PromptFile: "AGENT.md",
+			Kiro: map[string]any{
+				"model": "claude-sonnet-4",
+				"tools": []any{"read", "write"},
+			},
+		},
+	}
+	handler := NewAgentHandler(meta)
+	zipData := createTestAgentZip(t, "You are a smart agent.")
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// Check IDE format has model and tools
+	ideData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "smart-agent.md"))
+	if err != nil {
+		t.Fatalf("Failed to read IDE file: %v", err)
+	}
+	ideContent := string(ideData)
+	if !strings.Contains(ideContent, "model: claude-sonnet-4") {
+		t.Errorf("expected model in IDE frontmatter, got:\n%s", ideContent)
+	}
+	if !strings.Contains(ideContent, "tools:") {
+		t.Errorf("expected tools in IDE frontmatter, got:\n%s", ideContent)
+	}
+
+	// Check CLI format has model and tools
+	cliData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "smart-agent.json"))
+	if err != nil {
+		t.Fatalf("Failed to read CLI file: %v", err)
+	}
+	var cliConfig map[string]any
+	if err := json.Unmarshal(cliData, &cliConfig); err != nil {
+		t.Fatalf("Failed to parse CLI JSON: %v", err)
+	}
+	if cliConfig["model"] != "claude-sonnet-4" {
+		t.Errorf("expected model in CLI JSON, got %v", cliConfig["model"])
+	}
+	if _, ok := cliConfig["tools"]; !ok {
+		t.Errorf("expected tools in CLI JSON, got keys: %v", cliConfig)
+	}
+}
+
+func TestAgentHandler_Install_NoDescription(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "bare-agent"},
+		Agent: &metadata.AgentConfig{PromptFile: "AGENT.md"},
+	}
+	handler := NewAgentHandler(meta)
+	zipData := createTestAgentZip(t, "Minimal agent.")
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// IDE format should not have description key
+	ideData, _ := os.ReadFile(filepath.Join(targetBase, DirAgents, "bare-agent.md"))
+	if strings.Contains(string(ideData), "description:") {
+		t.Errorf("IDE file should not contain description when empty, got:\n%s", string(ideData))
+	}
+
+	// CLI format should not have description key
+	cliData, _ := os.ReadFile(filepath.Join(targetBase, DirAgents, "bare-agent.json"))
+	var config map[string]any
+	if err := json.Unmarshal(cliData, &config); err != nil {
+		t.Fatalf("Failed to parse CLI JSON: %v", err)
+	}
+	if _, ok := config["description"]; ok {
+		t.Errorf("CLI JSON should not contain description when empty, got: %v", config)
+	}
+}
+
+func TestAgentHandler_Install_WithPermissions(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "secure-agent", Description: "Agent with permissions"},
+		Agent: &metadata.AgentConfig{
+			PromptFile: "AGENT.md",
+			Kiro: map[string]any{
+				"permissions": []any{
+					map[string]any{"capability": "filesystem", "effect": "allow", "match": []any{"src/**"}},
+					map[string]any{"capability": "shell", "effect": "deny"},
+				},
+			},
+		},
+	}
+	handler := NewAgentHandler(meta)
+	zipData := createTestAgentZip(t, "A secure agent.")
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// IDE format should contain permissions wrapped in a "rules" object: permissions.rules[...]
+	ideData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "secure-agent.md"))
+	if err != nil {
+		t.Fatalf("Failed to read IDE file: %v", err)
+	}
+	ideContent := string(ideData)
+	if !strings.Contains(ideContent, "permissions:") {
+		t.Errorf("IDE file should contain permissions, got:\n%s", ideContent)
+	}
+	if !strings.Contains(ideContent, "rules:") {
+		t.Errorf("IDE file permissions should have a rules key, got:\n%s", ideContent)
+	}
+	if !strings.Contains(ideContent, "filesystem") {
+		t.Errorf("IDE file should contain capability names, got:\n%s", ideContent)
+	}
+
+	// CLI format (v2) should NOT contain permissions — no permissions model in v2
+	cliData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "secure-agent.json"))
+	if err != nil {
+		t.Fatalf("Failed to read CLI file: %v", err)
+	}
+	var cliConfig map[string]any
+	if err := json.Unmarshal(cliData, &cliConfig); err != nil {
+		t.Fatalf("Failed to parse CLI JSON: %v", err)
+	}
+	if _, ok := cliConfig["permissions"]; ok {
+		t.Errorf("CLI JSON should not contain permissions (CLI v2 has no permissions model), got: %v", cliConfig)
+	}
+}
+
+func TestAgentHandler_Install_V2FieldsInCLINotInIDE(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "v2-agent", Description: "Agent with v2-specific fields"},
+		Agent: &metadata.AgentConfig{
+			PromptFile: "AGENT.md",
+			Kiro: map[string]any{
+				"model":            "claude-sonnet-4",
+				"allowedTools":     []any{"fs_read", "shell"},
+				"keyboardShortcut": "ctrl+a",
+				"welcomeMessage":   "Hello from v2 agent",
+				"unknownFuture":    "somevalue", // unknown field — passes through to both formats
+				"hooks": map[string]any{
+					"agentSpawn": []any{map[string]any{"command": "echo spawned"}},
+				},
+			},
+		},
+	}
+	handler := NewAgentHandler(meta)
+	zipData := createTestAgentZip(t, "A v2 agent.")
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// CLI v2 JSON: known v2-only fields should be present
+	cliData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "v2-agent.json"))
+	if err != nil {
+		t.Fatalf("Failed to read CLI file: %v", err)
+	}
+	var cliConfig map[string]any
+	if err := json.Unmarshal(cliData, &cliConfig); err != nil {
+		t.Fatalf("Failed to parse CLI JSON: %v", err)
+	}
+	for _, key := range []string{"allowedTools", "keyboardShortcut", "welcomeMessage", "hooks"} {
+		if _, ok := cliConfig[key]; !ok {
+			t.Errorf("CLI JSON should contain v2 field %q, got keys: %v", key, cliConfig)
+		}
+	}
+	// Unknown fields pass through to CLI JSON (sx forward-compat principle)
+	if _, ok := cliConfig["unknownFuture"]; !ok {
+		t.Errorf("CLI JSON should preserve unknown field 'unknownFuture' for forward compat, got: %v", cliConfig)
+	}
+
+	// IDE .md: v2-only fields must NOT appear; welcomeMessage and unknownFuture should
+	ideData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "v2-agent.md"))
+	if err != nil {
+		t.Fatalf("Failed to read IDE file: %v", err)
+	}
+	ideContent := string(ideData)
+	for _, key := range []string{"allowedTools", "keyboardShortcut", "hooks"} {
+		if strings.Contains(ideContent, key+":") {
+			t.Errorf("IDE .md should not contain v2-only field %q, got:\n%s", key, ideContent)
+		}
+	}
+	// welcomeMessage is a known v3/IDE field — should be present
+	if !strings.Contains(ideContent, "welcomeMessage:") {
+		t.Errorf("IDE .md should contain welcomeMessage (known v3/IDE field), got:\n%s", ideContent)
+	}
+	// Unknown fields pass through to IDE .md for forward compat
+	if !strings.Contains(ideContent, "unknownFuture:") {
+		t.Errorf("IDE .md should preserve unknown field 'unknownFuture' for forward compat, got:\n%s", ideContent)
+	}
+}
+
+func TestAgentHandler_Install_EmptyCollectionsOmitted(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "sparse-agent", Description: "Agent with empty collections"},
+		Agent: &metadata.AgentConfig{
+			PromptFile: "AGENT.md",
+			Kiro: map[string]any{
+				"model":       "claude-sonnet-4",
+				"tools":       []any{},
+				"mcpServers":  map[string]any{},
+				"permissions": []any{},
+			},
+		},
+	}
+	handler := NewAgentHandler(meta)
+	zipData := createTestAgentZip(t, "Sparse agent.")
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	// IDE: empty tools/mcpServers/permissions should not appear in frontmatter
+	ideData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "sparse-agent.md"))
+	if err != nil {
+		t.Fatalf("Failed to read IDE file: %v", err)
+	}
+	ideContent := string(ideData)
+	for _, key := range []string{"tools:", "mcpServers:", "permissions:"} {
+		if strings.Contains(ideContent, key) {
+			t.Errorf("IDE file should not contain %q when value is empty, got:\n%s", key, ideContent)
+		}
+	}
+	if !strings.Contains(ideContent, "model: claude-sonnet-4") {
+		t.Errorf("IDE file should still contain non-empty fields, got:\n%s", ideContent)
+	}
+
+	// CLI JSON: empty tools/mcpServers should not appear
+	cliData, err := os.ReadFile(filepath.Join(targetBase, DirAgents, "sparse-agent.json"))
+	if err != nil {
+		t.Fatalf("Failed to read CLI file: %v", err)
+	}
+	var cliConfig map[string]any
+	if err := json.Unmarshal(cliData, &cliConfig); err != nil {
+		t.Fatalf("Failed to parse CLI JSON: %v", err)
+	}
+	for _, key := range []string{"tools", "mcpServers"} {
+		if _, ok := cliConfig[key]; ok {
+			t.Errorf("CLI JSON should not contain %q when value is empty, got: %v", key, cliConfig)
+		}
+	}
+	if cliConfig["model"] != "claude-sonnet-4" {
+		t.Errorf("CLI JSON should still contain non-empty fields, got: %v", cliConfig)
+	}
+}
+
+func TestAgentHandler_Remove(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "remove-agent"},
+		Agent: &metadata.AgentConfig{PromptFile: "AGENT.md"},
+	}
+	handler := NewAgentHandler(meta)
+
+	zipData := createTestAgentZip(t, "To be removed.")
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	mdPath := filepath.Join(targetBase, DirAgents, "remove-agent.md")
+	jsonPath := filepath.Join(targetBase, DirAgents, "remove-agent.json")
+
+	if _, err := os.Stat(mdPath); os.IsNotExist(err) {
+		t.Fatal(".md file should exist after install")
+	}
+	if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
+		t.Fatal(".json file should exist after install")
+	}
+
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := os.Stat(mdPath); !os.IsNotExist(err) {
+		t.Error(".md file should not exist after remove")
+	}
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Error(".json file should not exist after remove")
+	}
+}
+
+func TestAgentHandler_VerifyInstalled(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "verify-agent"},
+		Agent: &metadata.AgentConfig{PromptFile: "AGENT.md"},
+	}
+	handler := NewAgentHandler(meta)
+
+	installed, _ := handler.VerifyInstalled(targetBase)
+	if installed {
+		t.Error("should not be installed before install")
+	}
+
+	zipData := createTestAgentZip(t, "Verify me.")
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	installed, msg := handler.VerifyInstalled(targetBase)
+	if !installed {
+		t.Errorf("should be installed after install, got: %s", msg)
+	}
+
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	installed, _ = handler.VerifyInstalled(targetBase)
+	if installed {
+		t.Error("should not be installed after remove")
+	}
+}

--- a/internal/clients/kiro/handlers/agent_test.go
+++ b/internal/clients/kiro/handlers/agent_test.go
@@ -121,7 +121,7 @@ func TestAgentHandler_Install_WithKiroFields(t *testing.T) {
 		t.Fatalf("Failed to read IDE file: %v", err)
 	}
 	ideContent := string(ideData)
-	if !strings.Contains(ideContent, "model: claude-sonnet-4") {
+	if !strings.Contains(ideContent, `model: "claude-sonnet-4"`) {
 		t.Errorf("expected model in IDE frontmatter, got:\n%s", ideContent)
 	}
 	if !strings.Contains(ideContent, "tools:") {
@@ -323,7 +323,7 @@ func TestAgentHandler_Install_EmptyCollectionsOmitted(t *testing.T) {
 			t.Errorf("IDE file should not contain %q when value is empty, got:\n%s", key, ideContent)
 		}
 	}
-	if !strings.Contains(ideContent, "model: claude-sonnet-4") {
+	if !strings.Contains(ideContent, `model: "claude-sonnet-4"`) {
 		t.Errorf("IDE file should still contain non-empty fields, got:\n%s", ideContent)
 	}
 

--- a/internal/clients/kiro/handlers/handler.go
+++ b/internal/clients/kiro/handlers/handler.go
@@ -18,6 +18,8 @@ type Handler interface {
 // NewHandler creates a handler for the given asset type
 func NewHandler(assetType asset.Type, meta *metadata.Metadata) (Handler, error) {
 	switch assetType {
+	case asset.TypeAgent:
+		return NewAgentHandler(meta), nil
 	case asset.TypeCommand:
 		return NewCommandHandler(meta), nil
 	case asset.TypeSkill:

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -80,7 +80,8 @@ type CommandConfig struct {
 
 // AgentConfig represents the [agent] section
 type AgentConfig struct {
-	PromptFile string `toml:"prompt-file"`
+	PromptFile string         `toml:"prompt-file"`
+	Kiro       map[string]any `toml:"kiro,omitempty"`
 }
 
 // HookConfig represents the [hook] section


### PR DESCRIPTION
## What

Adds `type = "agent"` support to the Kiro client. When installed, sx writes the agent to `~/.kiro/agents/` in both formats Kiro expects:

- `{name}.md` — YAML frontmatter + system prompt body (Kiro IDE, `kiro-cli --v3`)
- `{name}.json` — JSON config with `prompt` field (Kiro CLI v2, the current default)

Both files coexist; Kiro picks the right one based on which engine is active.

## Why dual-write

`kiro-cli --v3` routes only the interactive chat session to the v3 engine — management subcommands (`agent list`, `agent validate`, `agent create`) always use the v2 engine. Since v2 is the default and v3 is opt-in, writing both formats means a distributed agent works without the vault author or end user needing to know which CLI version is installed.

## Field routing

`[agent.kiro]` fields in `metadata.toml` route based on what each format supports:

| Field | `.md` (IDE / v3) | `.json` (v2) | Notes |
|-------|:----------------:|:------------:|-------|
| `model`, `tools`, `mcpServers`, `resources`, `welcomeMessage` | ✅ | ✅ | |
| `permissions` | ✅ | ❌ | CLI v2 has no permissions model |
| `allowedTools`, `toolAliases`, `toolsSettings`, `hooks`, `includeMcpJson`, `keyboardShortcut` | ❌ | ✅ | v2-only |
| *(unknown fields)* | ✅ | ✅ | Forward-compat pass-through |

Unknown fields pass through to both formats. Both the Kiro IDE and CLI engines silently tolerate extra keys — confirmed by live harness test (see below).

Empty collections (`[]`, `{}`) and empty strings are omitted from both outputs.

## permissions schema

Kiro requires `permissions` as a wrapped object in `.md`:

```yaml
permissions:
  rules:
    - capability: filesystem
      effect: allow
      match: ["src/**"]
    - capability: shell
      effect: deny
```

sx transforms `[[agent.kiro.permissions]]` TOML array-of-tables into this structure automatically. A flat array directly under `permissions:` is silently ignored by Kiro — the wrapping is required.

Valid capabilities: `fs_read`, `fs_write`, `filesystem` (alias for both), `shell`, `web_fetch`, `web_search`, `mcp`, `subagent`, `skill`, `diagnostics`, `context`, `builtin`, `all`.

## Example metadata.toml

```toml
[asset]
name = "api-helper"
version = "1.0.0"
type = "agent"
description = "Agent for API development, testing, and documentation"

[agent]
prompt-file = "AGENT.md"

[agent.kiro]
model = "claude-sonnet-4"
tools = ["read", "write"]

[[agent.kiro.permissions]]
capability = "filesystem"
effect = "allow"
match = ["src/**"]

[[agent.kiro.permissions]]
capability = "shell"
effect = "deny"
```

## Validation

Three test agents installed globally via `sx add <dir> --yes --scope-global` and verified through both CLI engines:

```bash
# Static discovery
kiro-cli agent list
kiro-cli --v3 agent list

# Runtime harness — authoritative test
kiro-cli chat --no-interactive --trust-all-tools \
  "What agents do you have available?"
kiro-cli chat --no-interactive --v3 \
  "What agents do you have available?"
```

All three agents appeared in both harnesses with descriptions matching `metadata.toml`.

Forward-compat probe: agent files with intentional unknown keys (`unknownField`, `anotherUnknown`) in both `.json` and `.md` loaded cleanly in all four tests — `kiro-cli agent list`, `--v3 agent list`, v2 runtime, v3 runtime (invoked directly, returned expected response).

Note: `kiro-cli agent validate --path <file>.md` always fails with a JSON parse error regardless of `--v3` — this is a CLI limitation (the `validate` subcommand is wired to the v2 JSON parser only). It is not a valid correctness check for `.md` files.

## Files changed

| File | Change |
|------|--------|
| `internal/metadata/metadata.go` | Added `Kiro map[string]any` to `AgentConfig` |
| `internal/clients/kiro/handlers/agent.go` | New — `AgentHandler` with `Install`, `Remove`, `VerifyInstalled` |
| `internal/clients/kiro/handlers/handler.go` | `TypeAgent` case in `NewHandler` factory |
| `internal/clients/kiro/client.go` | `TypeAgent` in supported types, `InstallAssets`, `UninstallAssets` |
| `internal/clients/kiro/handlers/agent_test.go` | New — 9 tests covering both output formats |
| `docs/kiro.md` | Agent section: dual-write, field routing table, troubleshooting |
| `docs/metadata-spec.md` | `[agent.kiro]` field table, permissions schema, capability reference |
