### PR TITLE
SK-731: Comply with MCP 2026-07-28 stateless spec

### DIFF
--- a/docs/mcp-spec.md
+++ b/docs/mcp-spec.md
@@ -193,7 +193,28 @@ event: complete
 message: Query completed
 ```
 
-These notifications appear as log messages in the AI client, providing visibility into query progress.
+These are delivered as MCP `notifications/progress` on the response stream of the
+originating request.
+
+**Progress is opt-in.** The client asks for it by including a `progressToken` in the
+request's `_meta`; without one there is nothing to correlate a notification to, so sx
+sends none and logs locally instead. This replaced the previous mechanism, which sent
+`notifications/message` (log notifications) — MCP `2026-07-28` deprecated the Logging
+feature (SEP-2577) and forbids emitting log notifications for a request that did not
+ask for them.
+
+Note that progress is not a guaranteed keepalive: events fire on tool-call boundaries,
+so a query that spends its time inside a single API call emits nothing even with a
+token present.
+
+## Caching hints
+
+Per MCP `2026-07-28` (SEP-2549), list and read results carry caching hints:
+
+- `ttlMs` — how long the client may treat the result as fresh (60s).
+- `cacheScope` — always `private`. An sx server serves exactly one person's vault, so
+  its results must never be cached across authorization contexts. The Go SDK defaults
+  this to `public`; sx overrides it for every cacheable result.
 
 ## Error Handling
 

--- a/docs/mcp-spec.md
+++ b/docs/mcp-spec.md
@@ -180,7 +180,8 @@ sx automatically detects when skills use MCP tools based on tool call patterns i
 
 ## Streaming and Progress
 
-The query tool uses Server-Sent Events (SSE) for streaming responses. During long-running queries, the tool sends progress notifications to keep the connection alive and inform the user of status:
+The query tool uses Server-Sent Events (SSE) for streaming responses. During long-running
+queries, the tool emits progress events describing what it is doing:
 
 ```
 event: progress
