### PR TITLE
Harden the release path and add community docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Something in sx does not work the way it should
+title: ''
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+## What you expected
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Command and output
+
+```
+$ sx ...
+
+```
+
+## Environment
+
+- `sx --version`:
+- OS and architecture:
+- Installed via: (install.sh / Homebrew / built from source)
+
+## Notes
+
+<!--
+Not a bug report channel: security vulnerabilities. Please report those
+privately — see SECURITY.md. Redact any tokens before pasting output.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/sleuth-io/sx/security/advisories/new
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a capability or change to sx
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## The problem
+
+<!-- What are you trying to do that sx makes hard or impossible today? -->
+
+## What you'd like
+
+## Alternatives you've considered
+
+<!-- Including "I worked around it by ..." — that's useful signal. -->
+
+## Additional context

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Go modules were not covered, so dependency updates only ever arrived as
+  # security alerts. Weekly grouped PRs keep the module graph current instead.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What changed and why. If the reasoning isn't obvious from the diff, put it here. -->
+
+## Testing
+
+- [ ] `make prepush`
+
+<!-- How did you verify this? Command output is welcome. -->
+
+## Notes
+
+<!-- Breaking changes, follow-ups, anything a reviewer should know. -->

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -5,7 +5,48 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  # Pull requests from forks run without repository secrets, and forks of a
+  # public repo have no Anthropic credential of their own. Decide up front
+  # whether the review can run so those PRs skip cleanly instead of failing.
+  guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      review: ${{ steps.check.outputs.review }}
+      skills: ${{ steps.check.outputs.skills }}
+    env:
+      HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+      HAS_SKILLS_KEY: ${{ secrets.SKILLS_SITE_API_KEY != '' }}
+      IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+    steps:
+      - id: check
+        run: |
+          if [ "$IS_FORK" = "true" ]; then
+            echo "Skipping Claude review: pull request is from a fork, so repository secrets are unavailable."
+            echo "review=false" >> "$GITHUB_OUTPUT"
+            echo "skills=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$HAS_ANTHROPIC_KEY" != "true" ]; then
+            echo "Skipping Claude review: ANTHROPIC_API_KEY is not configured."
+            echo "review=false" >> "$GITHUB_OUTPUT"
+            echo "skills=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "review=true" >> "$GITHUB_OUTPUT"
+          # Skills are a bonus. Without a vault key the review still runs
+          # against the repo's own standards.
+          if [ "$HAS_SKILLS_KEY" = "true" ]; then
+            echo "skills=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skills vault key is not configured; reviewing without installed skills."
+            echo "skills=false" >> "$GITHUB_OUTPUT"
+          fi
+
   review:
+    needs: guard
+    if: needs.guard.outputs.review == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,12 +68,14 @@ jobs:
         run: make build
 
       - name: Setup sx config
+        if: needs.guard.outputs.skills == 'true'
         run: |
           mkdir -p $HOME/.config/sx
           mkdir -p $HOME/.claude
           printf '%s\n' '{' '  "type": "sleuth",' '  "repositoryUrl": "https://app.skills.new",' '  "authToken": "${{ secrets.SKILLS_SITE_API_KEY }}"' '}' > $HOME/.config/sx/config.json
 
       - name: Install skills
+        if: needs.guard.outputs.skills == 'true'
         run: ./dist/sx install
 
       - name: Discover installed Claude skills

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
     name: Release
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Required to mint the build provenance attestation below.
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -61,3 +66,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      # Sign a provenance statement for the published archives so anyone can
+      # verify they were built by this workflow, from this repository, at this
+      # commit:
+      #
+      #   gh attestation verify sx_Darwin_arm64.tar.gz --repo sleuth-io/sx
+      #
+      # install.sh already checks the release checksums; attestation is the
+      # stronger claim, tying the artifact to its build rather than to a hash
+      # file published alongside it.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "dist/*.tar.gz,dist/*.zip"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,7 +72,7 @@ brews:
   - name: sx
     homepage: https://github.com/sleuth-io/sx
     description: "Your team's private npm for AI assets - skills, MCP configs, commands, and more"
