### PR TITLE
SK-687: Support remote MCP servers for Copilot

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -22,7 +22,7 @@ Many AI tools ship in two forms: a **desktop IDE** and a **CLI**. These often ha
 | Codex          | CLI     | Full support                                                                                   |
 | Cursor         | IDE     | Full support                                                                                   |
 | Gemini         | CLI/IDE | Full support for CLI/VS Code; rules and MCP only (JetBrains); MCP-remote only (Android Studio) |
-| GitHub Copilot | IDE ext | Full support                                                                                   |
+| GitHub Copilot | IDE+CLI | Full support, including remote (http/sse) MCP. MCP servers are written to `.vscode/mcp.json` for VS Code and mirrored into the Copilot CLI config: `~/.copilot/mcp-config.json` (global scope) or `.github/mcp.json` (repo/path scope). Packaged servers are not mirrored into `.github/mcp.json` — their entries carry machine-absolute paths and that file is typically committed. Root `.mcp.json` is left to the Claude Code client. |
 | Kiro           | CLI+IDE | Full support. See [Kiro-specific docs](kiro.md) for hook setup.                                |
 | OpenCode       | CLI     | Skills, commands, agents, rules, MCP servers. Config at `~/.config/opencode/` (or `.opencode/` per-repo). Rules are written to `rules/<name>.md` and registered via the `instructions` array in `opencode.json`. |
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -396,22 +396,30 @@ description = "Go standards - applies to Go files only"
 
 **Required Section**: `[mcp]`
 
-**Required Fields**:
+**Required Fields** (local servers):
 
 - `command`: Command to run the MCP server
 - `args`: Array of command arguments
 
+**Required Fields** (remote servers):
+
+- `transport`: `"http"` or `"sse"` (defaults to `"stdio"` when omitted)
+- `url`: The remote server endpoint
+
 **Optional Fields**:
 
-- `env`: Map of environment variables
+- `env`: Map of environment variables (stdio servers only — clients that
+  distinguish remote entries, like Copilot, drop `env` on them since remote
+  servers authenticate via headers)
 - `timeout`: Timeout in milliseconds
 
 **Important**: All MCP configuration is in metadata.toml. No separate JSON config file is needed.
 
-MCP assets operate in two modes, determined automatically by zip contents:
+MCP assets operate in three modes:
 
 - **Packaged mode**: Zip contains server code files beyond `metadata.toml`. Files are extracted and command paths are resolved relative to the install directory.
 - **Config-only mode**: Zip contains only `metadata.toml`. No extraction needed - commands are used as-is (e.g., `npx`, `docker`).
+- **Remote mode**: `transport` is `"http"` or `"sse"`. Nothing runs locally; the client connects to `url` directly.
 
 **Example - Packaged MCP** (includes server code):
 