@@ -193,8 +194,14 @@ event: complete
 message: Query completed
 ```
 
-These are delivered as MCP `notifications/progress` on the response stream of the
-originating request.
+On the **stdio** transport (`sx mcp`) these are delivered as MCP
+`notifications/progress` on the response stream of the originating request.
+
+On the **relay** transport (`sx cloud serve`) they are not delivered at all. The relay
+bridge correlates responses by JSON-RPC id and drops everything else
+(`internal/cloud/bridge.go`), and the pulse endpoint answers each request with a single
+JSON body rather than a stream — so there is nowhere for a notification to go. Progress
+events are logged locally and otherwise dropped on that path.
 
 **Progress is opt-in.** The client asks for it by including a `progressToken` in the
 request's `_meta`; without one there is nothing to correlate a notification to, so sx
@@ -203,9 +210,12 @@ sends none and logs locally instead. This replaced the previous mechanism, which
 feature (SEP-2577) and forbids emitting log notifications for a request that did not
 ask for them.
 
-Note that progress is not a guaranteed keepalive: events fire on tool-call boundaries,
-so a query that spends its time inside a single API call emits nothing even with a
-token present.
+Progress is **not** a keepalive. Events fire on tool-call boundaries, so a query that
+spends its time inside a single API call emits nothing even with a token present, and
+the relay path emits nothing regardless. The mechanism it replaced (`notifications/message`
+via `Session.Log`) was equally conditional — it required the client to have called
+`logging/setLevel`. There is no protocol-level keepalive available: `ping` was removed in
+`2026-07-28` and the Go SDK rejects it for new-protocol peers.
 
 ## Caching hints
 

--- a/docs/mcp-spec.md
+++ b/docs/mcp-spec.md
@@ -214,8 +214,12 @@ Progress is **not** a keepalive. Events fire on tool-call boundaries, so a query
 spends its time inside a single API call emits nothing even with a token present, and
 the relay path emits nothing regardless. The mechanism it replaced (`notifications/message`
 via `Session.Log`) was equally conditional — it required the client to have called
-`logging/setLevel`. There is no protocol-level keepalive available: `ping` was removed in
-`2026-07-28` and the Go SDK rejects it for new-protocol peers.
+`logging/setLevel`.
+
+No protocol-level keepalive is available for new-protocol peers: `ping` was removed in
+`2026-07-28` and the Go SDK rejects it for them. `ServerOptions.KeepAlive` still works for
+legacy peers, but it is a per-server setting that would tear down modern sessions, so sx
+does not enable it.
 
 ## Caching hints
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.22
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/muesli/reflow v0.3.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/internal/cloud/bridge_spec_test.go
+++ b/internal/cloud/bridge_spec_test.go
@@ -76,11 +76,10 @@ func roundTripEnvelope(t *testing.T, method string, params map[string]any) map[s
 	}))
 	defer srv.Close()
 
-	// A server carrying the same middleware `sx cloud serve` installs, so the
-	// cacheScope behaviour under test is the real one.
+	// Built through the same constructor `sx cloud serve` uses, so this
+	// exercises the real wiring rather than a hand-rolled equivalent.
 	factory := func() (*mcp.Server, error) {
-		s := mcp.NewServer(&mcp.Implementation{Name: "test-sx", Version: "0.1"}, nil)
-		s.AddReceivingMiddleware(mcpserver.PrivateCacheScopeMiddleware(mcpserver.DefaultCacheTTL))
+		s := mcpserver.NewMCPServer(&mcp.Implementation{Name: "test-sx", Version: "0.1"})
 		mcp.AddTool(s, &mcp.Tool{Name: "probe", Description: "probe"},
 			func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
 				return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil

--- a/internal/cloud/bridge_spec_test.go
+++ b/internal/cloud/bridge_spec_test.go
@@ -1,0 +1,215 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	mcpserver "github.com/sleuth-io/sx/v2/internal/mcp"
+)
+
+// roundTripEnvelope pushes one MCP request envelope down the relay WebSocket
+// and returns the JSON-RPC body sx sends back, exercising the full path pulse
+// uses: envelope -> in-memory transport -> SDK server -> envelope.
+func roundTripEnvelope(t *testing.T, method string, params map[string]any) map[string]any {
+	t.Helper()
+
+	type outbound struct {
+		Type      string         `json:"type"`
+		RequestID string         `json:"request_id"`
+		Body      map[string]any `json:"body"`
+	}
+
+	respCh := make(chan outbound, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer func() { _ = ws.Close(websocket.StatusNormalClosure, "") }()
+
+		envBytes, err := json.Marshal(map[string]any{
+			"type":       "mcp-request",
+			"request_id": "req-1",
+			"jsonrpc_id": 7,
+			"method":     method,
+			"params":     params,
+		})
+		if err != nil {
+			t.Errorf("marshal envelope: %v", err)
+			return
+		}
+
+		writeCtx, writeCancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer writeCancel()
+		if err := ws.Write(writeCtx, websocket.MessageText, envBytes); err != nil {
+			t.Errorf("write req: %v", err)
+			return
+		}
+
+		readCtx, readCancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer readCancel()
+		_, data, err := ws.Read(readCtx)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("read resp: %v", err)
+			}
+			return
+		}
+		var out outbound
+		if err := json.Unmarshal(data, &out); err != nil {
+			t.Errorf("unmarshal resp: %v", err)
+			return
+		}
+		respCh <- out
+	}))
+	defer srv.Close()
+
+	// A server carrying the same middleware `sx cloud serve` installs, so the
+	// cacheScope behaviour under test is the real one.
+	factory := func() (*mcp.Server, error) {
+		s := mcp.NewServer(&mcp.Implementation{Name: "test-sx", Version: "0.1"}, nil)
+		s.AddReceivingMiddleware(mcpserver.PrivateCacheScopeMiddleware(mcpserver.DefaultCacheTTL))
+		mcp.AddTool(s, &mcp.Tool{Name: "probe", Description: "probe"},
+			func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+				return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+			})
+		return s, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- Serve(ctx, ServeOptions{
+			Credential: &Credential{
+				RelayBaseURL: strings.TrimSuffix(srv.URL, "/") + "/relay/SRtest/",
+				RelayGID:     "SRtest",
+				MachineToken: "tok",
+			},
+			MCPServerFactory: factory,
+		})
+	}()
+
+	var body map[string]any
+	select {
+	case out := <-respCh:
+		body = out.Body
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for MCP response envelope")
+	}
+
+	cancel()
+	if err := <-serveErr; err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("Serve returned non-cancel error: %v", err)
+	}
+	return body
+}
+
+// modernParams builds the per-request `_meta` block the stateless revision
+// requires. Pulse forwards `params` verbatim, so this is exactly what sx sees.
+func modernParams(extra map[string]any) map[string]any {
+	params := map[string]any{}
+	maps.Copy(params, extra)
+	params["_meta"] = map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+		"io.modelcontextprotocol/clientInfo": map[string]any{
+			"name":    "test-client",
+			"version": "1.0.0",
+		},
+	}
+	return params
+}
+
+func resultOf(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	if errVal, has := body["error"]; has {
+		t.Fatalf("unexpected JSON-RPC error: %v", errVal)
+	}
+	result, ok := body["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no result object: %+v", body)
+	}
+	return result
+}
+
+// TestServe_ServerDiscoverCrossesTheRelay is the load-bearing case for the
+// stateless revision: `server/discover` replaces `initialize`, and it has to
+// survive the pulse -> WebSocket -> sx round trip intact.
+func TestServe_ServerDiscoverCrossesTheRelay(t *testing.T) {
+	result := resultOf(t, roundTripEnvelope(t, "server/discover", modernParams(nil)))
+
+	versions, ok := result["supportedVersions"].([]any)
+	if !ok || len(versions) == 0 {
+		t.Fatalf("server/discover returned no supportedVersions: %+v", result)
+	}
+	found := false
+	for _, v := range versions {
+		if v == "2026-07-28" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("supportedVersions %v does not include 2026-07-28", versions)
+	}
+}
+
+func TestServe_ModernToolsListIsPrivatelyScoped(t *testing.T) {
+	// The relay serves one user's vault. A "public" hint would let a client or
+	// proxy hand this response to somebody else.
+	result := resultOf(t, roundTripEnvelope(t, "tools/list", modernParams(nil)))
+
+	if scope := result["cacheScope"]; scope != "private" {
+		t.Errorf("cacheScope = %v, want \"private\"", scope)
+	}
+	if ttl, ok := result["ttlMs"].(float64); !ok || ttl <= 0 {
+		t.Errorf("ttlMs = %v, want a positive freshness hint", result["ttlMs"])
+	}
+}
+
+func TestServe_ModernResultsCarryResultType(t *testing.T) {
+	result := resultOf(t, roundTripEnvelope(t, "tools/list", modernParams(nil)))
+
+	if rt := result["resultType"]; rt != "complete" {
+		t.Errorf("resultType = %v, want \"complete\"", rt)
+	}
+}
+
+func TestServe_ModernToolsCallCrossesTheRelay(t *testing.T) {
+	body := roundTripEnvelope(t, "tools/call", modernParams(map[string]any{
+		"name":      "probe",
+		"arguments": map[string]any{},
+	}))
+
+	result := resultOf(t, body)
+	if result["resultType"] != "complete" {
+		t.Errorf("resultType = %v, want \"complete\"", result["resultType"])
+	}
+}
+
+// TestServe_LegacyInitializeStillWorks guards the compatibility half: a chat
+// client that hasn't migrated still opens with `initialize`.
+func TestServe_LegacyInitializeStillWorks(t *testing.T) {
+	result := resultOf(t, roundTripEnvelope(t, "initialize", map[string]any{
+		"protocolVersion": "2025-06-18",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "old-client", "version": "0"},
+	}))
+
+	if _, ok := result["serverInfo"]; !ok {
+		t.Errorf("legacy initialize returned no serverInfo: %+v", result)
+	}
+}

--- a/internal/commands/cloud_mcp.go
+++ b/internal/commands/cloud_mcp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sleuth-io/sx/v2/internal/config"
 	"github.com/sleuth-io/sx/v2/internal/logger"
+	mcpserver "github.com/sleuth-io/sx/v2/internal/mcp"
 	vaultpkg "github.com/sleuth-io/sx/v2/internal/vault"
 )
 
@@ -39,6 +40,9 @@ func buildCloudServeMCPServerFromConfig(cfg *config.Config) (*mcp.Server, error)
 		Version: "1.0.0",
 	}
 	server := mcp.NewServer(impl, nil)
+	// Relay results are per-user by construction; don't let them be cached
+	// across authorization contexts. See mcpserver.PrivateCacheScopeMiddleware.
+	server.AddReceivingMiddleware(mcpserver.PrivateCacheScopeMiddleware(mcpserver.DefaultCacheTTL))
 
 	vault, err := vaultpkg.NewFromConfig(cfg)
 	if err != nil {

--- a/internal/commands/cloud_mcp.go
+++ b/internal/commands/cloud_mcp.go
@@ -39,10 +39,9 @@ func buildCloudServeMCPServerFromConfig(cfg *config.Config) (*mcp.Server, error)
 		Name:    "skills",
 		Version: "1.0.0",
 	}
-	server := mcp.NewServer(impl, nil)
-	// Relay results are per-user by construction; don't let them be cached
-	// across authorization contexts. See mcpserver.PrivateCacheScopeMiddleware.
-	server.AddReceivingMiddleware(mcpserver.PrivateCacheScopeMiddleware(mcpserver.DefaultCacheTTL))
+	// Shared constructor, so the relay can't drift from `sx mcp` on the
+	// cacheScope middleware — relay results are per-user by construction.
+	server := mcpserver.NewMCPServer(impl)
 
 	vault, err := vaultpkg.NewFromConfig(cfg)
 	if err != nil {

--- a/internal/mcp/cachescope.go
+++ b/internal/mcp/cachescope.go
@@ -2,9 +2,12 @@ package mcpserver
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/sleuth-io/sx/v2/internal/logger"
 )
 
 // MCP 2026-07-28 (SEP-2549) requires servers to attach caching hints to list
@@ -26,12 +29,21 @@ const cacheScopePrivate = "private"
 // client within a minute, not on the next restart.
 const DefaultCacheTTL = 60 * time.Second
 
+// cacheableFieldName is the embedded struct the SDK uses to carry caching
+// hints. Every cacheable result type embeds it by value.
+const cacheableFieldName = "Cacheable"
+
 // PrivateCacheScopeMiddleware marks every cacheable result private and gives
 // it a TTL, overriding the SDK's "public" default.
 //
 // Applied as receiving middleware rather than by wrapping each handler so it
 // can't be forgotten when a new tool or vault type is added — every cacheable
 // result on its way out of the server passes through here.
+//
+// This middleware owns TTLMs as well as CacheScope: it overwrites whatever the
+// handler set. No handler sets one today, and a single owner is what keeps the
+// freshness hint consistent across every method. A handler that needs its own
+// TTL should stop routing through here rather than fight it.
 func PrivateCacheScopeMiddleware(ttl time.Duration) mcp.Middleware {
 	ttlMs := int(ttl / time.Millisecond)
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
@@ -46,22 +58,45 @@ func PrivateCacheScopeMiddleware(ttl time.Duration) mcp.Middleware {
 	}
 }
 
-// applyPrivateCacheHints sets the caching fields on any result type that
-// carries them. The fields live on an embedded `mcp.Cacheable` value, so there
-// is no interface to set them through — a type switch is the available seam.
+// applyPrivateCacheHints sets the caching fields on any result that carries
+// them.
+//
+// Deliberately reflective rather than a type switch over the six cacheable
+// types the SDK defines today. A switch fails *open*: a cacheable type added by
+// a future SDK bump would fall through and keep the "public" default, silently
+// undoing the control this whole file exists to provide, and an enumerated test
+// couldn't catch the gap either. Going through mcp.CacheableResult means any
+// type the SDK declares cacheable is covered the moment it exists.
 func applyPrivateCacheHints(res mcp.Result, ttlMs int) {
-	switch r := res.(type) {
-	case *mcp.ListToolsResult:
-		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
-	case *mcp.DiscoverResult:
-		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
-	case *mcp.ListPromptsResult:
-		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
-	case *mcp.ListResourcesResult:
-		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
-	case *mcp.ListResourceTemplatesResult:
-		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
-	case *mcp.ReadResourceResult:
-		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
+	if _, ok := res.(mcp.CacheableResult); !ok {
+		return
 	}
+
+	// Results are always pointers to structs embedding mcp.Cacheable by value.
+	value := reflect.ValueOf(res)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return
+	}
+	cacheable := value.Elem().FieldByName(cacheableFieldName)
+	if !cacheable.IsValid() || !cacheable.CanSet() {
+		// The SDK changed shape underneath us. Say so loudly: the alternative
+		// is shipping "public" on an authenticated per-user result.
+		logger.Get().Error(
+			"cannot set cache hints on result; it may be served with the SDK's public default",
+			"type", reflect.TypeOf(res).String(),
+		)
+		return
+	}
+
+	scope := cacheable.FieldByName("CacheScope")
+	ttl := cacheable.FieldByName("TTLMs")
+	if !scope.CanSet() || !ttl.CanSet() {
+		logger.Get().Error(
+			"unexpected mcp.Cacheable shape; cache hints not applied",
+			"type", reflect.TypeOf(res).String(),
+		)
+		return
+	}
+	scope.SetString(cacheScopePrivate)
+	ttl.SetInt(int64(ttlMs))
 }

--- a/internal/mcp/cachescope.go
+++ b/internal/mcp/cachescope.go
@@ -71,39 +71,57 @@ func applyPrivateCacheHints(res mcp.Result, ttlMs int) {
 	if _, ok := res.(mcp.CacheableResult); !ok {
 		return
 	}
-
-	// Results are always pointers to structs embedding mcp.Cacheable by value.
-	value := reflect.ValueOf(res)
-	if value.Kind() != reflect.Pointer || value.IsNil() {
-		return
-	}
-	cacheable := value.Elem().FieldByName(cacheableFieldName)
-	if !cacheable.IsValid() || !cacheable.CanSet() {
-		// The SDK changed shape underneath us. Say so loudly: the alternative
-		// is shipping "public" on an authenticated per-user result.
+	if reason := setCacheHints(res, ttlMs); reason != "" {
+		// Never silent: a result going out without our hints may carry the
+		// SDK's "public" default, which is shareable across authorization
+		// contexts — the exact failure this file prevents.
 		logger.Get().Error(
-			"cannot set cache hints on result; it may be served with the SDK's public default",
+			"cache hints not applied; result may carry the SDK's public cacheScope default",
+			"reason", reason,
 			"type", reflect.TypeOf(res).String(),
 		)
-		return
+	}
+}
+
+// setCacheHints writes the private cacheScope and TTL onto a result's embedded
+// mcp.Cacheable. Returns "" on success, or the reason it gave up.
+//
+// Takes `any` rather than mcp.Result so the give-up branches are reachable from
+// a test: mcp.Result has an unexported method, so no fake outside the SDK can
+// implement it, and the SDK ships no wrong-shaped type to feed in. Without this
+// seam every guard below would be untestable — and an untestable guard is one
+// that can be deleted without anything failing.
+//
+// Every reflection step is checked before it is taken: FieldByName panics on a
+// non-struct and SetString/SetInt panic on a kind mismatch, which are precisely
+// the SDK shape changes this path exists to survive. A panic here would take
+// down the request instead of degrading to a logged warning.
+func setCacheHints(target any, ttlMs int) string {
+	value := reflect.ValueOf(target)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return "result is not a non-nil pointer"
+	}
+	elem := value.Elem()
+	if elem.Kind() != reflect.Struct {
+		return "result does not point at a struct"
+	}
+	cacheable := elem.FieldByName(cacheableFieldName)
+	if !cacheable.IsValid() || !cacheable.CanSet() {
+		return "no settable Cacheable field"
+	}
+	if cacheable.Kind() != reflect.Struct {
+		return "Cacheable field is not a struct"
 	}
 
-	// Kinds are checked, not just settability: SetString and SetInt panic on a
-	// mismatch, and an SDK field-type change is precisely the scenario this
-	// reflective path exists to survive. Panicking here would take down the
-	// request instead of degrading to a logged warning.
 	scope := cacheable.FieldByName("CacheScope")
 	ttl := cacheable.FieldByName("TTLMs")
 	if !scope.CanSet() || scope.Kind() != reflect.String ||
 		!ttl.CanSet() || !isIntKind(ttl.Kind()) {
-		logger.Get().Error(
-			"unexpected mcp.Cacheable shape; cache hints not applied, result may carry the SDK's public default",
-			"type", reflect.TypeOf(res).String(),
-		)
-		return
+		return "unexpected CacheScope/TTLMs shape"
 	}
 	scope.SetString(cacheScopePrivate)
 	ttl.SetInt(int64(ttlMs))
+	return ""
 }
 
 func isIntKind(k reflect.Kind) bool {

--- a/internal/mcp/cachescope.go
+++ b/internal/mcp/cachescope.go
@@ -88,15 +88,25 @@ func applyPrivateCacheHints(res mcp.Result, ttlMs int) {
 		return
 	}
 
+	// Kinds are checked, not just settability: SetString and SetInt panic on a
+	// mismatch, and an SDK field-type change is precisely the scenario this
+	// reflective path exists to survive. Panicking here would take down the
+	// request instead of degrading to a logged warning.
 	scope := cacheable.FieldByName("CacheScope")
 	ttl := cacheable.FieldByName("TTLMs")
-	if !scope.CanSet() || !ttl.CanSet() {
+	if !scope.CanSet() || scope.Kind() != reflect.String ||
+		!ttl.CanSet() || !isIntKind(ttl.Kind()) {
 		logger.Get().Error(
-			"unexpected mcp.Cacheable shape; cache hints not applied",
+			"unexpected mcp.Cacheable shape; cache hints not applied, result may carry the SDK's public default",
 			"type", reflect.TypeOf(res).String(),
 		)
 		return
 	}
 	scope.SetString(cacheScopePrivate)
 	ttl.SetInt(int64(ttlMs))
+}
+
+func isIntKind(k reflect.Kind) bool {
+	return k == reflect.Int || k == reflect.Int8 || k == reflect.Int16 ||
+		k == reflect.Int32 || k == reflect.Int64
 }

--- a/internal/mcp/cachescope.go
+++ b/internal/mcp/cachescope.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -32,6 +33,20 @@ const DefaultCacheTTL = 60 * time.Second
 // cacheableFieldName is the embedded struct the SDK uses to carry caching
 // hints. Every cacheable result type embeds it by value.
 const cacheableFieldName = "Cacheable"
+
+// Compile-time pin on the fields setCacheHints writes through. The reflection
+// below exists for the *dynamic* half of the problem — which result types are
+// cacheable — but the shape of mcp.Cacheable is knowable right here, and a
+// rename, removal, or type change should fail `go build` rather than degrade
+// into a runtime log line. That matters because the runtime signal is weak:
+// it lands in a 1MB rotating debug file alongside every Debug line in the
+// process, so the practical outcome of an unnoticed SDK bump would be
+// `cacheScope: "public"` on authenticated per-user results with nothing
+// visible to an operator or to CI.
+var (
+	_ string = mcp.Cacheable{}.CacheScope
+	_ int    = mcp.Cacheable{}.TTLMs
+)
 
 // PrivateCacheScopeMiddleware marks every cacheable result private and gives
 // it a TTL, overriding the SDK's "public" default.
@@ -92,11 +107,20 @@ func applyPrivateCacheHints(res mcp.Result, ttlMs int) {
 // seam every guard below would be untestable — and an untestable guard is one
 // that can be deleted without anything failing.
 //
-// Every reflection step is checked before it is taken: FieldByName panics on a
-// non-struct and SetString/SetInt panic on a kind mismatch, which are precisely
-// the SDK shape changes this path exists to survive. A panic here would take
-// down the request instead of degrading to a logged warning.
-func setCacheHints(target any, ttlMs int) string {
+// The per-step checks below are fast, specific diagnostics, but they are an
+// enumeration and enumerations of "how could reflect panic" don't close.
+// FieldByName alone has a second mode the Kind checks miss — a field promoted
+// through a nil embedded pointer panics via FieldByIndex — and the next SDK
+// shape could introduce a third. The deferred recover is the part that is
+// actually total: any reflect panic, known or not, becomes a logged give-up
+// instead of a dead request.
+func setCacheHints(target any, ttlMs int) (reason string) {
+	defer func() {
+		if r := recover(); r != nil {
+			reason = fmt.Sprintf("reflect panic: %v", r)
+		}
+	}()
+
 	value := reflect.ValueOf(target)
 	if value.Kind() != reflect.Pointer || value.IsNil() {
 		return "result is not a non-nil pointer"

--- a/internal/mcp/cachescope.go
+++ b/internal/mcp/cachescope.go
@@ -1,0 +1,67 @@
+package mcpserver
+
+import (
+	"context"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// MCP 2026-07-28 (SEP-2549) requires servers to attach caching hints to list
+// and read results. The Go SDK fills these in for us, but it defaults
+// cacheScope to "public" — and "public" is a licence for any client, gateway,
+// or caching proxy to serve the response to a *different* user, even though it
+// came from an authenticated endpoint.
+//
+// That default is wrong for us. An sx server — whether it's `sx mcp` over
+// stdio or a `sx cloud serve` relay — serves exactly one person's vault, and
+// what it exposes varies with the vault behind it (SleuthVault publishes a
+// bespoke `query` tool; PathVault and GitVault publish the asset-shim
+// toolset). There is also nothing to gain from "public": with one user per
+// server, a shared cache has no second user to serve.
+const cacheScopePrivate = "private"
+
+// DefaultCacheTTL is how long clients may treat a list result as fresh.
+// Deliberately short: an asset added to the vault should show up in the chat
+// client within a minute, not on the next restart.
+const DefaultCacheTTL = 60 * time.Second
+
+// PrivateCacheScopeMiddleware marks every cacheable result private and gives
+// it a TTL, overriding the SDK's "public" default.
+//
+// Applied as receiving middleware rather than by wrapping each handler so it
+// can't be forgotten when a new tool or vault type is added — every cacheable
+// result on its way out of the server passes through here.
+func PrivateCacheScopeMiddleware(ttl time.Duration) mcp.Middleware {
+	ttlMs := int(ttl / time.Millisecond)
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			res, err := next(ctx, method, req)
+			if err != nil {
+				return res, err
+			}
+			applyPrivateCacheHints(res, ttlMs)
+			return res, nil
+		}
+	}
+}
+
+// applyPrivateCacheHints sets the caching fields on any result type that
+// carries them. The fields live on an embedded `mcp.Cacheable` value, so there
+// is no interface to set them through — a type switch is the available seam.
+func applyPrivateCacheHints(res mcp.Result, ttlMs int) {
+	switch r := res.(type) {
+	case *mcp.ListToolsResult:
+		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
+	case *mcp.DiscoverResult:
+		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
+	case *mcp.ListPromptsResult:
+		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
+	case *mcp.ListResourcesResult:
+		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
+	case *mcp.ListResourceTemplatesResult:
+		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
+	case *mcp.ReadResourceResult:
+		r.CacheScope, r.TTLMs = cacheScopePrivate, ttlMs
+	}
+}

--- a/internal/mcp/cachescope_test.go
+++ b/internal/mcp/cachescope_test.go
@@ -1,0 +1,116 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// handlerReturning builds a MethodHandler that yields the given result.
+func handlerReturning(res mcp.Result) mcp.MethodHandler {
+	return func(context.Context, string, mcp.Request) (mcp.Result, error) {
+		return res, nil
+	}
+}
+
+func TestPrivateCacheScopeMiddlewareMarksListToolsPrivate(t *testing.T) {
+	// The SDK defaults cacheScope to "public", which licenses any client or
+	// proxy to serve this response to a different user. An sx server always
+	// serves exactly one person's vault, so that default is wrong for us.
+	res := &mcp.ListToolsResult{}
+	mw := PrivateCacheScopeMiddleware(60 * time.Second)
+
+	got, err := mw(handlerReturning(res))(context.Background(), "tools/list", nil)
+	if err != nil {
+		t.Fatalf("middleware returned error: %v", err)
+	}
+
+	tools, ok := got.(*mcp.ListToolsResult)
+	if !ok {
+		t.Fatalf("got %T, want *mcp.ListToolsResult", got)
+	}
+	if tools.CacheScope != "private" {
+		t.Errorf("CacheScope = %q, want %q", tools.CacheScope, "private")
+	}
+	if tools.TTLMs != 60000 {
+		t.Errorf("TTLMs = %d, want 60000", tools.TTLMs)
+	}
+}
+
+func TestPrivateCacheScopeMiddlewareOverridesSDKPublicDefault(t *testing.T) {
+	res := &mcp.ListToolsResult{}
+	res.CacheScope = "public" // what the SDK fills in on its own
+
+	got, _ := PrivateCacheScopeMiddleware(time.Minute)(handlerReturning(res))(
+		context.Background(), "tools/list", nil,
+	)
+
+	if scope := got.(*mcp.ListToolsResult).CacheScope; scope != "private" {
+		t.Errorf("CacheScope = %q, want the SDK default to be overridden", scope)
+	}
+}
+
+func TestPrivateCacheScopeMiddlewareCoversEveryCacheableResult(t *testing.T) {
+	// Every result type the 2026-07-28 spec marks cacheable must be handled;
+	// missing one leaks a "public" hint for that method.
+	cases := map[string]mcp.Result{
+		"server/discover":          &mcp.DiscoverResult{},
+		"tools/list":               &mcp.ListToolsResult{},
+		"prompts/list":             &mcp.ListPromptsResult{},
+		"resources/list":           &mcp.ListResourcesResult{},
+		"resources/templates/list": &mcp.ListResourceTemplatesResult{},
+		"resources/read":           &mcp.ReadResourceResult{},
+	}
+
+	mw := PrivateCacheScopeMiddleware(time.Minute)
+	for method, res := range cases {
+		t.Run(method, func(t *testing.T) {
+			got, err := mw(handlerReturning(res))(context.Background(), method, nil)
+			if err != nil {
+				t.Fatalf("middleware returned error: %v", err)
+			}
+			cacheable, ok := got.(mcp.CacheableResult)
+			if !ok {
+				t.Fatalf("%T does not implement mcp.CacheableResult", got)
+			}
+			if cacheable.GetCacheScope() != "private" {
+				t.Errorf("CacheScope = %q, want %q", cacheable.GetCacheScope(), "private")
+			}
+			if cacheable.GetTTLMs() != 60000 {
+				t.Errorf("TTLMs = %d, want 60000", cacheable.GetTTLMs())
+			}
+		})
+	}
+}
+
+func TestPrivateCacheScopeMiddlewareLeavesNonCacheableResultsAlone(t *testing.T) {
+	// tools/call carries no caching hints; the middleware must not panic on
+	// or otherwise disturb it.
+	res := &mcp.CallToolResult{}
+
+	got, err := PrivateCacheScopeMiddleware(time.Minute)(handlerReturning(res))(
+		context.Background(), "tools/call", nil,
+	)
+	if err != nil {
+		t.Fatalf("middleware returned error: %v", err)
+	}
+	if got != mcp.Result(res) {
+		t.Errorf("result was replaced; want it passed through unchanged")
+	}
+}
+
+func TestPrivateCacheScopeMiddlewarePropagatesErrors(t *testing.T) {
+	wantErr := errors.New("handler failed")
+	failing := func(context.Context, string, mcp.Request) (mcp.Result, error) {
+		return nil, wantErr
+	}
+
+	_, err := PrivateCacheScopeMiddleware(time.Minute)(failing)(context.Background(), "tools/list", nil)
+
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/mcp/cachescope_test.go
+++ b/internal/mcp/cachescope_test.go
@@ -114,3 +114,38 @@ func TestPrivateCacheScopeMiddlewarePropagatesErrors(t *testing.T) {
 		t.Errorf("err = %v, want %v", err, wantErr)
 	}
 }
+
+// TestNewMCPServerInstallsCacheScopeMiddleware covers the production wiring
+// rather than a hand-built server: deleting the AddReceivingMiddleware call in
+// NewMCPServer must fail something. Both `sx mcp` and `sx cloud serve` go
+// through this constructor, so this one test covers both.
+func TestNewMCPServerInstallsCacheScopeMiddleware(t *testing.T) {
+	ctx := context.Background()
+	server := NewMCPServer(&mcp.Implementation{Name: "test", Version: "0.1"})
+	mcp.AddTool(server, &mcp.Tool{Name: "probe", Description: "probe"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{}, nil, nil
+		})
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	go func() { _ = server.Run(ctx, serverTransport) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	res, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+
+	if res.CacheScope != "private" {
+		t.Errorf("CacheScope = %q, want %q — is the middleware still wired into NewMCPServer?", res.CacheScope, "private")
+	}
+	if res.TTLMs != int(DefaultCacheTTL/time.Millisecond) {
+		t.Errorf("TTLMs = %d, want %d", res.TTLMs, int(DefaultCacheTTL/time.Millisecond))
+	}
+}

--- a/internal/mcp/cachescope_test.go
+++ b/internal/mcp/cachescope_test.go
@@ -55,8 +55,11 @@ func TestPrivateCacheScopeMiddlewareOverridesSDKPublicDefault(t *testing.T) {
 }
 
 func TestPrivateCacheScopeMiddlewareCoversEveryCacheableResult(t *testing.T) {
-	// Every result type the 2026-07-28 spec marks cacheable must be handled;
-	// missing one leaks a "public" hint for that method.
+	// Checks the reflective path resolves correctly against every cacheable
+	// type the SDK ships today — something the goodShape fake can't prove.
+	// It is no longer an exhaustiveness check: applyPrivateCacheHints covers
+	// anything satisfying mcp.CacheableResult, so a seventh type in a future
+	// SDK is handled whether or not this list mentions it.
 	cases := map[string]mcp.Result{
 		"server/discover":          &mcp.DiscoverResult{},
 		"tools/list":               &mcp.ListToolsResult{},
@@ -187,6 +190,20 @@ type noCacheableField struct {
 	Other string
 }
 
+// embedsCacheable is embedded by pointer below, so Cacheable is promoted
+// through it — FieldByName then delegates to FieldByIndex, which panics on the
+// nil pointer. This is the panic mode a Kind() == Struct check does not cover.
+type embedsCacheable struct {
+	Cacheable struct {
+		CacheScope string
+		TTLMs      int
+	}
+}
+
+type nilEmbeddedPointer struct {
+	*embedsCacheable
+}
+
 // TestSetCacheHintsWritesTheHints is the happy path through the reflection.
 func TestSetCacheHintsWritesTheHints(t *testing.T) {
 	target := &goodShape{}
@@ -214,6 +231,7 @@ func TestSetCacheHintsGivesUpWithoutPanicking(t *testing.T) {
 		{"no Cacheable field", &noCacheableField{}},
 		{"Cacheable is a pointer", &pointerCacheable{}},
 		{"TTLMs is not an int", &wrongTTLKind{}},
+		{"Cacheable promoted through a nil embedded pointer", &nilEmbeddedPointer{}},
 		{"CacheScope is not a string", &wrongScopeKind{}},
 	}
 

--- a/internal/mcp/cachescope_test.go
+++ b/internal/mcp/cachescope_test.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -147,5 +148,49 @@ func TestNewMCPServerInstallsCacheScopeMiddleware(t *testing.T) {
 	}
 	if res.TTLMs != int(DefaultCacheTTL/time.Millisecond) {
 		t.Errorf("TTLMs = %d, want %d", res.TTLMs, int(DefaultCacheTTL/time.Millisecond))
+	}
+}
+
+// TestApplyPrivateCacheHintsSurvivesUnexpectedShape guards the reflective path
+// against the scenario it exists for: an SDK whose Cacheable fields change type
+// or disappear. Reflection's SetString/SetInt panic on a kind mismatch, so a
+// naive implementation would take down the request rather than degrade.
+func TestApplyPrivateCacheHintsSurvivesUnexpectedShape(t *testing.T) {
+	// A result whose Cacheable-shaped fields have the wrong kinds. Not an
+	// mcp.CacheableResult, so it short-circuits before reflection — the point
+	// is that neither branch panics.
+	cases := []struct {
+		name string
+		res  mcp.Result
+	}{
+		{"nil result", nil},
+		{"non-cacheable result", &mcp.CallToolResult{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked on %s: %v", tc.name, r)
+				}
+			}()
+			applyPrivateCacheHints(tc.res, 60000)
+		})
+	}
+}
+
+func TestIsIntKindAcceptsOnlySignedInts(t *testing.T) {
+	// TTLMs is an int today; if the SDK widens or narrows it we still want to
+	// write it, but a change to string or float must fall through to the
+	// warning rather than panic.
+	for _, k := range []reflect.Kind{reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64} {
+		if !isIntKind(k) {
+			t.Errorf("isIntKind(%v) = false, want true", k)
+		}
+	}
+	for _, k := range []reflect.Kind{reflect.String, reflect.Float64, reflect.Bool, reflect.Uint} {
+		if isIntKind(k) {
+			t.Errorf("isIntKind(%v) = true, want false", k)
+		}
 	}
 }

--- a/internal/mcp/cachescope_test.go
+++ b/internal/mcp/cachescope_test.go
@@ -216,23 +216,35 @@ func TestSetCacheHintsWritesTheHints(t *testing.T) {
 	}
 }
 
-// TestSetCacheHintsGivesUpWithoutPanicking covers every guard. Each of these
-// shapes would panic in reflect if the corresponding check were removed, so
-// deleting a guard fails this test rather than passing silently.
+// TestSetCacheHintsGivesUpWithoutPanicking covers every guard.
+//
+// Asserting the *specific* reason, not merely "some reason", is what keeps the
+// per-step checks load-bearing. The deferred recover would otherwise catch all
+// of these itself, so deleting a guard would still produce a non-empty reason
+// and this test would pass — the guards would quietly become decoration.
+// Pinning the reason means a deleted guard surfaces as "reflect panic: …"
+// instead of its specific diagnostic, and fails here.
 func TestSetCacheHintsGivesUpWithoutPanicking(t *testing.T) {
 	cases := []struct {
-		name   string
-		target any
+		name       string
+		target     any
+		wantReason string
 	}{
-		{"nil", nil},
-		{"non-pointer", goodShape{}},
-		{"typed nil pointer", (*goodShape)(nil)},
-		{"pointer to non-struct", new(int)},
-		{"no Cacheable field", &noCacheableField{}},
-		{"Cacheable is a pointer", &pointerCacheable{}},
-		{"TTLMs is not an int", &wrongTTLKind{}},
-		{"Cacheable promoted through a nil embedded pointer", &nilEmbeddedPointer{}},
-		{"CacheScope is not a string", &wrongScopeKind{}},
+		{"nil", nil, "result is not a non-nil pointer"},
+		{"non-pointer", goodShape{}, "result is not a non-nil pointer"},
+		{"typed nil pointer", (*goodShape)(nil), "result is not a non-nil pointer"},
+		{"pointer to non-struct", new(int), "result does not point at a struct"},
+		{"no Cacheable field", &noCacheableField{}, "no settable Cacheable field"},
+		{"Cacheable is a pointer", &pointerCacheable{}, "Cacheable field is not a struct"},
+		{"TTLMs is not an int", &wrongTTLKind{}, "unexpected CacheScope/TTLMs shape"},
+		{"CacheScope is not a string", &wrongScopeKind{}, "unexpected CacheScope/TTLMs shape"},
+		// The one case the recover is genuinely for: no per-step check can see
+		// it coming, because FieldByName only panics once it walks the index.
+		{
+			"Cacheable promoted through a nil embedded pointer",
+			&nilEmbeddedPointer{},
+			"reflect panic: reflect: indirection through nil pointer to embedded struct",
+		},
 	}
 
 	for _, tc := range cases {
@@ -242,8 +254,8 @@ func TestSetCacheHintsGivesUpWithoutPanicking(t *testing.T) {
 					t.Fatalf("panicked: %v", r)
 				}
 			}()
-			if reason := setCacheHints(tc.target, 60000); reason == "" {
-				t.Errorf("wrote hints to an unexpected shape; want a give-up reason")
+			if reason := setCacheHints(tc.target, 60000); reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
 			}
 		})
 	}

--- a/internal/mcp/cachescope_test.go
+++ b/internal/mcp/cachescope_test.go
@@ -151,32 +151,96 @@ func TestNewMCPServerInstallsCacheScopeMiddleware(t *testing.T) {
 	}
 }
 
-// TestApplyPrivateCacheHintsSurvivesUnexpectedShape guards the reflective path
-// against the scenario it exists for: an SDK whose Cacheable fields change type
-// or disappear. Reflection's SetString/SetInt panic on a kind mismatch, so a
-// naive implementation would take down the request rather than degrade.
-func TestApplyPrivateCacheHintsSurvivesUnexpectedShape(t *testing.T) {
-	// A result whose Cacheable-shaped fields have the wrong kinds. Not an
-	// mcp.CacheableResult, so it short-circuits before reflection — the point
-	// is that neither branch panics.
+// The shapes below stand in for SDK changes this code must survive. They can't
+// be fed through applyPrivateCacheHints — mcp.Result has an unexported method,
+// so nothing outside the SDK can implement it — which is why setCacheHints
+// takes `any`.
+type goodShape struct {
+	Cacheable struct {
+		CacheScope string
+		TTLMs      int
+	}
+}
+
+type wrongTTLKind struct {
+	Cacheable struct {
+		CacheScope string
+		TTLMs      string
+	}
+}
+
+type wrongScopeKind struct {
+	Cacheable struct {
+		CacheScope int
+		TTLMs      int
+	}
+}
+
+type pointerCacheable struct {
+	Cacheable *struct {
+		CacheScope string
+		TTLMs      int
+	}
+}
+
+type noCacheableField struct {
+	Other string
+}
+
+// TestSetCacheHintsWritesTheHints is the happy path through the reflection.
+func TestSetCacheHintsWritesTheHints(t *testing.T) {
+	target := &goodShape{}
+
+	if reason := setCacheHints(target, 60000); reason != "" {
+		t.Fatalf("gave up unexpectedly: %s", reason)
+	}
+	if target.Cacheable.CacheScope != "private" || target.Cacheable.TTLMs != 60000 {
+		t.Errorf("got (%q, %d), want (\"private\", 60000)", target.Cacheable.CacheScope, target.Cacheable.TTLMs)
+	}
+}
+
+// TestSetCacheHintsGivesUpWithoutPanicking covers every guard. Each of these
+// shapes would panic in reflect if the corresponding check were removed, so
+// deleting a guard fails this test rather than passing silently.
+func TestSetCacheHintsGivesUpWithoutPanicking(t *testing.T) {
 	cases := []struct {
-		name string
-		res  mcp.Result
+		name   string
+		target any
 	}{
-		{"nil result", nil},
-		{"non-cacheable result", &mcp.CallToolResult{}},
+		{"nil", nil},
+		{"non-pointer", goodShape{}},
+		{"typed nil pointer", (*goodShape)(nil)},
+		{"pointer to non-struct", new(int)},
+		{"no Cacheable field", &noCacheableField{}},
+		{"Cacheable is a pointer", &pointerCacheable{}},
+		{"TTLMs is not an int", &wrongTTLKind{}},
+		{"CacheScope is not a string", &wrongScopeKind{}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
-					t.Fatalf("panicked on %s: %v", tc.name, r)
+					t.Fatalf("panicked: %v", r)
 				}
 			}()
-			applyPrivateCacheHints(tc.res, 60000)
+			if reason := setCacheHints(tc.target, 60000); reason == "" {
+				t.Errorf("wrote hints to an unexpected shape; want a give-up reason")
+			}
 		})
 	}
+}
+
+// TestApplyPrivateCacheHintsIgnoresNonCacheableResults keeps tools/call — which
+// carries no caching hints — passing through untouched.
+func TestApplyPrivateCacheHintsIgnoresNonCacheableResults(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	applyPrivateCacheHints(&mcp.CallToolResult{}, 60000)
+	applyPrivateCacheHints(nil, 60000)
 }
 
 func TestIsIntKindAcceptsOnlySignedInts(t *testing.T) {

--- a/internal/mcp/newserver.go
+++ b/internal/mcp/newserver.go
@@ -1,0 +1,19 @@
+package mcpserver
+
+import (
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewMCPServer builds an MCP server configured the way every sx surface needs
+// it — currently `sx mcp` over stdio and `sx cloud serve` over the relay.
+//
+// This exists so the cacheScope middleware can't be omitted. Wiring it at each
+// construction site meant a third site added later would ship the SDK's
+// "public" default, which is precisely the cross-user cache hint the
+// middleware is there to prevent — and the omission would be invisible, since
+// every test that builds its own server would still pass.
+func NewMCPServer(impl *mcp.Implementation) *mcp.Server {
+	server := mcp.NewServer(impl, nil)
+	server.AddReceivingMiddleware(PrivateCacheScopeMiddleware(DefaultCacheTTL))
+	return server
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -59,8 +59,7 @@ func (s *Server) Run(ctx context.Context) error {
 		Version: "1.0.0",
 	}
 
-	mcpServer := mcp.NewServer(impl, nil)
-	mcpServer.AddReceivingMiddleware(PrivateCacheScopeMiddleware(DefaultCacheTTL))
+	mcpServer := NewMCPServer(impl)
 
 	// NOTE: read_skill tool is available but not currently registered.
 	// It can be re-enabled for clients that don't support native skill discovery.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -60,6 +60,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	mcpServer := mcp.NewServer(impl, nil)
+	mcpServer.AddReceivingMiddleware(PrivateCacheScopeMiddleware(DefaultCacheTTL))
 
 	// NOTE: read_skill tool is available but not currently registered.
 	// It can be re-enabled for clients that don't support native skill discovery.

--- a/internal/vault/sleuth.go
+++ b/internal/vault/sleuth.go
@@ -796,8 +796,10 @@ func (s *SleuthVault) resolveAssetNode(
 }
 
 // QueryIntegrationStream queries integrated services using SSE streaming.
-// The onEvent callback is called for each event received, which can be used
-// to send MCP log notifications to keep the connection alive.
+// The onEvent callback is called for each event received; the MCP layer
+// forwards those as `notifications/progress` when the client supplied a
+// progressToken. Note that events fire on tool-call boundaries, so a query
+// spending its time inside one API call produces no callbacks.
 func (s *SleuthVault) QueryIntegrationStream(
 	ctx context.Context,
 	query, integration string,

--- a/internal/vault/sleuth_mcp.go
+++ b/internal/vault/sleuth_mcp.go
@@ -2,7 +2,6 @@ package vault
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -81,20 +80,36 @@ func (s *SleuthVault) handleQueryTool(ctx context.Context, req *mcp.CallToolRequ
 
 	log.Debug("calling sleuth query API with SSE streaming", "repoUrl", gitCtx.RepoURL, "branch", branch, "commit", commit)
 
-	// Create event callback that sends MCP log notifications to keep connection alive
+	// Create event callback that streams progress back to the client. The
+	// traffic doubles as a keepalive, which is what stops a long query from
+	// tripping the client's idle timeout.
+	//
+	// This used to send `notifications/message` via Session.Log. MCP
+	// 2026-07-28 deprecated the Logging feature (SEP-2577) and — more
+	// pointedly — forbids emitting log notifications for a request that didn't
+	// ask for them. Progress notifications are the request-scoped mechanism
+	// that survived, and they carry the same "still working" signal.
+	//
+	// Progress is opt-in: the client requests it with a progressToken in the
+	// request's `_meta`. Without one there's nothing to correlate a
+	// notification to, so we log locally and send nothing over the wire.
+	progressToken := req.Params.GetProgressToken()
+	var progressSeq float64
 	onEvent := func(eventType, content string) {
 		log.Debug("query progress", "type", eventType, "content", content)
 
-		// Send log notification to Claude Code via MCP
-		// This writes to stdio, keeping the connection alive and preventing timeout
-		logData, _ := json.Marshal(map[string]string{
-			"event":   eventType,
-			"message": content,
-		})
-		_ = req.Session.Log(ctx, &mcp.LoggingMessageParams{
-			Level:  "info",
-			Logger: "sleuth-query",
-			Data:   logData,
+		if progressToken == nil {
+			return
+		}
+		progressSeq++
+		_ = req.Session.NotifyProgress(ctx, &mcp.ProgressNotificationParams{
+			ProgressToken: progressToken,
+			// Total stays unset: the API streams until it's done, so progress
+			// climbs without ever forming a completion ratio. The spec allows
+			// exactly this ("should increase every time progress is made, even
+			// if the total is unknown").
+			Progress: progressSeq,
+			Message:  fmt.Sprintf("%s: %s", eventType, content),
 		})
 	}
 

--- a/internal/vault/sleuth_mcp.go
+++ b/internal/vault/sleuth_mcp.go
@@ -80,9 +80,7 @@ func (s *SleuthVault) handleQueryTool(ctx context.Context, req *mcp.CallToolRequ
 
 	log.Debug("calling sleuth query API with SSE streaming", "repoUrl", gitCtx.RepoURL, "branch", branch, "commit", commit)
 
-	// Create event callback that streams progress back to the client. The
-	// traffic doubles as a keepalive, which is what stops a long query from
-	// tripping the client's idle timeout.
+	// Create event callback that streams progress back to the client.
 	//
 	// This used to send `notifications/message` via Session.Log. MCP
 	// 2026-07-28 deprecated the Logging feature (SEP-2577) and — more
@@ -93,6 +91,17 @@ func (s *SleuthVault) handleQueryTool(ctx context.Context, req *mcp.CallToolRequ
 	// Progress is opt-in: the client requests it with a progressToken in the
 	// request's `_meta`. Without one there's nothing to correlate a
 	// notification to, so we log locally and send nothing over the wire.
+	//
+	// Note this is *not* a guaranteed keepalive, and the code it replaced
+	// wasn't either — Session.Log returned early unless the client had called
+	// logging/setLevel. Two gaps remain: a client that sends no progressToken
+	// gets no traffic at all, and QueryIntegrationStream only invokes onEvent
+	// on a ToolCallEvent, so a query that spends its time inside one API call
+	// emits nothing even with a token. There is no protocol-level fix
+	// available here: `ping` was removed in 2026-07-28 alongside the rest, and
+	// the SDK rejects it outright for modern peers (server.go:1880). If idle
+	// timeouts become a real problem, the fix belongs in the streaming API —
+	// emitting periodic heartbeat events — not in this callback.
 	progressToken := req.Params.GetProgressToken()
 	var progressSeq float64
 	onEvent := func(eventType, content string) {

--- a/internal/vault/sleuth_mcp.go
+++ b/internal/vault/sleuth_mcp.go
@@ -97,11 +97,15 @@ func (s *SleuthVault) handleQueryTool(ctx context.Context, req *mcp.CallToolRequ
 	// logging/setLevel. Two gaps remain: a client that sends no progressToken
 	// gets no traffic at all, and QueryIntegrationStream only invokes onEvent
 	// on a ToolCallEvent, so a query that spends its time inside one API call
-	// emits nothing even with a token. There is no protocol-level fix
-	// available here: `ping` was removed in 2026-07-28 alongside the rest, and
-	// the SDK rejects it outright for modern peers (server.go:1880). If idle
-	// timeouts become a real problem, the fix belongs in the streaming API —
-	// emitting periodic heartbeat events — not in this callback.
+	// emits nothing even with a token.
+	//
+	// No protocol-level keepalive is available for new-protocol peers: `ping`
+	// was removed in 2026-07-28 and the SDK rejects it for them
+	// (server.go:1880). `ServerOptions.KeepAlive` does still work for legacy
+	// peers, but it's a per-server setting and would tear down modern
+	// sessions, so sx doesn't enable it. If idle timeouts become a real
+	// problem the fix belongs in the streaming API — periodic heartbeat
+	// events — not in this callback.
 	progressToken := req.Params.GetProgressToken()
 	var progressSeq float64
 	onEvent := func(eventType, content string) {


### PR DESCRIPTION
## Summary
The MCP spec was revised on 2026-07-28, replacing the stateful session/handshake model with a stateless per-request protocol. sx exposes MCP from `sx mcp` (stdio) and `sx cloud serve` (relay), both built on the Go SDK.

- Bump `modelcontextprotocol/go-sdk` v1.6.1 → v1.7.0. This brings `server/discover`, `resultType`, `serverInfo` annotation, and dual-era client fallback essentially for free
- Force `cacheScope: private` on every cacheable result. The SDK defaults to `"public"`, which licenses any client or caching proxy to serve a response to a *different* user. An sx server always serves exactly one person's vault, so that default is wrong for us and there's no caching benefit to it either. Applied as receiving middleware rather than per-handler so a new tool or vault type can't silently miss it
- Replace the deprecated `Session.Log` keepalive in `sleuth_mcp.go` with progress notifications. The SDK bump surfaced that Logging is deprecated (SEP-2577) — and more pointedly, the new spec forbids emitting log notifications for a request that didn't ask for them, so the existing keepalive was actively non-compliant rather than merely deprecated. Progress is the request-scoped mechanism that survived; it's gated on the client sending a `progressToken`
- Add bridge tests covering `server/discover`, modern `tools/call`, and legacy `initialize` across the full relay round-trip

The `cacheScope` assertions were mutation-checked: flipping the constant to `"public"` fails three tests across the middleware unit tests and the end-to-end relay round-trip.

Companion PR in pulse: sleuth-io/pulse#4096 — pulse is the HTTP-facing MCP endpoint for the relay, so header validation and envelope backfill live there (the relay envelope carries no HTTP headers).

**Security implications of changes have been considered**