-    license: MIT
+    license: Apache-2.0
     repository:
       owner: sleuth-io
       name: homebrew-tap

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code Of Conduct
+
+sx should be a practical and respectful project space.
+
+Expected behavior:
+
+- Be direct and constructive.
+- Assume good intent while still being precise about technical risk.
+- Keep discussions focused on the issue or pull request.
+- Avoid harassment, threats, personal attacks, or disclosure of private
+  information.
+
+Maintainers may moderate issues, pull requests, discussions, or access for
+behavior that makes the project unsafe or unproductive.
+
+Report conduct concerns privately to the maintainers listed in
+[.github/CODEOWNERS](.github/CODEOWNERS).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing To sx
+
+Pull requests are welcome. Keep changes focused, add or update tests for
+behavior changes, and update docs when a command's behavior or setup changes.
+
+## Development Setup
+
+You need Go (see the version in `go.mod`) and `make`.
+
+```bash
+git clone https://github.com/sleuth-io/sx.git
+cd sx
+make init          # download dependencies
+make build         # build to ./dist/sx
+```
+
+Run your build directly:
+
+```bash
+./dist/sx <command>
+```
+
+## Before Opening A Pull Request
+
+```bash
+make prepush       # format, lint, test, build
+```
+
+CI runs the same checks. If `make prepush` fails locally, it will fail on your
+pull request.
+
+Useful individual targets:
+
+| Target | Description |
+|---|---|
+| `make build` | Build the binary to `./dist/sx` |
+| `make test` | Run tests |
+| `make lint` | Run linters |
+| `make format` | Format code |
+| `make dev` | Run with hot reload (requires air) |
+| `make tidy` | Tidy `go.mod` |
+
+`make help` lists everything.
+
+## Pull Requests
+
+- One logical change per pull request. Unrelated fixes are easier to review,
+  and easier to revert, on their own.
+- Explain what changed and why. If the reasoning is not obvious from the diff,
+  it belongs in the description.
+- Say how you verified the change. "Ran `make prepush`" is a fine answer; so is
+  a command transcript showing the new behavior.
+- Pull requests from forks skip the automated Claude review, which needs
+  repository secrets. A maintainer will review those by hand.
+
+## Reporting Bugs
+
+Open an issue with the version (`sx --version`), your OS, the command you ran,
+what you expected, and what happened. Include the full error output when there
+is one.
+
+For anything security-related, do **not** open a public issue — see
+[SECURITY.md](SECURITY.md).
+
+## Code Of Conduct
+
+Participation is covered by our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ An AI agent is only as good as what it knows and what it's allowed to do. `sx` l
 - **Bundle the whole capability** — skills, rules, commands, hooks, and MCP config travel together as versioned assets, not loose files scattered across repos and machines
 - **Decoupled from any one vendor** — AI tools are commoditizing; the agents running on them shouldn't be locked in. Describe them in a portable format you own and carry them between tools as the landscape shifts
 