@@ -475,6 +483,20 @@ env = {
 hosted-github/
   metadata.toml
   (that's it!)
+```
+
+**Example - Remote MCP** (hosted service, no local process):
+
+```toml
+[asset]
+name = "deepwiki"
+version = "1.0.0"
+type = "mcp"
+description = "DeepWiki hosted MCP service"
+
+[mcp]
+transport = "http"
+url = "https://mcp.deepwiki.com/mcp"
 ```
 
 > **Migration note**: The legacy type `mcp-remote` is accepted as an alias for `mcp`. Existing lock files and vaults using `type = "mcp-remote"` continue to work without changes.

--- a/internal/clients/github_copilot/client.go
+++ b/internal/clients/github_copilot/client.go
@@ -173,7 +173,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 				installErr = mcpErr
 			} else {
 				handler := handlers.NewMCPHandler(bundle.Metadata)
-				handler.CLIConfigPath = c.determineCLIMCPConfigPath(req.Scope)
+				handler.CLIConfigPath, handler.CLIConfigShared = c.determineCLIMCPConfig(req.Scope)
 				installErr = handler.Install(ctx, bundle.ZipData, mcpTargetBase)
 			}
 		default:
@@ -242,7 +242,7 @@ func (c *Client) UninstallAssets(ctx context.Context, req clients.UninstallReque
 				uninstallErr = mcpErr
 			} else {
 				handler := handlers.NewMCPHandler(meta)
-				handler.CLIConfigPath = c.determineCLIMCPConfigPath(req.Scope)
+				handler.CLIConfigPath, handler.CLIConfigShared = c.determineCLIMCPConfig(req.Scope)
 				uninstallErr = handler.Remove(ctx, mcpTargetBase)
 			}
 		default:
@@ -316,27 +316,28 @@ func (c *Client) determineMCPTargetBase(scope *clients.InstallScope) (string, er
 	}
 }
 
-// determineCLIMCPConfigPath returns the Copilot CLI MCP config file MCP entries
+// determineCLIMCPConfig returns the Copilot CLI MCP config file MCP entries
 // are mirrored into, alongside VS Code's mcp.json. The CLI doesn't read VS
 // Code's user-level mcp.json: its user config is ~/.copilot/mcp-config.json,
 // and at repo level it auto-loads .github/mcp.json (root .mcp.json is left to
-// the Claude Code client, which manages that file). Returns "" (mirror
-// disabled) when the location can't be determined.
-func (c *Client) determineCLIMCPConfigPath(scope *clients.InstallScope) string {
+// the Claude Code client, which manages that file). shared marks the repo-level
+// file, which is typically committed. Returns "" (mirror disabled) when the
+// location can't be determined.
+func (c *Client) determineCLIMCPConfig(scope *clients.InstallScope) (path string, shared bool) {
 	switch scope.Type {
 	case clients.ScopeRepository, clients.ScopePath:
 		if scope.RepoRoot == "" {
-			return ""
+			return "", false
 		}
-		return filepath.Join(scope.RepoRoot, ".github", "mcp.json")
+		return filepath.Join(scope.RepoRoot, ".github", "mcp.json"), true
 	case clients.ScopeGlobal:
 		fallthrough
 	default:
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return ""
+			return "", false
 		}
-		return filepath.Join(home, handlers.ConfigDir, "mcp-config.json")
+		return filepath.Join(home, handlers.ConfigDir, "mcp-config.json"), false
 	}
 }
 
@@ -470,6 +471,9 @@ func (c *Client) VerifyAssets(ctx context.Context, assets []*lockfile.Asset, sco
 		if err != nil {
 			result.Message = err.Error()
 		} else {
+			if mcpHandler, ok := handler.(*handlers.MCPHandler); ok {
+				mcpHandler.CLIConfigPath, mcpHandler.CLIConfigShared = c.determineCLIMCPConfig(scope)
+			}
 			result.Installed, result.Message = handler.VerifyInstalled(targetBase)
 		}
 

--- a/internal/clients/github_copilot/client.go
+++ b/internal/clients/github_copilot/client.go
@@ -167,13 +167,6 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 			handler := handlers.NewAgentHandler(bundle.Metadata)
 			installErr = handler.Install(ctx, bundle.ZipData, targetBase)
 		case asset.TypeMCP:
-			// Remote MCP (sse/http) not supported for GitHub Copilot
-			if bundle.Metadata.MCP != nil && bundle.Metadata.MCP.IsRemote() {
-				result.Status = clients.StatusSkipped
-				result.Message = "Remote MCP (sse/http) not supported"
-				resp.Results = append(resp.Results, result)
-				continue
-			}
 			// MCP uses .vscode/ instead of .github/
 			mcpTargetBase, mcpErr := c.determineMCPTargetBase(req.Scope)
 			if mcpErr != nil {

--- a/internal/clients/github_copilot/client.go
+++ b/internal/clients/github_copilot/client.go
@@ -173,6 +173,7 @@ func (c *Client) InstallAssets(ctx context.Context, req clients.InstallRequest) 
 				installErr = mcpErr
 			} else {
 				handler := handlers.NewMCPHandler(bundle.Metadata)
+				handler.CLIConfigPath = c.determineCLIMCPConfigPath(req.Scope)
 				installErr = handler.Install(ctx, bundle.ZipData, mcpTargetBase)
 			}
 		default:
@@ -241,6 +242,7 @@ func (c *Client) UninstallAssets(ctx context.Context, req clients.UninstallReque
 				uninstallErr = mcpErr
 			} else {
 				handler := handlers.NewMCPHandler(meta)
+				handler.CLIConfigPath = c.determineCLIMCPConfigPath(req.Scope)
 				uninstallErr = handler.Remove(ctx, mcpTargetBase)
 			}
 		default:
@@ -311,6 +313,30 @@ func (c *Client) determineMCPTargetBase(scope *clients.InstallScope) (string, er
 		return filepath.Join(scope.RepoRoot, ".vscode"), nil
 	default:
 		return filepath.Join(home, ".vscode"), nil
+	}
+}
+
+// determineCLIMCPConfigPath returns the Copilot CLI MCP config file MCP entries
+// are mirrored into, alongside VS Code's mcp.json. The CLI doesn't read VS
+// Code's user-level mcp.json: its user config is ~/.copilot/mcp-config.json,
+// and at repo level it auto-loads .github/mcp.json (root .mcp.json is left to
+// the Claude Code client, which manages that file). Returns "" (mirror
+// disabled) when the location can't be determined.
+func (c *Client) determineCLIMCPConfigPath(scope *clients.InstallScope) string {
+	switch scope.Type {
+	case clients.ScopeRepository, clients.ScopePath:
+		if scope.RepoRoot == "" {
+			return ""
+		}
+		return filepath.Join(scope.RepoRoot, ".github", "mcp.json")
+	case clients.ScopeGlobal:
+		fallthrough
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		return filepath.Join(home, handlers.ConfigDir, "mcp-config.json")
 	}
 }
 

--- a/internal/clients/github_copilot/handlers/mcp.go
+++ b/internal/clients/github_copilot/handlers/mcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,11 @@ var mcpOps = dirasset.NewOperations(DirMCPServers, &asset.TypeMCP)
 // MCPHandler handles MCP asset installation for GitHub Copilot (VS Code)
 type MCPHandler struct {
 	metadata *metadata.Metadata
+
+	// CLIConfigPath is the Copilot CLI MCP config file to mirror entries into
+	// (~/.copilot/mcp-config.json for global scope, {repoRoot}/.github/mcp.json
+	// for repo/path scopes). Empty disables the CLI mirror.
+	CLIConfigPath string
 }
 
 // NewMCPHandler creates a new MCP handler
@@ -71,6 +77,14 @@ func (h *MCPHandler) Install(ctx context.Context, zipData []byte, targetBase str
 		return fmt.Errorf("failed to write mcp.json: %w", err)
 	}
 
+	// Mirror the entry into the Copilot CLI config so the asset also works in
+	// `copilot` sessions, which don't read VS Code's user-level mcp.json.
+	if h.CLIConfigPath != "" {
+		if err := setCLIMCPServer(h.CLIConfigPath, h.metadata.Asset.Name, cliMCPEntry(entry)); err != nil {
+			return fmt.Errorf("failed to update Copilot CLI MCP config: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -92,11 +106,57 @@ func (h *MCPHandler) Remove(ctx context.Context, targetBase string) error {
 		return fmt.Errorf("failed to write mcp.json: %w", err)
 	}
 
+	if h.CLIConfigPath != "" {
+		if err := removeCLIMCPServer(h.CLIConfigPath, h.metadata.Asset.Name); err != nil {
+			return fmt.Errorf("failed to update Copilot CLI MCP config: %w", err)
+		}
+	}
+
 	// Remove server directory (if exists)
 	serverDir := filepath.Join(targetBase, DirMCPServers, h.metadata.Asset.Name)
 	os.RemoveAll(serverDir) // Ignore errors if doesn't exist
 
 	return nil
+}
+
+// cliMCPEntry adapts a VS Code mcp.json entry for the Copilot CLI config.
+// The CLI requires an explicit "type" on every server; VS Code stdio entries
+// omit it, so add it here. Remote entries already carry their type.
+func cliMCPEntry(entry map[string]any) map[string]any {
+	cliEntry := make(map[string]any, len(entry)+1)
+	maps.Copy(cliEntry, entry)
+	if _, ok := cliEntry["type"]; !ok {
+		cliEntry["type"] = "stdio"
+	}
+	return cliEntry
+}
+
+// setCLIMCPServer writes an MCP server entry to a Copilot CLI config file
+// (mcpServers key), overwriting any existing entry so upgrades take effect.
+func setCLIMCPServer(configPath, name string, entry map[string]any) error {
+	config, err := readCopilotCLIMCPConfig(configPath)
+	if err != nil {
+		return err
+	}
+	if config.MCPServers == nil {
+		config.MCPServers = make(map[string]any)
+	}
+	config.MCPServers[name] = entry
+	return writeCopilotCLIMCPConfig(configPath, config)
+}
+
+// removeCLIMCPServer removes an MCP server entry from a Copilot CLI config file.
+// A missing file or entry is a no-op so the config isn't materialized on removal.
+func removeCLIMCPServer(configPath, name string) error {
+	config, err := readCopilotCLIMCPConfig(configPath)
+	if err != nil {
+		return err
+	}
+	if _, exists := config.MCPServers[name]; !exists {
+		return nil
+	}
+	delete(config.MCPServers, name)
+	return writeCopilotCLIMCPConfig(configPath, config)
 }
 
 func (h *MCPHandler) generateMCPEntry(serverDir string) map[string]any {

--- a/internal/clients/github_copilot/handlers/mcp.go
+++ b/internal/clients/github_copilot/handlers/mcp.go
@@ -42,14 +42,18 @@ func (h *MCPHandler) Install(ctx context.Context, zipData []byte, targetBase str
 	}
 
 	var entry map[string]any
-	if hasContent {
+	switch {
+	case h.metadata.MCP != nil && h.metadata.MCP.IsRemote():
+		// Remote mode: nothing runs locally, so never extract — just register the URL
+		entry = h.generateRemoteMCPEntry()
+	case hasContent:
 		// Packaged mode: extract MCP server files to .vscode/mcp-servers/{name}/
 		serverDir := filepath.Join(targetBase, DirMCPServers, h.metadata.Asset.Name)
 		if err := utils.ExtractZip(zipData, serverDir); err != nil {
 			return fmt.Errorf("failed to extract MCP server: %w", err)
 		}
 		entry = h.generateMCPEntry(serverDir)
-	} else {
+	default:
 		// Config-only mode: no extraction, register commands as-is
 		entry = h.generateConfigOnlyMCPEntry()
 	}
@@ -111,6 +115,19 @@ func (h *MCPHandler) generateMCPEntry(serverDir string) map[string]any {
 	return entry
 }
 
+// generateRemoteMCPEntry builds a VS Code mcp.json entry for a remote (sse/http)
+// MCP server. VS Code requires an explicit "type" on every server and connects
+// to the given URL directly. Env is not written: per the VS Code MCP config
+// reference, env applies only to stdio servers — remote servers authenticate via
+// "headers", which sx metadata has no analogue for, so env vars on a remote MCP
+// are dropped rather than written into an unrecognized field.
+func (h *MCPHandler) generateRemoteMCPEntry() map[string]any {
+	return map[string]any{
+		"type": h.metadata.MCP.Transport,
+		"url":  h.metadata.MCP.URL,
+	}
+}
+
 func (h *MCPHandler) generateConfigOnlyMCPEntry() map[string]any {
 	mcpConfig := h.metadata.MCP
 
@@ -170,9 +187,24 @@ func writeMCPConfig(path string, config *mcpConfig) error {
 	return os.WriteFile(path, data, 0644)
 }
 
-// VerifyInstalled checks if the MCP server is properly installed
+// VerifyInstalled checks if the MCP server is properly installed. Packaged
+// servers are verified through their extracted directory; config-only and
+// remote servers have no directory, so fall back to checking for the server's
+// entry in mcp.json.
 func (h *MCPHandler) VerifyInstalled(targetBase string) (bool, string) {
-	return mcpOps.VerifyInstalled(targetBase, h.metadata.Asset.Name, h.metadata.Asset.Version)
+	serverDir := filepath.Join(targetBase, DirMCPServers, h.metadata.Asset.Name)
+	if utils.IsDirectory(serverDir) {
+		return mcpOps.VerifyInstalled(targetBase, h.metadata.Asset.Name, h.metadata.Asset.Version)
+	}
+
+	config, err := readMCPConfig(filepath.Join(targetBase, "mcp.json"))
+	if err != nil {
+		return false, "failed to read mcp.json: " + err.Error()
+	}
+	if _, exists := config.Servers[h.metadata.Asset.Name]; exists {
+		return true, "registered in mcp.json"
+	}
+	return false, "not found in mcp.json"
 }
 
 // AddMCPServer adds an MCP server entry to .vscode/mcp.json

--- a/internal/clients/github_copilot/handlers/mcp.go
+++ b/internal/clients/github_copilot/handlers/mcp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/handlers/dirasset"
@@ -36,26 +37,27 @@ func (h *MCPHandler) Install(ctx context.Context, zipData []byte, targetBase str
 		return fmt.Errorf("failed to read mcp.json: %w", err)
 	}
 
-	hasContent, err := utils.HasContentFiles(zipData)
-	if err != nil {
-		return fmt.Errorf("failed to inspect zip contents: %w", err)
-	}
-
 	var entry map[string]any
-	switch {
-	case h.metadata.MCP != nil && h.metadata.MCP.IsRemote():
+	if h.metadata.MCP != nil && h.metadata.MCP.IsRemote() {
 		// Remote mode: nothing runs locally, so never extract — just register the URL
 		entry = h.generateRemoteMCPEntry()
-	case hasContent:
-		// Packaged mode: extract MCP server files to .vscode/mcp-servers/{name}/
-		serverDir := filepath.Join(targetBase, DirMCPServers, h.metadata.Asset.Name)
-		if err := utils.ExtractZip(zipData, serverDir); err != nil {
-			return fmt.Errorf("failed to extract MCP server: %w", err)
+	} else {
+		hasContent, err := utils.HasContentFiles(zipData)
+		if err != nil {
+			return fmt.Errorf("failed to inspect zip contents: %w", err)
 		}
-		entry = h.generateMCPEntry(serverDir)
-	default:
-		// Config-only mode: no extraction, register commands as-is
-		entry = h.generateConfigOnlyMCPEntry()
+
+		if hasContent {
+			// Packaged mode: extract MCP server files to .vscode/mcp-servers/{name}/
+			serverDir := filepath.Join(targetBase, DirMCPServers, h.metadata.Asset.Name)
+			if err := utils.ExtractZip(zipData, serverDir); err != nil {
+				return fmt.Errorf("failed to extract MCP server: %w", err)
+			}
+			entry = h.generateMCPEntry(serverDir)
+		} else {
+			// Config-only mode: no extraction, register commands as-is
+			entry = h.generateConfigOnlyMCPEntry()
+		}
 	}
 
 	// Add to config
@@ -201,10 +203,36 @@ func (h *MCPHandler) VerifyInstalled(targetBase string) (bool, string) {
 	if err != nil {
 		return false, "failed to read mcp.json: " + err.Error()
 	}
-	if _, exists := config.Servers[h.metadata.Asset.Name]; exists {
-		return true, "registered in mcp.json"
+	entry, exists := config.Servers[h.metadata.Asset.Name].(map[string]any)
+	if !exists {
+		return false, "not found in mcp.json"
 	}
-	return false, "not found in mcp.json"
+	// Verification runs with minimal lockfile metadata (no [mcp] section), so
+	// packaged vs config-only can't be told apart from metadata. A packaged
+	// entry references absolute paths under the extracted server directory;
+	// if it points at the missing directory the install is broken and needs
+	// repair rather than being reported healthy.
+	if entryReferencesDir(entry, serverDir) {
+		return false, "server directory missing"
+	}
+	return true, "registered in mcp.json"
+}
+
+// entryReferencesDir reports whether an mcp.json entry's command or args
+// reference files under dir.
+func entryReferencesDir(entry map[string]any, dir string) bool {
+	prefix := dir + string(os.PathSeparator)
+	if cmd, ok := entry["command"].(string); ok && strings.HasPrefix(cmd, prefix) {
+		return true
+	}
+	if args, ok := entry["args"].([]any); ok {
+		for _, arg := range args {
+			if s, ok := arg.(string); ok && strings.HasPrefix(s, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // AddMCPServer adds an MCP server entry to .vscode/mcp.json

--- a/internal/clients/github_copilot/handlers/mcp.go
+++ b/internal/clients/github_copilot/handlers/mcp.go
@@ -226,15 +226,18 @@ func (h *MCPHandler) generateConfigOnlyMCPEntry() map[string]any {
 	return entry
 }
 
-// mcpConfig represents VS Code's .vscode/mcp.json structure
+// mcpConfig represents VS Code's .vscode/mcp.json structure. Extra holds any
+// other top-level keys (e.g. "inputs") so rewrites don't drop them.
 type mcpConfig struct {
-	Servers map[string]any `json:"servers"`
+	Servers map[string]any
+	Extra   map[string]any
 }
 
 // readMCPConfig reads VS Code's mcp.json file
 func readMCPConfig(path string) (*mcpConfig, error) {
 	config := &mcpConfig{
 		Servers: make(map[string]any),
+		Extra:   make(map[string]any),
 	}
 
 	data, err := os.ReadFile(path)
@@ -245,9 +248,15 @@ func readMCPConfig(path string) (*mcpConfig, error) {
 		return nil, err
 	}
 
-	if err := utils.UnmarshalJSONC(data, config); err != nil {
+	doc := make(map[string]any)
+	if err := utils.UnmarshalJSONC(data, &doc); err != nil {
 		return nil, err
 	}
+	if servers, ok := doc["servers"].(map[string]any); ok {
+		config.Servers = servers
+	}
+	delete(doc, "servers")
+	config.Extra = doc
 
 	return config, nil
 }
@@ -259,7 +268,11 @@ func writeMCPConfig(path string, config *mcpConfig) error {
 		return err
 	}
 
-	data, err := json.MarshalIndent(config, "", "  ")
+	doc := make(map[string]any, len(config.Extra)+1)
+	maps.Copy(doc, config.Extra)
+	doc["servers"] = config.Servers
+
+	data, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -388,9 +401,12 @@ func RemoveMCPServer(vscodeDir, name string) error {
 	return nil
 }
 
-// copilotCLIMCPConfig represents Copilot CLI's ~/.copilot/mcp-config.json structure
+// copilotCLIMCPConfig represents Copilot CLI's ~/.copilot/mcp-config.json
+// structure (also used for the repo-level .github/mcp.json mirror). Extra
+// holds any other top-level keys so rewrites don't drop them.
 type copilotCLIMCPConfig struct {
-	MCPServers map[string]any `json:"mcpServers"`
+	MCPServers map[string]any
+	Extra      map[string]any
 }
 
 // AddCopilotCLIMCPServer adds an MCP server entry to ~/.copilot/mcp-config.json
@@ -451,6 +467,7 @@ func RemoveCopilotCLIMCPServer(copilotDir, name string) error {
 func readCopilotCLIMCPConfig(path string) (*copilotCLIMCPConfig, error) {
 	config := &copilotCLIMCPConfig{
 		MCPServers: make(map[string]any),
+		Extra:      make(map[string]any),
 	}
 
 	data, err := os.ReadFile(path)
@@ -461,9 +478,15 @@ func readCopilotCLIMCPConfig(path string) (*copilotCLIMCPConfig, error) {
 		return nil, err
 	}
 
-	if err := utils.UnmarshalJSONC(data, config); err != nil {
+	doc := make(map[string]any)
+	if err := utils.UnmarshalJSONC(data, &doc); err != nil {
 		return nil, err
 	}
+	if servers, ok := doc["mcpServers"].(map[string]any); ok {
+		config.MCPServers = servers
+	}
+	delete(doc, "mcpServers")
+	config.Extra = doc
 
 	return config, nil
 }
@@ -475,7 +498,11 @@ func writeCopilotCLIMCPConfig(path string, config *copilotCLIMCPConfig) error {
 		return err
 	}
 
-	data, err := json.MarshalIndent(config, "", "  ")
+	doc := make(map[string]any, len(config.Extra)+1)
+	maps.Copy(doc, config.Extra)
+	doc["mcpServers"] = config.MCPServers
+
+	data, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/clients/github_copilot/handlers/mcp.go
+++ b/internal/clients/github_copilot/handlers/mcp.go
@@ -25,6 +25,12 @@ type MCPHandler struct {
 	// (~/.copilot/mcp-config.json for global scope, {repoRoot}/.github/mcp.json
 	// for repo/path scopes). Empty disables the CLI mirror.
 	CLIConfigPath string
+
+	// CLIConfigShared marks CLIConfigPath as a shared, typically committed file
+	// ({repoRoot}/.github/mcp.json). Packaged servers are not mirrored there:
+	// their entries carry machine-absolute paths under .vscode/mcp-servers/
+	// that won't resolve on teammates' machines.
+	CLIConfigShared bool
 }
 
 // NewMCPHandler creates a new MCP handler
@@ -44,6 +50,7 @@ func (h *MCPHandler) Install(ctx context.Context, zipData []byte, targetBase str
 	}
 
 	var entry map[string]any
+	packaged := false
 	if h.metadata.MCP != nil && h.metadata.MCP.IsRemote() {
 		// Remote mode: nothing runs locally, so never extract — just register the URL
 		entry = h.generateRemoteMCPEntry()
@@ -55,6 +62,7 @@ func (h *MCPHandler) Install(ctx context.Context, zipData []byte, targetBase str
 
 		if hasContent {
 			// Packaged mode: extract MCP server files to .vscode/mcp-servers/{name}/
+			packaged = true
 			serverDir := filepath.Join(targetBase, DirMCPServers, h.metadata.Asset.Name)
 			if err := utils.ExtractZip(zipData, serverDir); err != nil {
 				return fmt.Errorf("failed to extract MCP server: %w", err)
@@ -79,13 +87,23 @@ func (h *MCPHandler) Install(ctx context.Context, zipData []byte, targetBase str
 
 	// Mirror the entry into the Copilot CLI config so the asset also works in
 	// `copilot` sessions, which don't read VS Code's user-level mcp.json.
-	if h.CLIConfigPath != "" {
+	if h.shouldMirrorToCLI(packaged) {
 		if err := setCLIMCPServer(h.CLIConfigPath, h.metadata.Asset.Name, cliMCPEntry(entry)); err != nil {
 			return fmt.Errorf("failed to update Copilot CLI MCP config: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// shouldMirrorToCLI reports whether an entry belongs in the Copilot CLI config.
+// Packaged entries reference machine-absolute paths and are kept out of shared
+// (committed) config files; remote and config-only entries are portable.
+func (h *MCPHandler) shouldMirrorToCLI(packaged bool) bool {
+	if h.CLIConfigPath == "" {
+		return false
+	}
+	return !packaged || !h.CLIConfigShared
 }
 
 // Remove removes an MCP entry from VS Code
@@ -252,11 +270,19 @@ func writeMCPConfig(path string, config *mcpConfig) error {
 // VerifyInstalled checks if the MCP server is properly installed. Packaged
 // servers are verified through their extracted directory; config-only and
 // remote servers have no directory, so fall back to checking for the server's
-// entry in mcp.json.
+// entry in mcp.json. When a Copilot CLI mirror is expected, its entry must
+// also be present so --repair rewrites a broken CLI config.
 func (h *MCPHandler) VerifyInstalled(targetBase string) (bool, string) {
 	serverDir := filepath.Join(targetBase, DirMCPServers, h.metadata.Asset.Name)
 	if utils.IsDirectory(serverDir) {
-		return mcpOps.VerifyInstalled(targetBase, h.metadata.Asset.Name, h.metadata.Asset.Version)
+		installed, msg := mcpOps.VerifyInstalled(targetBase, h.metadata.Asset.Name, h.metadata.Asset.Version)
+		if !installed {
+			return installed, msg
+		}
+		if h.shouldMirrorToCLI(true) && !cliEntryExists(h.CLIConfigPath, h.metadata.Asset.Name) {
+			return false, "missing from Copilot CLI config"
+		}
+		return installed, msg
 	}
 
 	config, err := readMCPConfig(filepath.Join(targetBase, "mcp.json"))
@@ -275,7 +301,20 @@ func (h *MCPHandler) VerifyInstalled(targetBase string) (bool, string) {
 	if entryReferencesDir(entry, serverDir) {
 		return false, "server directory missing"
 	}
+	if h.shouldMirrorToCLI(false) && !cliEntryExists(h.CLIConfigPath, h.metadata.Asset.Name) {
+		return false, "missing from Copilot CLI config"
+	}
 	return true, "registered in mcp.json"
+}
+
+// cliEntryExists reports whether a Copilot CLI config file has an entry for name
+func cliEntryExists(configPath, name string) bool {
+	config, err := readCopilotCLIMCPConfig(configPath)
+	if err != nil {
+		return false
+	}
+	_, exists := config.MCPServers[name]
+	return exists
 }
 
 // entryReferencesDir reports whether an mcp.json entry's command or args

--- a/internal/clients/github_copilot/handlers/mcp_test.go
+++ b/internal/clients/github_copilot/handlers/mcp_test.go
@@ -309,3 +309,49 @@ args = ["-y", "some-server"]
 		t.Errorf("config-only MCP should verify as installed, got: %s", msg)
 	}
 }
+
+func TestCopilotMCPHandler_VerifyInstalled_PackagedDirDeleted(t *testing.T) {
+	// A packaged server whose extracted directory was deleted but whose
+	// mcp.json entry survives is broken (the entry points into the missing
+	// directory) and must not verify as installed, so --repair re-extracts it.
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "packaged", Version: "1.0.0", Type: asset.TypeMCP},
+		MCP: &metadata.MCPConfig{
+			Command: "node",
+			Args:    []string{"index.js"},
+		},
+	}
+	zipData := createTestZip(t, map[string]string{
+		"metadata.toml": `[asset]
+name = "packaged"
+version = "1.0.0"
+type = "mcp"
+
+[mcp]
+command = "node"
+args = ["index.js"]
+`,
+		"index.js": "console.log('hi')",
+	})
+
+	handler := NewMCPHandler(meta)
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	installed, msg := handler.VerifyInstalled(targetBase)
+	if !installed {
+		t.Fatalf("packaged MCP should verify as installed, got: %s", msg)
+	}
+
+	serverDir := filepath.Join(targetBase, DirMCPServers, "packaged")
+	if err := os.RemoveAll(serverDir); err != nil {
+		t.Fatalf("Failed to delete server dir: %v", err)
+	}
+
+	installed, msg = handler.VerifyInstalled(targetBase)
+	if installed {
+		t.Errorf("packaged MCP with deleted directory should not verify as installed, got: %s", msg)
+	}
+}

--- a/internal/clients/github_copilot/handlers/mcp_test.go
+++ b/internal/clients/github_copilot/handlers/mcp_test.go
@@ -598,3 +598,57 @@ func TestCopilotMCPHandler_VerifyInstalled_MissingCLIMirror(t *testing.T) {
 		t.Error("missing CLI mirror entry should fail verification")
 	}
 }
+
+func TestCopilotMCPHandler_PreservesUnknownTopLevelKeys(t *testing.T) {
+	// VS Code's mcp.json supports sibling keys like "inputs" (prompted
+	// secrets); rewrites must not drop them. Same for the CLI config.
+	targetBase := t.TempDir()
+	cliConfigPath := filepath.Join(t.TempDir(), "mcp-config.json")
+	if err := os.MkdirAll(targetBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	vscodeSeed := `{
+  "inputs": [{"id": "api-key", "type": "promptString", "password": true}],
+  "servers": {}
+}`
+	if err := os.WriteFile(filepath.Join(targetBase, "mcp.json"), []byte(vscodeSeed), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cliSeed := `{
+  "customSetting": {"foo": "bar"},
+  "mcpServers": {}
+}`
+	if err := os.WriteFile(cliConfigPath, []byte(cliSeed), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := remoteMCPMeta("keys-test", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "keys-test", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	vscodeData, _ := os.ReadFile(filepath.Join(targetBase, "mcp.json"))
+	var vscodeDoc map[string]any
+	if err := json.Unmarshal(vscodeData, &vscodeDoc); err != nil {
+		t.Fatalf("Failed to parse mcp.json: %v", err)
+	}
+	if _, ok := vscodeDoc["inputs"]; !ok {
+		t.Errorf("mcp.json should preserve the inputs key across install/remove, got: %s", vscodeData)
+	}
+
+	cliData, _ := os.ReadFile(cliConfigPath)
+	var cliDoc map[string]any
+	if err := json.Unmarshal(cliData, &cliDoc); err != nil {
+		t.Fatalf("Failed to parse CLI config: %v", err)
+	}
+	if _, ok := cliDoc["customSetting"]; !ok {
+		t.Errorf("CLI config should preserve unknown top-level keys, got: %s", cliData)
+	}
+}

--- a/internal/clients/github_copilot/handlers/mcp_test.go
+++ b/internal/clients/github_copilot/handlers/mcp_test.go
@@ -1,6 +1,10 @@
 package handlers
 
 import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +12,71 @@ import (
 	"github.com/sleuth-io/sx/internal/asset"
 	"github.com/sleuth-io/sx/internal/metadata"
 )
+
+func createTestZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	for name, content := range files {
+		f, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("Failed to create zip entry %q: %v", name, err)
+		}
+		if _, err := f.Write([]byte(content)); err != nil {
+			t.Fatalf("Failed to write zip entry %q: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Failed to close zip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func remoteMCPMeta(name, transport, url string) *metadata.Metadata {
+	return &metadata.Metadata{
+		Asset: metadata.Asset{Name: name, Version: "1.0.0", Type: asset.TypeMCP},
+		MCP: &metadata.MCPConfig{
+			Transport: transport,
+			URL:       url,
+		},
+	}
+}
+
+func remoteMCPZip(t *testing.T, name, transport, url string) []byte {
+	t.Helper()
+	return createTestZip(t, map[string]string{
+		"metadata.toml": `[asset]
+name = "` + name + `"
+version = "1.0.0"
+type = "mcp"
+
+[mcp]
+transport = "` + transport + `"
+url = "` + url + `"
+`,
+	})
+}
+
+func readServerEntry(t *testing.T, targetBase, name string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(targetBase, "mcp.json"))
+	if err != nil {
+		t.Fatalf("Failed to read mcp.json: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse mcp.json: %v", err)
+	}
+	servers, ok := config["servers"].(map[string]any)
+	if !ok {
+		t.Fatalf("servers key not found in mcp.json, got: %s", data)
+	}
+	entry, ok := servers[name].(map[string]any)
+	if !ok {
+		t.Fatalf("server %q not found in mcp.json, got: %s", name, data)
+	}
+	return entry
+}
 
 func TestCopilotMCPHandler_Packaged_SubcommandArgs(t *testing.T) {
 	// When args contain a mix of subcommands (e.g. "run") and actual files (e.g. "server.py"),
@@ -79,5 +148,164 @@ func TestCopilotMCPHandler_Packaged_BareCommand(t *testing.T) {
 	expectedPath := filepath.Join(installPath, "src/index.js")
 	if args[0] != expectedPath {
 		t.Errorf("arg[0] = %q, want %q", args[0], expectedPath)
+	}
+}
+
+func TestCopilotMCPHandler_Remote_HTTPInstall(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := remoteMCPMeta("remote-http", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "remote-http", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	entry := readServerEntry(t, targetBase, "remote-http")
+	if entry["type"] != "http" {
+		t.Errorf("type = %v, want \"http\"", entry["type"])
+	}
+	if entry["url"] != "https://example.com/mcp" {
+		t.Errorf("url = %v, want \"https://example.com/mcp\"", entry["url"])
+	}
+	if _, hasCommand := entry["command"]; hasCommand {
+		t.Error("remote MCP entry should not have a command field")
+	}
+
+	// Remote servers run nothing locally — no extraction
+	serverDir := filepath.Join(targetBase, DirMCPServers, "remote-http")
+	if _, err := os.Stat(serverDir); !os.IsNotExist(err) {
+		t.Errorf("remote MCP should not extract a server directory, found %s", serverDir)
+	}
+}
+
+func TestCopilotMCPHandler_Remote_SSEInstall(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := remoteMCPMeta("remote-sse", "sse", "https://example.com/mcp/sse")
+	zipData := remoteMCPZip(t, "remote-sse", "sse", "https://example.com/mcp/sse")
+
+	handler := NewMCPHandler(meta)
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	entry := readServerEntry(t, targetBase, "remote-sse")
+	if entry["type"] != "sse" {
+		t.Errorf("type = %v, want \"sse\"", entry["type"])
+	}
+	if entry["url"] != "https://example.com/mcp/sse" {
+		t.Errorf("url = %v, want \"https://example.com/mcp/sse\"", entry["url"])
+	}
+}
+
+func TestCopilotMCPHandler_Remote_EnvNotWritten(t *testing.T) {
+	// VS Code's mcp.json only supports env on stdio servers; remote servers
+	// authenticate via headers, so env must not leak into the remote entry.
+	targetBase := t.TempDir()
+	meta := remoteMCPMeta("remote-env", "http", "https://example.com/mcp")
+	meta.MCP.Env = map[string]string{"API_KEY": "secret"}
+	zipData := remoteMCPZip(t, "remote-env", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	entry := readServerEntry(t, targetBase, "remote-env")
+	if _, hasEnv := entry["env"]; hasEnv {
+		t.Errorf("remote MCP entry should not have an env field, got: %v", entry)
+	}
+}
+
+func TestCopilotMCPHandler_Remote_Remove(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := remoteMCPMeta("remote-rm", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "remote-rm", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(targetBase, "mcp.json"))
+	if err != nil {
+		t.Fatalf("Failed to read mcp.json: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse mcp.json: %v", err)
+	}
+	servers, _ := config["servers"].(map[string]any)
+	if _, exists := servers["remote-rm"]; exists {
+		t.Errorf("mcp.json should not contain remote-rm after remove, got: %s", data)
+	}
+}
+
+func TestCopilotMCPHandler_VerifyInstalled_Remote(t *testing.T) {
+	targetBase := t.TempDir()
+	meta := remoteMCPMeta("remote-verify", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "remote-verify", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+
+	installed, _ := handler.VerifyInstalled(targetBase)
+	if installed {
+		t.Error("should not be installed before install")
+	}
+
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	installed, msg := handler.VerifyInstalled(targetBase)
+	if !installed {
+		t.Errorf("should be installed after install, got: %s", msg)
+	}
+
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	installed, _ = handler.VerifyInstalled(targetBase)
+	if installed {
+		t.Error("should not be installed after remove")
+	}
+}
+
+func TestCopilotMCPHandler_VerifyInstalled_ConfigOnly(t *testing.T) {
+	// Config-only stdio servers (external commands like npx) also have no
+	// extracted directory; verification falls back to the mcp.json entry.
+	targetBase := t.TempDir()
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "config-only", Version: "1.0.0", Type: asset.TypeMCP},
+		MCP: &metadata.MCPConfig{
+			Command: "npx",
+			Args:    []string{"-y", "some-server"},
+		},
+	}
+	zipData := createTestZip(t, map[string]string{
+		"metadata.toml": `[asset]
+name = "config-only"
+version = "1.0.0"
+type = "mcp"
+
+[mcp]
+command = "npx"
+args = ["-y", "some-server"]
+`,
+	})
+
+	handler := NewMCPHandler(meta)
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	installed, msg := handler.VerifyInstalled(targetBase)
+	if !installed {
+		t.Errorf("config-only MCP should verify as installed, got: %s", msg)
 	}
 }

--- a/internal/clients/github_copilot/handlers/mcp_test.go
+++ b/internal/clients/github_copilot/handlers/mcp_test.go
@@ -527,3 +527,74 @@ func TestCopilotMCPHandler_CLIMirror_PreservesOtherEntries(t *testing.T) {
 		t.Errorf("new CLI entry should be written, got: %v", entry)
 	}
 }
+
+func TestCopilotMCPHandler_Packaged_NotMirroredToSharedCLIConfig(t *testing.T) {
+	// Packaged entries carry machine-absolute paths and must stay out of the
+	// shared (committed) .github/mcp.json; portable entries still mirror.
+	targetBase := t.TempDir()
+	cliConfigPath := filepath.Join(t.TempDir(), "mcp.json")
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "packaged-shared", Version: "1.0.0", Type: asset.TypeMCP},
+		MCP: &metadata.MCPConfig{
+			Command: "node",
+			Args:    []string{"index.js"},
+		},
+	}
+	zipData := createTestZip(t, map[string]string{
+		"metadata.toml": `[asset]
+name = "packaged-shared"
+version = "1.0.0"
+type = "mcp"
+
+[mcp]
+command = "node"
+args = ["index.js"]
+`,
+		"index.js": "console.log('hi')",
+	})
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	handler.CLIConfigShared = true
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	if _, err := os.Stat(cliConfigPath); !os.IsNotExist(err) {
+		t.Errorf("packaged server should not be mirrored into a shared CLI config")
+	}
+
+	// Verification must not demand the skipped mirror
+	installed, msg := handler.VerifyInstalled(targetBase)
+	if !installed {
+		t.Errorf("packaged server without shared mirror should verify as installed, got: %s", msg)
+	}
+}
+
+func TestCopilotMCPHandler_VerifyInstalled_MissingCLIMirror(t *testing.T) {
+	// A deleted CLI mirror entry must fail verification so --repair rewrites it.
+	targetBase := t.TempDir()
+	cliConfigPath := filepath.Join(t.TempDir(), "mcp-config.json")
+	meta := remoteMCPMeta("remote-cli-verify", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "remote-cli-verify", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	installed, msg := handler.VerifyInstalled(targetBase)
+	if !installed {
+		t.Fatalf("should verify as installed with both configs present, got: %s", msg)
+	}
+
+	if err := os.Remove(cliConfigPath); err != nil {
+		t.Fatalf("Failed to delete CLI config: %v", err)
+	}
+
+	installed, _ = handler.VerifyInstalled(targetBase)
+	if installed {
+		t.Error("missing CLI mirror entry should fail verification")
+	}
+}

--- a/internal/clients/github_copilot/handlers/mcp_test.go
+++ b/internal/clients/github_copilot/handlers/mcp_test.go
@@ -355,3 +355,175 @@ args = ["index.js"]
 		t.Errorf("packaged MCP with deleted directory should not verify as installed, got: %s", msg)
 	}
 }
+
+func readCLIServerEntry(t *testing.T, configPath, name string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read CLI config %s: %v", configPath, err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse CLI config: %v", err)
+	}
+	servers, ok := config["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers key not found in CLI config, got: %s", data)
+	}
+	entry, ok := servers[name].(map[string]any)
+	if !ok {
+		t.Fatalf("server %q not found in CLI config, got: %s", name, data)
+	}
+	return entry
+}
+
+func TestCopilotMCPHandler_Remote_CLIMirror(t *testing.T) {
+	targetBase := t.TempDir()
+	cliConfigPath := filepath.Join(t.TempDir(), "mcp-config.json")
+	meta := remoteMCPMeta("remote-cli", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "remote-cli", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	entry := readCLIServerEntry(t, cliConfigPath, "remote-cli")
+	if entry["type"] != "http" {
+		t.Errorf("CLI entry type = %v, want \"http\"", entry["type"])
+	}
+	if entry["url"] != "https://example.com/mcp" {
+		t.Errorf("CLI entry url = %v, want \"https://example.com/mcp\"", entry["url"])
+	}
+
+	// VS Code mcp.json is still written alongside
+	vscodeEntry := readServerEntry(t, targetBase, "remote-cli")
+	if vscodeEntry["url"] != "https://example.com/mcp" {
+		t.Errorf("VS Code entry url = %v, want \"https://example.com/mcp\"", vscodeEntry["url"])
+	}
+}
+
+func TestCopilotMCPHandler_Stdio_CLIMirrorAddsType(t *testing.T) {
+	// VS Code stdio entries omit "type"; the Copilot CLI requires it.
+	targetBase := t.TempDir()
+	cliConfigPath := filepath.Join(t.TempDir(), "mcp-config.json")
+	meta := &metadata.Metadata{
+		Asset: metadata.Asset{Name: "stdio-cli", Version: "1.0.0", Type: asset.TypeMCP},
+		MCP: &metadata.MCPConfig{
+			Command: "npx",
+			Args:    []string{"-y", "some-server"},
+			Env:     map[string]string{"API_KEY": "secret"},
+		},
+	}
+	zipData := createTestZip(t, map[string]string{
+		"metadata.toml": `[asset]
+name = "stdio-cli"
+version = "1.0.0"
+type = "mcp"
+
+[mcp]
+command = "npx"
+args = ["-y", "some-server"]
+`,
+	})
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	entry := readCLIServerEntry(t, cliConfigPath, "stdio-cli")
+	if entry["type"] != "stdio" {
+		t.Errorf("CLI entry type = %v, want \"stdio\"", entry["type"])
+	}
+	if entry["command"] != "npx" {
+		t.Errorf("CLI entry command = %v, want \"npx\"", entry["command"])
+	}
+
+	// The VS Code entry keeps its existing shape without a type field
+	vscodeEntry := readServerEntry(t, targetBase, "stdio-cli")
+	if _, hasType := vscodeEntry["type"]; hasType {
+		t.Errorf("VS Code stdio entry should not gain a type field, got: %v", vscodeEntry)
+	}
+}
+
+func TestCopilotMCPHandler_Remove_CLIMirror(t *testing.T) {
+	targetBase := t.TempDir()
+	cliDir := t.TempDir()
+	cliConfigPath := filepath.Join(cliDir, "mcp-config.json")
+	meta := remoteMCPMeta("remote-rm-cli", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "remote-rm-cli", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	data, err := os.ReadFile(cliConfigPath)
+	if err != nil {
+		t.Fatalf("Failed to read CLI config: %v", err)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse CLI config: %v", err)
+	}
+	servers, _ := config["mcpServers"].(map[string]any)
+	if _, exists := servers["remote-rm-cli"]; exists {
+		t.Errorf("CLI config should not contain remote-rm-cli after remove, got: %s", data)
+	}
+}
+
+func TestCopilotMCPHandler_Remove_NoCLIConfigNoop(t *testing.T) {
+	// Removing an asset that was never mirrored must not materialize the CLI config
+	targetBase := t.TempDir()
+	cliConfigPath := filepath.Join(t.TempDir(), "mcp.json")
+	meta := remoteMCPMeta("never-mirrored", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	if err := handler.Remove(context.Background(), targetBase); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := os.Stat(cliConfigPath); !os.IsNotExist(err) {
+		t.Errorf("CLI config should not be created by a no-op remove")
+	}
+}
+
+func TestCopilotMCPHandler_CLIMirror_PreservesOtherEntries(t *testing.T) {
+	// Installing must not clobber pre-existing entries (e.g. user-added servers
+	// or the sx bootstrap query server) in the CLI config.
+	targetBase := t.TempDir()
+	cliDir := t.TempDir()
+	cliConfigPath := filepath.Join(cliDir, "mcp-config.json")
+	existing := `{
+  "mcpServers": {
+    "user-server": {"type": "stdio", "command": "my-tool"}
+  }
+}`
+	if err := os.WriteFile(cliConfigPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("Failed to seed CLI config: %v", err)
+	}
+
+	meta := remoteMCPMeta("added-later", "http", "https://example.com/mcp")
+	zipData := remoteMCPZip(t, "added-later", "http", "https://example.com/mcp")
+
+	handler := NewMCPHandler(meta)
+	handler.CLIConfigPath = cliConfigPath
+	if err := handler.Install(context.Background(), zipData, targetBase); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	if entry := readCLIServerEntry(t, cliConfigPath, "user-server"); entry["command"] != "my-tool" {
+		t.Errorf("pre-existing CLI entry should be preserved, got: %v", entry)
+	}
+	if entry := readCLIServerEntry(t, cliConfigPath, "added-later"); entry["url"] != "https://example.com/mcp" {
+		t.Errorf("new CLI entry should be written, got: %v", entry)
+	}
+}


### PR DESCRIPTION
## Summary
- Remove the install-time skip that reported "Remote MCP (sse/http) not supported" for GitHub Copilot (fixes #201)
- Write remote MCP assets to `.vscode/mcp.json` as `{"type": "http"|"sse", "url": ...}` per the VS Code MCP configuration reference; no extraction since nothing runs locally
- Mirror all MCP assets (stdio and remote) into the Copilot CLI config so they work in `copilot` sessions too: `~/.copilot/mcp-config.json` for global scope, `{repoRoot}/.github/mcp.json` for repo/path scopes (both use the `mcpServers` key; CLI entries carry an explicit `type`)
- Root `.mcp.json` is deliberately not used for the CLI mirror — the Claude Code client manages that file
- Env vars are intentionally not written on remote entries — VS Code only supports `env` on stdio servers; remote servers authenticate via `headers`, which sx metadata does not model yet
- Fix `VerifyInstalled` for config-only and remote MCP servers: they have no extracted `mcp-servers/{name}/` directory, so verification now falls back to checking the `mcp.json` entry (and detects packaged entries pointing at a deleted directory so `--repair` still re-extracts them)

**Security implications of changes have been considered**