+## Put them to work: sx + hetchy
+
+`sx` gets your skills and agents onto every client your team uses. [**hetchy**](https://github.com/sleuth-io/hetchy) is where they run unattended: connect a repo, send a request from the web UI, Slack, or Linear, and hetchy runs a coding agent in an isolated sandbox, then opens a reviewable pull request with the evidence attached.
+
+The two are wired together. Every hetchy run installs agent personas and scoped skills from an `sx` vault before the agent starts — its public vault by default, or your own Skills.new vault once an org admin adds an SX key. Publish here and it's in the next run:
+
+```bash
+sx add ~/.claude/skills/migration-reviewer   # publish to your vault
+# hetchy installs it into the next sandbox — no copy-paste, no redeploy
+```
+
+hetchy embeds `sx` as a Go library ([`pkg/sxvault`](#use-sx-as-a-go-library)) rather than shelling out to the CLI, so vault access is part of the run itself.
+
+hetchy is self-hostable and Apache-2.0 — `docker compose up`. See [docs/hetchy.md](docs/hetchy.md) for the end-to-end workflow.
+
 ## Distribution models
 
 Choose the right distribution model for your team:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting A Vulnerability
+
+Please report suspected vulnerabilities privately through GitHub's private
+vulnerability reporting:
+
+**https://github.com/sleuth-io/sx/security/advisories/new**
+
+That channel is private to the maintainers and lets us coordinate a fix and a
+release before anything is public. Please do not open a public issue for a
+security problem.
+
+Include what you can:
+
+- Affected command, subsystem, or workflow.
+- Steps to reproduce.
+- Impact and the access an attacker would need.
+- Any logs or proof-of-concept details that are safe to share.
+
+We will acknowledge reports as quickly as practical and coordinate remediation
+before public disclosure.
+
+## Supported Versions
+
+The `main` branch receives security fixes, which ship in the next tagged
+release. Older tags are not patched in place — upgrade to the latest release.
+
+## Verifying What You Install
+
+`install.sh` downloads the release archive and verifies it against the
+`checksums.txt` published with that release, refusing to install on a mismatch.
+
+Releases from v2.2.9 onward also carry a signed build provenance attestation.
+To confirm an archive was built by this repository's release workflow:
+
+```bash
+gh attestation verify sx_Darwin_arm64.tar.gz --repo sleuth-io/sx
+```
+
+Homebrew installs are verified by Homebrew against the formula's own checksum.
+
+## Handling Secrets
+
+`sx` stores a vault auth token in `~/.config/sx/config.json`. Never paste real
+tokens, credentials, or private keys into issues, pull requests, or discussions
+— redact them first. If you believe a token has been exposed, rotate it before
+reporting.

--- a/docs/hetchy.md
+++ b/docs/hetchy.md
@@ -1,0 +1,86 @@
+# sx + hetchy
+
+[hetchy](https://github.com/sleuth-io/hetchy) runs coding agents in isolated
+sandboxes and opens reviewable pull requests. `sx` is where those agents get
+their skills.
+
+The split is clean: `sx` owns authoring, versioning, and distribution of AI
+assets. hetchy owns execution — sandboxes, credentials, streaming, pull requests,
+validation. Neither needs to know how the other does its half.
+
+## Why they pair
+
+An agent running unattended against a real repository needs to know your
+conventions: how you write migrations, what your review standards are, which
+commands to run before claiming done. That knowledge is exactly what an `sx`
+skill is.
+
+Without a vault, you would bake those instructions into the runner's image and
+redeploy to change them. With one, you publish a skill and the next run has it.
+
+## The loop
+
+**1. Author and publish a skill**
+
+```bash
+sx add ~/.claude/skills/migration-reviewer
+```
+
+Or drag it into the app. Either way it lands in your vault as a versioned asset.
+
+**2. Point hetchy at that vault**
+
+hetchy draws on two independent sources, not one fallback chain.
+
+A **public vault**, set process-wide for the deployment:
+
+| `HETCHY_SX_PUBLIC_VAULT_URL` | Result |
+|---|---|
+| empty (default) | hetchy's own public vault |
+| a clone URL | your fork, or any public Git vault |
+| `disabled` (also `off`, `none`, `-`) | skip the public install |
+
+And a **per-organization vault** for your team's own assets, resolved in this
+order:
+
+1. A Skills.new SX key, added by an org admin under **Organization settings →
+   Integrations → SX skills vault**. Stored per organization and encrypted at
+   rest, so each org in a deployment reads from its own vault.
+2. Otherwise, a configured GitHub Git vault repository.
+
+The per-org Skills.new key is the one that matters for a team — it is what makes
+"publish a skill, next run has it" true for your private assets rather than just
+the public set.
+
+**3. Run an agent**
+
+Send a request from hetchy's web UI, Slack, Linear, a GitHub mention, or a
+scheduled job. Before the agent starts, hetchy installs the personas and scoped
+skills from the vault into the sandbox. The agent then works with your
+conventions already in context.
+
+**4. Iterate on the skill, not the deployment**
+
+Publish a new version with `sx` and the next hetchy run picks it up. No image
+rebuild, no restart.
+
+## Scoping
+
+`sx` scoping does real work here. Skills scoped to an org, repo, or path only
+install where they apply, which keeps sandbox context from bloating with skills
+that are irrelevant to the repository being worked on. See
+[scoping.md](scoping.md).
+
+## Under the hood
+
+hetchy imports [`pkg/sxvault`](library.md) directly rather than shelling out to
+the `sx` binary, so vault reads happen in-process with the rest of the run. It
+also maintains a server-side Git cache for vault clones — see hetchy's
+[SX setup guide](https://github.com/sleuth-io/hetchy/blob/main/docs/sx-setup.md)
+for the cache and timeout settings.
+
+## Getting started
+
+- Install `sx`: see the [README quickstart](../README.md#quickstart)
+- Run hetchy: `cp .env.example .env && docker compose up --build`, per its
+  [README](https://github.com/sleuth-io/hetchy#quickstart)

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,51 @@ if ! curl -fsSL "$URL" -o "$BINARY_NAME"; then
     exit 1
 fi
 
+# Verify the download against the release's published checksums. This script is
+# meant to be piped straight into a shell, so an unverified archive gets
+# extracted and executed on the user's machine — a corrupted mirror, a truncated
+# transfer, or a tampered artifact would otherwise install silently.
+CHECKSUM_URL="https://github.com/sleuth-io/sx/releases/download/${VERSION}/checksums.txt"
+echo "Verifying checksum..."
+if ! curl -fsSL "$CHECKSUM_URL" -o checksums.txt; then
+    echo "Error: failed to download checksums.txt from ${CHECKSUM_URL}"
+    echo "Refusing to install an unverified binary."
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+# Use whichever hashing tool the platform ships: sha256sum on most Linux
+# images, shasum on macOS.
+if command -v sha256sum > /dev/null 2>&1; then
+    SHA_CMD="sha256sum"
+elif command -v shasum > /dev/null 2>&1; then
+    SHA_CMD="shasum -a 256"
+else
+    echo "Error: neither sha256sum nor shasum is available; cannot verify the download."
+    echo "Install one of them, or download and verify manually against:"
+    echo "  ${CHECKSUM_URL}"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+EXPECTED=$(grep " ${BINARY_NAME}\$" checksums.txt | awk '{print $1}')
+if [ -z "$EXPECTED" ]; then
+    echo "Error: ${BINARY_NAME} is not listed in checksums.txt"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+ACTUAL=$($SHA_CMD "$BINARY_NAME" | awk '{print $1}')
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+    echo "Error: checksum mismatch for ${BINARY_NAME}"
+    echo "  expected: ${EXPECTED}"
+    echo "  actual:   ${ACTUAL}"
+    echo "Refusing to install. Please report this at https://github.com/sleuth-io/sx/issues"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+echo "✓ Checksum verified"
+
 # Extract based on file type
 if [ "$EXT" = "tar.gz" ]; then
     tar -xzf "$BINARY_NAME"


### PR DESCRIPTION
## Summary

Follow-up from an open-source readiness audit of this repo. Everything here is either a concrete defect or a gap relative to what a public repo with this much traffic should have.

### 1. `install.sh` never verified its download

This is the one I'd merge first. The documented install path is a script piped straight into a shell, and it downloaded the release archive, extracted it, and installed the binary to `~/.local/bin` without checking anything. A corrupted mirror, a truncated transfer, or a tampered artifact installed silently.

It now fetches the release's `checksums.txt`, hashes the archive with whichever of `sha256sum` / `shasum` the platform provides, and refuses to install on a mismatch — or when the checksums can't be fetched at all, rather than falling back to trusting the download.

### 2. Build provenance attestation

`release.yml` now mints a signed provenance statement for the published archives via `actions/attest-build-provenance`, so users can tie an artifact to this repository and commit:

```bash
gh attestation verify sx_Darwin_arm64.tar.gz --repo sleuth-io/sx
```

Checksums prove the archive matches a hash file published alongside it; attestation proves it came from this build. The job gains `id-token: write` and `attestations: write` for this.

### 3. The Homebrew formula declared the wrong license

`.goreleaser.yml` had `license: MIT`. The repository is Apache-2.0. Every formula published through v2.2.8 has told `brew info sx` the wrong license. One-line fix; takes effect on the next release.

### 4. Dependabot didn't cover Go modules

`dependabot.yml` configured `github-actions` only, so Go dependencies never received update PRs — they'd only ever surface as security alerts after a CVE landed. Added `gomod`, weekly, grouped for minor/patch.

### 5. `claude-pr-review.yml` had no fork guard

Every fork PR triggered the review with empty secrets. Added the guard job pattern: fork PRs and repos without `ANTHROPIC_API_KEY` skip cleanly, and a missing `SKILLS_SITE_API_KEY` degrades to a review without installed skills instead of failing.

### 6. Community docs

Added `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, issue templates, and a PR template — none existed. `SECURITY.md` points at GitHub private vulnerability reporting (now enabled), so there's a private channel for reports.

## Testing

- [x] `make prepush` — green, all 44 packages pass.
- [x] `bash -n install.sh` — syntax clean.
- [x] **Installer verified against the real `v2.2.8` release**: downloaded the actual archive and `checksums.txt`, confirmed the grep/awk extraction matches goreleaser's format, and ran the full script end to end — installs and reports `✓ Checksum verified`, then `sx --version` works.
- [x] **Failure path verified**: appended a byte to the archive after download; the script reported the mismatch, refused to install, and left nothing in the install dir.
- [x] All changed YAML parses.

## Notes

Applied alongside this, via the API rather than in the diff:

| Setting | Before | Now |
|---|---|---|
| Secret scanning | disabled | enabled |
| Push protection | disabled | enabled |
| Dependabot security updates | disabled | enabled |
| Private vulnerability reporting | disabled | enabled |
| Default workflow token | `write` | `read` |
| Token can approve PRs | yes | no |
| Branch protection on `main` | none | PR + `Test` required |
| Topics | none | 12 |
| Homepage | unset | https://sleuth-io.github.io/sx/ |

Dropping the default workflow token to `read` is safe: `release.yml`, `app-release.yml`, `pages.yml`, and `claude-pr-review.yml` each declare their own `permissions:` block, and `test.yml` needs nothing beyond read. Worth watching the next release run to confirm.

`SECURITY.md` references attestation as available "from v2.2.9 onward" — accurate if this merges before the next tag, worth a tweak if it doesn't.