### PR TITLE
SK-738: Document config env vars, fix install.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ make build && ./dist/sx <command>
 - [Usage analytics](docs/stats.md) - `sx stats` dashboard and event format
 - [Metadata Spec](docs/metadata-spec.md) - Asset metadata format and fields
 - [MCP Spec](docs/mcp-spec.md) - MCP server tools (query)
+- [Environment Variables](docs/environment-variables.md) - SX_CONFIG_DIR, SX_CACHE_DIR, and isolation recipes
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ See LICENSE file for details.
 - [Profiles](docs/profiles.md) - Multiple configuration profiles
 - [Clients](docs/clients.md) - Client support model and IDE vs CLI limitations
 - [Cloud relay](docs/cloud-relay.md) - Expose your vault to claude.ai and chatgpt.com via skills.new
+- [Environment Variables](docs/environment-variables.md) - SX_CONFIG_DIR, SX_CACHE_DIR, and sandbox recipes
 - [Library](docs/library.md) - Use sx as a Go library via the `pkg/sxvault` public API
 
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,59 @@
+# Environment Variables
+
+sx honors a small set of environment variables that relocate its state.
+They are the supported way to isolate sx — in CI, Docker, test
+harnesses, demo recordings, or any sandbox — without overriding `$HOME`.
+All of them work on every platform.
+
+## Supported variables
+
+### `SX_CONFIG_DIR`
+
+Overrides the **config directory** — where sx reads and writes
+`config.json` (vault URL, profile, auth). This is the config-isolation
+boundary: point it at an empty directory and sx starts unconfigured,
+leaving real user state untouched.
+
+When unset, sx uses the platform default:
+
+| Platform | Default |
+|----------|---------|
+| Linux    | `$XDG_CONFIG_HOME/sx` (falls back to `~/.config/sx`) |
+| macOS    | `~/Library/Application Support/sx` |
+| Windows  | `%AppData%\sx` |
+
+### `SKILLS_CONFIG_DIR`
+
+Legacy alias for `SX_CONFIG_DIR`, checked only when `SX_CONFIG_DIR` is
+unset. Prefer `SX_CONFIG_DIR` in new setups.
+
+### `SX_CACHE_DIR`
+
+Overrides the **cache directory** — downloaded assets, cloned git
+repositories, ETags, and lock files. When unset, sx uses the platform
+cache default (e.g. `~/Library/Caches/sx` on macOS, `$XDG_CACHE_HOME/sx`
+or `~/.cache/sx` on Linux).
+
+## Isolating sx completely
+
+Set both variables to sandbox directories:
+
+```bash
+export SX_CONFIG_DIR="$SANDBOX/config"
+export SX_CACHE_DIR="$SANDBOX/cache"
+
+sx init --type git --repo-url "$VAULT_URL"
+sx install
+sx config   # verify: reported config path is under $SX_CONFIG_DIR
+```
+
+Always verify isolation with `sx config` — it prints the effective
+config path.
+
+## What is *not* an sx environment variable
+
+`SX_CONFIG` is **not** read by sx on any platform. A variable of that
+name previously appeared inside the generated vault `install.sh` as a
+script-local file path (it has since been renamed `SX_CONFIG_FILE`
+there). Setting `SX_CONFIG` in the environment has no effect — use
+`SX_CONFIG_DIR` (a directory, not a file path) to relocate config.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,8 +34,13 @@ When unset, sx uses the platform default:
 
 Overrides the **cache directory** — downloaded assets, cloned git
 repositories, ETags, and lock files. When unset, sx uses the platform
-cache default (e.g. `~/Library/Caches/sx` on macOS, `$XDG_CACHE_HOME/sx`
-or `~/.cache/sx` on Linux).
+default:
+
+| Platform | Default |
+|----------|---------|
+| Linux    | `$XDG_CACHE_HOME/sx` (falls back to `~/.cache/sx`) |
+| macOS    | `~/Library/Caches/sx` |
+| Windows  | `%LocalAppData%\sx` |
 
 `SKILLS_CACHE_DIR` is the legacy alias, checked only when
 `SX_CACHE_DIR` is unset.
@@ -50,6 +55,7 @@ overrides all three:
 export HOME="$SANDBOX/home"          # client install targets (~/.claude, …)
 export SX_CONFIG_DIR="$SANDBOX/config"
 export SX_CACHE_DIR="$SANDBOX/cache"
+export DISABLE_AUTOUPDATER=1         # no background binary replacement
 mkdir -p "$HOME"
 
 sx init --type git --repo-url "$VAULT_URL"
@@ -59,8 +65,9 @@ sx config   # verify: reported config path is under $SX_CONFIG_DIR
 
 Always verify isolation with `sx config` — it prints the effective
 config path and directories. Also make sure the sandbox environment
-doesn't inherit a stray `SX_PROFILE` (below), which would change which
-profile a sandboxed run resolves.
+doesn't inherit a stray `SX_PROFILE`, `SX_BOT`, or `SX_BOT_KEY`
+(below), which would change which profile or identity a sandboxed run
+resolves.
 
 ## Other variables
 
@@ -70,11 +77,15 @@ state:
 | Variable | Effect |
 |----------|--------|
 | `SX_PROFILE` | Selects the active config profile, overriding the one saved in config |
+| `SX_BOT` | Runs as the named bot identity (see [Bots](bots.md)) |
+| `SX_BOT_KEY` | Authentication key for the bot identity (see [Bots](bots.md)) |
 | `SX_STRICT` | `1` makes hook installs that soft-skip count as failures (same as `--strict`) |
 | `SX_SSH_KEY` | SSH key path (or inline key content) for git operations (same as `--ssh-key`; legacy alias `SKILLS_SSH_KEY`) |
 | `SX_SYNC_SILENT` | `true` silences background sync output (legacy alias `SKILLS_SYNC_SILENT`) |
 | `SX_CLOUD_URL` | Overrides the cloud relay URL for `sx cloud` |
 | `SX_CLI_PATH` | Overrides which sx binary gets written into client hook/MCP configs |
+| `SLEUTH_SERVER_URL` | Overrides the Sleuth server URL for `type=sleuth` vaults |
+| `DISABLE_AUTOUPDATER` | Truthy (`1`/`true`/`yes`/`on`) disables the background self-updater — recommended in CI and containers |
 
 ## What is *not* an sx environment variable
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,18 +1,23 @@
 # Environment Variables
 
-sx honors a small set of environment variables that relocate its state.
-They are the supported way to isolate sx — in CI, Docker, test
-harnesses, demo recordings, or any sandbox — without overriding `$HOME`.
-All of them work on every platform.
+sx honors a small set of environment variables that relocate its own
+state — config and cache. They work on every platform and are the
+supported way to redirect that state in CI, Docker, test harnesses,
+demo recordings, or any sandbox.
 
-## Supported variables
+Note their scope: these variables isolate **sx's own state only**.
+Client install targets (`~/.claude`, `~/.codex`, …) are derived from
+the home directory, so fully sandboxing `sx install` also requires
+overriding `$HOME` — see the recipe below.
+
+## State-relocating variables
 
 ### `SX_CONFIG_DIR`
 
 Overrides the **config directory** — where sx reads and writes
-`config.json` (vault URL, profile, auth). This is the config-isolation
-boundary: point it at an empty directory and sx starts unconfigured,
-leaving real user state untouched.
+`config.json` (vault URL, profile, auth). Point it at an empty
+directory and sx starts unconfigured, leaving real user config
+untouched.
 
 When unset, sx uses the platform default:
 
@@ -22,10 +27,8 @@ When unset, sx uses the platform default:
 | macOS    | `~/Library/Application Support/sx` |
 | Windows  | `%AppData%\sx` |
 
-### `SKILLS_CONFIG_DIR`
-
-Legacy alias for `SX_CONFIG_DIR`, checked only when `SX_CONFIG_DIR` is
-unset. Prefer `SX_CONFIG_DIR` in new setups.
+`SKILLS_CONFIG_DIR` is the legacy alias, checked only when
+`SX_CONFIG_DIR` is unset. Prefer `SX_CONFIG_DIR` in new setups.
 
 ### `SX_CACHE_DIR`
 
@@ -34,13 +37,20 @@ repositories, ETags, and lock files. When unset, sx uses the platform
 cache default (e.g. `~/Library/Caches/sx` on macOS, `$XDG_CACHE_HOME/sx`
 or `~/.cache/sx` on Linux).
 
-## Isolating sx completely
+`SKILLS_CACHE_DIR` is the legacy alias, checked only when
+`SX_CACHE_DIR` is unset.
 
-Set both variables to sandbox directories:
+## Sandboxing sx completely
+
+Config and cache cover sx's own state, but `sx install` writes assets
+into client directories under the home directory. A complete sandbox
+overrides all three:
 
 ```bash
+export HOME="$SANDBOX/home"          # client install targets (~/.claude, …)
 export SX_CONFIG_DIR="$SANDBOX/config"
 export SX_CACHE_DIR="$SANDBOX/cache"
+mkdir -p "$HOME"
 
 sx init --type git --repo-url "$VAULT_URL"
 sx install
@@ -48,7 +58,23 @@ sx config   # verify: reported config path is under $SX_CONFIG_DIR
 ```
 
 Always verify isolation with `sx config` — it prints the effective
-config path.
+config path and directories. Also make sure the sandbox environment
+doesn't inherit a stray `SX_PROFILE` (below), which would change which
+profile a sandboxed run resolves.
+
+## Other variables
+
+These behave as flag or setting equivalents rather than relocating
+state:
+
+| Variable | Effect |
+|----------|--------|
+| `SX_PROFILE` | Selects the active config profile, overriding the one saved in config |
+| `SX_STRICT` | `1` makes hook installs that soft-skip count as failures (same as `--strict`) |
+| `SX_SSH_KEY` | SSH key path (or inline key content) for git operations (same as `--ssh-key`; legacy alias `SKILLS_SSH_KEY`) |
+| `SX_SYNC_SILENT` | `true` silences background sync output (legacy alias `SKILLS_SYNC_SILENT`) |
+| `SX_CLOUD_URL` | Overrides the cloud relay URL for `sx cloud` |
+| `SX_CLI_PATH` | Overrides which sx binary gets written into client hook/MCP configs |
 
 ## What is *not* an sx environment variable
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -7,8 +7,11 @@ demo recordings, or any sandbox.
 
 Note their scope: these variables isolate **sx's own state only**.
 Client install targets (`~/.claude`, `~/.codex`, …) are derived from
-the home directory, so fully sandboxing `sx install` also requires
-overriding `$HOME` — see the recipe below.
+the home directory, and repo-scoped clients (GitHub Copilot's
+`.github/hooks/`, Kiro's `.kiro/hooks/`) write into the **current
+repository's working tree** — so fully sandboxing `sx install` also
+requires overriding `$HOME` and running from a scratch directory. See
+the recipe below.
 
 ## State-relocating variables
 
@@ -57,6 +60,7 @@ export SX_CONFIG_DIR="$SANDBOX/config"
 export SX_CACHE_DIR="$SANDBOX/cache"
 export DISABLE_AUTOUPDATER=1         # no background binary replacement
 mkdir -p "$HOME"
+cd "$HOME"   # repo-scoped clients write into the current repo's working tree
 
 sx init --type git --repo-url "$VAULT_URL"
 sx install

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -55,6 +55,10 @@ into client directories under the home directory. A complete sandbox
 overrides all three:
 
 ```bash
+set -u                               # fail loudly on any unset variable
+SANDBOX="$(mktemp -d)"
+VAULT_URL="https://github.com/acme/vault"   # your vault URL
+
 export HOME="$SANDBOX/home"          # client install targets (~/.claude, …)
 export SX_CONFIG_DIR="$SANDBOX/config"
 export SX_CACHE_DIR="$SANDBOX/cache"

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -120,8 +120,9 @@ Environment variables:
   SX_CONFIG_DIR      Override the config directory (isolation boundary)
   SKILLS_CONFIG_DIR  Legacy alias for SX_CONFIG_DIR
   SX_CACHE_DIR       Override the cache directory
+  SKILLS_CACHE_DIR   Legacy alias for SX_CACHE_DIR
 
-See docs/environment-variables.md for details.`,
+See https://github.com/sleuth-io/sx/blob/main/docs/environment-variables.md for details.`,
 		RunE: runConfig,
 	}
 	cmd.Flags().Bool("json", false, "Output in JSON format")

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -114,8 +114,15 @@ func NewConfigCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Display configuration and installation status",
-		Long:  "Shows current configuration, detected clients, installed assets, and paths for debugging and remote support.",
-		RunE:  runConfig,
+		Long: `Shows current configuration, detected clients, installed assets, and paths for debugging and remote support.
+
+Environment variables:
+  SX_CONFIG_DIR      Override the config directory (isolation boundary)
+  SKILLS_CONFIG_DIR  Legacy alias for SX_CONFIG_DIR
+  SX_CACHE_DIR       Override the cache directory
+
+See docs/environment-variables.md for details.`,
+		RunE: runConfig,
 	}
 	cmd.Flags().Bool("json", false, "Output in JSON format")
 	cmd.Flags().Bool("all", false, "Show all assets from lock file, not just those for current repo context")

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -37,7 +37,7 @@ var readmeTemplate string
 const (
 	// installScriptTemplateVersion is the current version of the install.sh template
 	// Increment this when making changes to the template
-	installScriptTemplateVersion = "1"
+	installScriptTemplateVersion = "2"
 
 	// gitSyncTTL is how long cloneOrUpdate trusts the local clone before
 	// pulling again. Within the window every read short-circuits to the

--- a/internal/vault/gitrepo_test.go
+++ b/internal/vault/gitrepo_test.go
@@ -186,6 +186,10 @@ func TestGenerateInstallScript_ConfigFileCheck(t *testing.T) {
 		"${APPDATA:-$HOME/AppData/Roaming}/sx/config.json",
 		"MINGW*|MSYS*|CYGWIN*",
 		`[ -f "$SX_CONFIG_FILE" ]`,
+		// The "already configured" check must match this vault's URL, not
+		// mere file existence — a different vault's config is not success.
+		`grep -qF "$VAULT_URL" "$SX_CONFIG_FILE"`,
+		"SX_PROFILE=<name> sx init",
 	} {
 		if !strings.Contains(result, want) {
 			t.Errorf("generateInstallScript() should contain %q", want)
@@ -197,6 +201,9 @@ func TestGenerateInstallScript_ConfigFileCheck(t *testing.T) {
 	}
 	if strings.Contains(result, `"$SX_CONFIG"`) {
 		t.Error("generateInstallScript() still uses the misleading SX_CONFIG variable")
+	}
+	if strings.Index(result, "VAULT_URL=") > strings.Index(result, `grep -qF "$VAULT_URL"`) {
+		t.Error("VAULT_URL must be assigned before the already-configured check uses it")
 	}
 }
 

--- a/internal/vault/gitrepo_test.go
+++ b/internal/vault/gitrepo_test.go
@@ -183,6 +183,8 @@ func TestGenerateInstallScript_ConfigFileCheck(t *testing.T) {
 		`[ -n "$SKILLS_CONFIG_DIR" ]`,
 		"Library/Application Support/sx/config.json",
 		"${XDG_CONFIG_HOME:-$HOME/.config}/sx/config.json",
+		"${APPDATA:-$HOME/AppData/Roaming}/sx/config.json",
+		"MINGW*|MSYS*|CYGWIN*",
 		`[ -f "$SX_CONFIG_FILE" ]`,
 	} {
 		if !strings.Contains(result, want) {

--- a/internal/vault/gitrepo_test.go
+++ b/internal/vault/gitrepo_test.go
@@ -169,6 +169,35 @@ func TestGenerateInstallScript(t *testing.T) {
 	}
 }
 
+// TestGenerateInstallScript_ConfigFileCheck guards against issue #219:
+// the script's "already configured?" check must use the script-local
+// SX_CONFIG_FILE name (not the env-var-lookalike SX_CONFIG), honor the
+// real SX_CONFIG_DIR/SKILLS_CONFIG_DIR overrides, and not point at the
+// stale legacy sleuth/skills path sx no longer writes.
+func TestGenerateInstallScript_ConfigFileCheck(t *testing.T) {
+	result := generateInstallScript("https://github.com/test/repo.git")
+
+	for _, want := range []string{
+		"SX_CONFIG_FILE=",
+		`[ -n "$SX_CONFIG_DIR" ]`,
+		`[ -n "$SKILLS_CONFIG_DIR" ]`,
+		"Library/Application Support/sx/config.json",
+		"${XDG_CONFIG_HOME:-$HOME/.config}/sx/config.json",
+		`[ -f "$SX_CONFIG_FILE" ]`,
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("generateInstallScript() should contain %q", want)
+		}
+	}
+
+	if strings.Contains(result, ".config/sleuth/skills") {
+		t.Error("generateInstallScript() still references the stale legacy config path")
+	}
+	if strings.Contains(result, `"$SX_CONFIG"`) {
+		t.Error("generateInstallScript() still uses the misleading SX_CONFIG variable")
+	}
+}
+
 func TestGenerateReadme(t *testing.T) {
 	repoURL := "https://github.com/test/repo.git"
 	result := generateReadme(repoURL)

--- a/internal/vault/gitrepo_test.go
+++ b/internal/vault/gitrepo_test.go
@@ -186,10 +186,18 @@ func TestGenerateInstallScript_ConfigFileCheck(t *testing.T) {
 		"${APPDATA:-$HOME/AppData/Roaming}/sx/config.json",
 		"MINGW*|MSYS*|CYGWIN*",
 		`[ -f "$SX_CONFIG_FILE" ]`,
-		// The "already configured" check must match this vault's URL, not
-		// mere file existence — a different vault's config is not success.
-		`grep -qF "$VAULT_URL" "$SX_CONFIG_FILE"`,
+		// The "already configured" check must compare this vault's URL
+		// against each configured repositoryUrl value (normalized), not
+		// grep the file for a substring — and a different vault's config
+		// is not success.
+		"normalize_vault_url",
+		`s#\.git$##`,
+		`s#^git@([^:]+):#https://\1/#`,
+		`"repositoryUrl"`,
 		"SX_PROFILE=<name> sx init",
+		"sx profile activate <name>",
+		// Credential-bearing URLs must not be echoed verbatim.
+		`s#://[^/@]+@#://#`,
 	} {
 		if !strings.Contains(result, want) {
 			t.Errorf("generateInstallScript() should contain %q", want)
@@ -202,7 +210,7 @@ func TestGenerateInstallScript_ConfigFileCheck(t *testing.T) {
 	if strings.Contains(result, `"$SX_CONFIG"`) {
 		t.Error("generateInstallScript() still uses the misleading SX_CONFIG variable")
 	}
-	if strings.Index(result, "VAULT_URL=") > strings.Index(result, `grep -qF "$VAULT_URL"`) {
+	if strings.Index(result, "VAULT_URL=") > strings.Index(result, `normalize_vault_url "$VAULT_URL"`) {
 		t.Error("VAULT_URL must be assigned before the already-configured check uses it")
 	}
 }

--- a/internal/vault/gitrepo_test.go
+++ b/internal/vault/gitrepo_test.go
@@ -194,7 +194,10 @@ func TestGenerateInstallScript_ConfigFileCheck(t *testing.T) {
 		`s#\.git$##`,
 		`s#^git@([^:]+):#https://\1/#`,
 		`"repositoryUrl"`,
-		"SX_PROFILE=<name> sx init",
+		// The remediation must use the interactive profile add flow: the
+		// non-interactive `SX_PROFILE=<name> sx init` path silently clears
+		// the global force-enabled/disabled client lists.
+		"sx profile add <name>",
 		"sx profile activate <name>",
 		// Credential-bearing URLs must not be echoed verbatim.
 		`s#://[^/@]+@#://#`,

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -173,6 +173,15 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 			},
 		},
 		{
+			// With SX_PROFILE set, the add-a-profile guidance must not
+			// prescribe a bare activate — the override keeps winning.
+			name:        "different vault with SX_PROFILE set adjusts guidance",
+			configJSON:  multiProfileConfig([]string{"other"}, "https://github.com/acme/other", "https://github.com/acme/third"),
+			extraEnv:    []string{"SX_PROFILE=other"},
+			wantExit:    1,
+			wantOutputs: []string{"add <name> to SX_PROFILE"},
+		},
+		{
 			name:        "no config falls through to sx init",
 			configJSON:  "",
 			wantExit:    0,

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -77,15 +77,17 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 			},
 		})
 	}
-	multiProfileConfig := func(activeURL, otherURL string) string {
+	// defaultURL belongs to profile "other" (the default); workURL to
+	// profile "work". activeProfiles controls which are active.
+	multiProfileConfig := func(activeProfiles []string, defaultURL, workURL string) string {
 		return marshal(testConfig{
 			DefaultProfile: "other",
-			ActiveProfiles: []string{"other"},
+			ActiveProfiles: activeProfiles,
 			Type:           "git",
-			RepositoryURL:  activeURL,
+			RepositoryURL:  defaultURL,
 			Profiles: map[string]testProfile{
-				"other": {Type: "git", RepositoryURL: activeURL},
-				"work":  {Type: "git", RepositoryURL: otherURL},
+				"other": {Type: "git", RepositoryURL: defaultURL},
+				"work":  {Type: "git", RepositoryURL: workURL},
 			},
 		})
 	}
@@ -125,13 +127,23 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 			// only loads active profiles, so exiting 0 here would be the
 			// silent-nothing outcome the check exists to prevent.
 			name:        "inactive profile matching this vault exits 1 with activate guidance",
-			configJSON:  multiProfileConfig("https://github.com/acme/other", "git@github.com:acme/vault.git"),
+			configJSON:  multiProfileConfig([]string{"other"}, "https://github.com/acme/other", "git@github.com:acme/vault.git"),
 			wantExit:    1,
 			wantOutputs: []string{"not active", "sx profile activate"},
 		},
 		{
+			// sx install merges every ACTIVE profile, not just the
+			// default — this is exactly the state the script's own
+			// remediation (profile add + activate) creates, so it must
+			// read as success.
+			name:        "second active profile matching this vault exits 0",
+			configJSON:  multiProfileConfig([]string{"other", "work"}, "https://github.com/acme/other", "git@github.com:acme/vault.git"),
+			wantExit:    0,
+			wantOutputs: []string{"already configured for this vault"},
+		},
+		{
 			name:       "no profile matches lists every configured vault",
-			configJSON: multiProfileConfig("https://github.com/acme/other", "https://github.com/acme/third"),
+			configJSON: multiProfileConfig([]string{"other"}, "https://github.com/acme/other", "https://github.com/acme/third"),
 			wantExit:   1,
 			wantOutputs: []string{
 				"sx profile activate",

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -144,12 +144,14 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 		},
 		{
 			// SX_PROFILE overrides the active set outright on sx's read
-			// side, so a file-active profile it excludes must not count.
+			// side, so a file-active profile it excludes must not count —
+			// and the remedy is fixing SX_PROFILE, not activating (which
+			// is a no-op while the override keeps winning).
 			name:        "SX_PROFILE excluding the matching profile exits 1",
 			configJSON:  multiProfileConfig([]string{"other", "work"}, "https://github.com/acme/other", "git@github.com:acme/vault.git"),
 			extraEnv:    []string{"SX_PROFILE=other"},
 			wantExit:    1,
-			wantOutputs: []string{"not active"},
+			wantOutputs: []string{"SX_PROFILE=other", "comma-separated) or unset SX_PROFILE"},
 		},
 		{
 			// …and a profile it includes counts even when the file's

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -1,8 +1,8 @@
 package vault
 
 import (
+	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,45 +43,104 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The fixture mirrors what sx actually writes: json.MarshalIndent
+	// output with the active profile's repositoryUrl duplicated at the
+	// top level for old-binary compat (internal/config/profile.go), so
+	// the script's extraction is tested against the real spacing and
+	// against multiple URL lines.
+	type testProfile struct {
+		Type          string `json:"type,omitempty"`
+		RepositoryURL string `json:"repositoryUrl,omitempty"`
+	}
+	type testConfig struct {
+		DefaultProfile string                 `json:"defaultProfile,omitempty"`
+		ActiveProfiles []string               `json:"activeProfiles,omitempty"`
+		Type           string                 `json:"type,omitempty"`
+		RepositoryURL  string                 `json:"repositoryUrl,omitempty"`
+		Profiles       map[string]testProfile `json:"profiles"`
+	}
+	marshal := func(cfg testConfig) string {
+		data, err := json.MarshalIndent(cfg, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(data)
+	}
 	configFor := func(url string) string {
-		return fmt.Sprintf(`{"profiles":{"default":{"repositoryUrl":%q}}}`, url)
+		return marshal(testConfig{
+			DefaultProfile: "default",
+			ActiveProfiles: []string{"default"},
+			Type:           "git",
+			RepositoryURL:  url,
+			Profiles: map[string]testProfile{
+				"default": {Type: "git", RepositoryURL: url},
+			},
+		})
+	}
+	multiProfileConfig := func(activeURL, otherURL string) string {
+		return marshal(testConfig{
+			DefaultProfile: "other",
+			ActiveProfiles: []string{"other"},
+			Type:           "git",
+			RepositoryURL:  activeURL,
+			Profiles: map[string]testProfile{
+				"other": {Type: "git", RepositoryURL: activeURL},
+				"work":  {Type: "git", RepositoryURL: otherURL},
+			},
+		})
 	}
 
 	cases := []struct {
-		name       string
-		configJSON string
-		wantExit   int
-		wantOutput string
+		name        string
+		configJSON  string
+		wantExit    int
+		wantOutputs []string
 	}{
 		{
-			name:       "same vault exits 0",
-			configJSON: configFor("https://github.com/acme/vault"),
-			wantExit:   0,
-			wantOutput: "already configured for this vault",
+			name:        "same vault exits 0",
+			configJSON:  configFor("https://github.com/acme/vault"),
+			wantExit:    0,
+			wantOutputs: []string{"already configured for this vault"},
 		},
 		{
-			name:       "ssh spelling of same vault exits 0",
-			configJSON: configFor("git@github.com:acme/vault.git"),
-			wantExit:   0,
-			wantOutput: "already configured for this vault",
+			name:        "ssh spelling of same vault exits 0",
+			configJSON:  configFor("git@github.com:acme/vault.git"),
+			wantExit:    0,
+			wantOutputs: []string{"already configured for this vault"},
 		},
 		{
-			name:       "gitless spelling of same vault exits 0",
-			configJSON: configFor("https://github.com/acme/vault.git"),
-			wantExit:   0,
-			wantOutput: "already configured for this vault",
+			name:        "gitless spelling of same vault exits 0",
+			configJSON:  configFor("https://github.com/acme/vault.git"),
+			wantExit:    0,
+			wantOutputs: []string{"already configured for this vault"},
 		},
 		{
-			name:       "prefix neighbour is a different vault",
-			configJSON: configFor("https://github.com/acme/vault-team"),
+			name:        "prefix neighbour is a different vault",
+			configJSON:  configFor("https://github.com/acme/vault-team"),
+			wantExit:    1,
+			wantOutputs: []string{"sx profile activate"},
+		},
+		{
+			name:        "inactive profile matching this vault exits 0",
+			configJSON:  multiProfileConfig("https://github.com/acme/other", "git@github.com:acme/vault.git"),
+			wantExit:    0,
+			wantOutputs: []string{"already configured for this vault"},
+		},
+		{
+			name:       "no profile matches lists every configured vault",
+			configJSON: multiProfileConfig("https://github.com/acme/other", "https://github.com/acme/third"),
 			wantExit:   1,
-			wantOutput: "sx profile activate",
+			wantOutputs: []string{
+				"sx profile activate",
+				"https://github.com/acme/other",
+				"https://github.com/acme/third",
+			},
 		},
 		{
-			name:       "no config falls through to sx init",
-			configJSON: "",
-			wantExit:   0,
-			wantOutput: "stub-sx init --type git --repo-url https://github.com/acme/vault",
+			name:        "no config falls through to sx init",
+			configJSON:  "",
+			wantExit:    0,
+			wantOutputs: []string{"stub-sx init --type git --repo-url https://github.com/acme/vault"},
 		},
 	}
 
@@ -112,8 +171,10 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 			if exit != tc.wantExit {
 				t.Fatalf("exit = %d, want %d\noutput:\n%s", exit, tc.wantExit, out)
 			}
-			if !strings.Contains(string(out), tc.wantOutput) {
-				t.Fatalf("output missing %q:\n%s", tc.wantOutput, out)
+			for _, want := range tc.wantOutputs {
+				if !strings.Contains(string(out), want) {
+					t.Fatalf("output missing %q:\n%s", want, out)
+				}
 			}
 		})
 	}

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -121,10 +121,13 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 			wantOutputs: []string{"sx profile activate"},
 		},
 		{
-			name:        "inactive profile matching this vault exits 0",
+			// A match in an inactive profile is NOT success: sx install
+			// only loads active profiles, so exiting 0 here would be the
+			// silent-nothing outcome the check exists to prevent.
+			name:        "inactive profile matching this vault exits 1 with activate guidance",
 			configJSON:  multiProfileConfig("https://github.com/acme/other", "git@github.com:acme/vault.git"),
-			wantExit:    0,
-			wantOutputs: []string{"already configured for this vault"},
+			wantExit:    1,
+			wantOutputs: []string{"not active", "sx profile activate"},
 		},
 		{
 			name:       "no profile matches lists every configured vault",

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -1,0 +1,139 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestInstallScriptSyntax runs the rendered install script through
+// bash -n so a template edit that breaks the shell fails here instead of
+// shipping to every vault.
+func TestInstallScriptSyntax(t *testing.T) {
+	requireBash(t)
+
+	scriptPath := writeRenderedInstallScript(t, "https://github.com/acme/vault")
+	if out, err := exec.Command("bash", "-n", scriptPath).CombinedOutput(); err != nil {
+		t.Fatalf("rendered install.sh has a shell syntax error: %v\n%s", err, out)
+	}
+}
+
+// TestInstallScriptConfigCheckExecution executes the rendered script
+// against fake configs and a stub sx binary, asserting the exit codes
+// the already-configured logic exists to distinguish. String assertions
+// can't hold this behavior — only running it can.
+func TestInstallScriptConfigCheckExecution(t *testing.T) {
+	requireBash(t)
+
+	scriptPath := writeRenderedInstallScript(t, "https://github.com/acme/vault")
+
+	// A stub sx first on PATH: `command -v sx` finds it, and
+	// --version / init are harmless no-ops.
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stub := "#!/bin/sh\necho \"stub-sx $*\"\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "sx"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	configFor := func(url string) string {
+		return fmt.Sprintf(`{"profiles":{"default":{"repositoryUrl":%q}}}`, url)
+	}
+
+	cases := []struct {
+		name       string
+		configJSON string
+		wantExit   int
+		wantOutput string
+	}{
+		{
+			name:       "same vault exits 0",
+			configJSON: configFor("https://github.com/acme/vault"),
+			wantExit:   0,
+			wantOutput: "already configured for this vault",
+		},
+		{
+			name:       "ssh spelling of same vault exits 0",
+			configJSON: configFor("git@github.com:acme/vault.git"),
+			wantExit:   0,
+			wantOutput: "already configured for this vault",
+		},
+		{
+			name:       "gitless spelling of same vault exits 0",
+			configJSON: configFor("https://github.com/acme/vault.git"),
+			wantExit:   0,
+			wantOutput: "already configured for this vault",
+		},
+		{
+			name:       "prefix neighbour is a different vault",
+			configJSON: configFor("https://github.com/acme/vault-team"),
+			wantExit:   1,
+			wantOutput: "sx profile activate",
+		},
+		{
+			name:       "no config falls through to sx init",
+			configJSON: "",
+			wantExit:   0,
+			wantOutput: "stub-sx init --type git --repo-url https://github.com/acme/vault",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgDir := t.TempDir()
+			if tc.configJSON != "" {
+				if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(tc.configJSON), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cmd := exec.Command("bash", scriptPath)
+			cmd.Env = append(os.Environ(),
+				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"SX_CONFIG_DIR="+cfgDir,
+			)
+			out, err := cmd.CombinedOutput()
+
+			exit := 0
+			if err != nil {
+				ee, ok := err.(*exec.ExitError)
+				if !ok {
+					t.Fatalf("failed to run script: %v\n%s", err, out)
+				}
+				exit = ee.ExitCode()
+			}
+			if exit != tc.wantExit {
+				t.Fatalf("exit = %d, want %d\noutput:\n%s", exit, tc.wantExit, out)
+			}
+			if !strings.Contains(string(out), tc.wantOutput) {
+				t.Fatalf("output missing %q:\n%s", tc.wantOutput, out)
+			}
+		})
+	}
+}
+
+func requireBash(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("requires bash")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+}
+
+func writeRenderedInstallScript(t *testing.T, repoURL string) string {
+	t.Helper()
+	script := generateInstallScript(repoURL)
+	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return scriptPath
+}

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -95,6 +95,7 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 	cases := []struct {
 		name        string
 		configJSON  string
+		extraEnv    []string
 		wantExit    int
 		wantOutputs []string
 	}{
@@ -142,6 +143,24 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 			wantOutputs: []string{"already configured for this vault"},
 		},
 		{
+			// SX_PROFILE overrides the active set outright on sx's read
+			// side, so a file-active profile it excludes must not count.
+			name:        "SX_PROFILE excluding the matching profile exits 1",
+			configJSON:  multiProfileConfig([]string{"other", "work"}, "https://github.com/acme/other", "git@github.com:acme/vault.git"),
+			extraEnv:    []string{"SX_PROFILE=other"},
+			wantExit:    1,
+			wantOutputs: []string{"not active"},
+		},
+		{
+			// …and a profile it includes counts even when the file's
+			// activeProfiles doesn't list it.
+			name:        "SX_PROFILE selecting the matching profile exits 0",
+			configJSON:  multiProfileConfig([]string{"other"}, "https://github.com/acme/other", "git@github.com:acme/vault.git"),
+			extraEnv:    []string{"SX_PROFILE=work"},
+			wantExit:    0,
+			wantOutputs: []string{"already configured for this vault"},
+		},
+		{
 			name:       "no profile matches lists every configured vault",
 			configJSON: multiProfileConfig([]string{"other"}, "https://github.com/acme/other", "https://github.com/acme/third"),
 			wantExit:   1,
@@ -169,10 +188,21 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 			}
 
 			cmd := exec.Command("bash", scriptPath)
-			cmd.Env = append(os.Environ(),
+			// Strip any host SX_PROFILE so only the case's extraEnv can
+			// set it — the script honors it, so a stray value would
+			// change the non-override cases.
+			env := make([]string, 0, len(os.Environ()))
+			for _, kv := range os.Environ() {
+				if strings.HasPrefix(kv, "SX_PROFILE=") {
+					continue
+				}
+				env = append(env, kv)
+			}
+			cmd.Env = append(env,
 				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 				"SX_CONFIG_DIR="+cfgDir,
 			)
+			cmd.Env = append(cmd.Env, tc.extraEnv...)
 			out, err := cmd.CombinedOutput()
 
 			exit := 0

--- a/internal/vault/install_script_test.go
+++ b/internal/vault/install_script_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -102,8 +103,8 @@ func TestInstallScriptConfigCheckExecution(t *testing.T) {
 
 			exit := 0
 			if err != nil {
-				ee, ok := err.(*exec.ExitError)
-				if !ok {
+				var ee *exec.ExitError
+				if !errors.As(err, &ee) {
 					t.Fatalf("failed to run script: %v\n%s", err, out)
 				}
 				exit = ee.ExitCode()

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -150,7 +150,15 @@ EOF
     echo "To add this vault as a separate profile, run:"
     echo "  sx profile add <name>   # enter this vault URL when prompted:"
     echo "  #   $VAULT_URL"
-    echo "  sx profile activate <name>"
+    # Activation guidance must match how sx will actually resolve the
+    # active set: while SX_PROFILE is set, activate is a no-op because
+    # the override keeps winning.
+    if [ -n "${SX_PROFILE:-}" ]; then
+        echo "  # then add <name> to SX_PROFILE (comma-separated), or unset"
+        echo "  # SX_PROFILE and run: sx profile activate <name>"
+    else
+        echo "  sx profile activate <name>"
+    fi
     echo
     echo "See docs/profiles.md in the sx repository for details."
     exit 1

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -6,7 +6,18 @@ set -e
 # Safe to run multiple times (idempotent).
 # Template version: {{.TEMPLATE_VERSION}}
 
-SX_CONFIG="$HOME/.config/sleuth/skills/config.json"
+# Resolve sx's config file location, mirroring the sx CLI's own lookup:
+# SX_CONFIG_DIR, then the legacy SKILLS_CONFIG_DIR, then the platform
+# default. This is a script-local file path, not an sx env var.
+if [ -n "$SX_CONFIG_DIR" ]; then
+    SX_CONFIG_FILE="$SX_CONFIG_DIR/config.json"
+elif [ -n "$SKILLS_CONFIG_DIR" ]; then
+    SX_CONFIG_FILE="$SKILLS_CONFIG_DIR/config.json"
+elif [ "$(uname)" = "Darwin" ]; then
+    SX_CONFIG_FILE="$HOME/Library/Application Support/sx/config.json"
+else
+    SX_CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/sx/config.json"
+fi
 
 # Check if sx CLI is already installed
 if command -v sx &> /dev/null; then
@@ -29,7 +40,7 @@ else
 fi
 
 # Check if already configured
-if [ -f "$SX_CONFIG" ]; then
+if [ -f "$SX_CONFIG_FILE" ]; then
     echo "✓ sx CLI is already configured"
     exit 0
 fi

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -66,12 +66,26 @@ normalize_vault_url() {
 # vault's config.
 if [ -n "$VAULT_URL" ] && [ -f "$SX_CONFIG_FILE" ]; then
     VAULT_URL_NORM="$(normalize_vault_url "$VAULT_URL")"
+    # The top-level repositoryUrl (exactly two spaces of indent in sx's
+    # pretty-printed config) is the ACTIVE profile's URL; profile blocks
+    # are indented deeper. Only an active match is success — a matching
+    # profile that isn't active still installs nothing, so it must say
+    # so rather than green-check.
+    ACTIVE_URL="$(grep -E '^  "repositoryUrl"' "$SX_CONFIG_FILE" | sed -E 's#.*:[[:space:]]*"([^"]*)".*#\1#' | head -1 || true)"
+    if [ -n "$ACTIVE_URL" ] && [ "$(normalize_vault_url "$ACTIVE_URL")" = "$VAULT_URL_NORM" ]; then
+        echo "✓ sx CLI is already configured for this vault"
+        exit 0
+    fi
     CONFIGURED_URLS="$(grep -o '"repositoryUrl"[[:space:]]*:[[:space:]]*"[^"]*"' "$SX_CONFIG_FILE" | sed -E 's#.*:[[:space:]]*"([^"]*)"#\1#' || true)"
     while IFS= read -r configured_url; do
         [ -n "$configured_url" ] || continue
         if [ "$(normalize_vault_url "$configured_url")" = "$VAULT_URL_NORM" ]; then
-            echo "✓ sx CLI is already configured for this vault"
-            exit 0
+            echo "sx CLI has a profile for this vault, but it is not active,"
+            echo "so 'sx install' will not install this vault's assets."
+            echo "Activate it with:"
+            echo "  sx profile list"
+            echo "  sx profile activate <name>"
+            exit 1
         fi
     done <<EOF
 $CONFIGURED_URLS

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -3,7 +3,9 @@ set -e
 
 # Auto-generated install script for sx asset vault
 # This script ensures the sx CLI is installed and configured.
-# Safe to run multiple times (idempotent).
+# Idempotent for this vault: re-running when already configured for it
+# is a no-op (exit 0). Exits non-zero when sx is configured for a
+# DIFFERENT vault, with instructions to add this one as a profile.
 # Template version: {{.TEMPLATE_VERSION}}
 
 # Resolve sx's config file location, mirroring the sx CLI's own lookup:
@@ -48,21 +50,42 @@ fi
 # The asset vault URL this script configures
 VAULT_URL="{{.REPO_URL}}"
 
+# Normalize a vault URL for comparison: strip a trailing .git and
+# rewrite the ssh form (git@host:path) to the https form, so equivalent
+# spellings of the same repository compare equal.
+normalize_vault_url() {
+    printf '%s' "$1" | sed -E -e 's#\.git$##' -e 's#^git@([^:]+):#https://\1/#'
+}
+
 # Check if already configured for THIS vault. config.json stores every
-# profile's repositoryUrl, so a plain match covers all profiles. Mere
-# existence of the file is not enough: being configured for a different
-# vault must not read as success, and running sx init here would
-# silently overwrite that other vault's config.
-if [ -f "$SX_CONFIG_FILE" ]; then
-    if grep -qF "$VAULT_URL" "$SX_CONFIG_FILE"; then
-        echo "✓ sx CLI is already configured for this vault"
-        exit 0
-    fi
+# profile's repositoryUrl; compare each full value (normalized), never a
+# substring — a substring match would call a repo that merely shares a
+# prefix "already configured". Mere existence of the file is not enough
+# either: being configured for a different vault must not read as
+# success, and running sx init here would silently overwrite that other
+# vault's config.
+if [ -n "$VAULT_URL" ] && [ -f "$SX_CONFIG_FILE" ]; then
+    VAULT_URL_NORM="$(normalize_vault_url "$VAULT_URL")"
+    CONFIGURED_URLS="$(grep -o '"repositoryUrl"[[:space:]]*:[[:space:]]*"[^"]*"' "$SX_CONFIG_FILE" | sed -E 's#.*:[[:space:]]*"([^"]*)"#\1#' || true)"
+    while IFS= read -r configured_url; do
+        [ -n "$configured_url" ] || continue
+        if [ "$(normalize_vault_url "$configured_url")" = "$VAULT_URL_NORM" ]; then
+            echo "✓ sx CLI is already configured for this vault"
+            exit 0
+        fi
+    done <<EOF
+$CONFIGURED_URLS
+EOF
     echo "sx CLI is already configured, but for a different vault:"
-    grep -o '"repositoryUrl"[^,}]*' "$SX_CONFIG_FILE" | head -5 || true
+    # Strip userinfo (user:token@) so credential-bearing URLs never land
+    # in logs.
+    printf '%s\n' "$CONFIGURED_URLS" | sed -E 's#://[^/@]+@#://#' | head -5
     echo
     echo "To add this vault as a separate profile, run:"
     echo "  SX_PROFILE=<name> sx init --type git --repo-url \"$VAULT_URL\""
+    echo "  sx profile activate <name>"
+    echo
+    echo "See docs/profiles.md in the sx repository for details."
     exit 1
 fi
 

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -82,7 +82,8 @@ EOF
     printf '%s\n' "$CONFIGURED_URLS" | sed -E 's#://[^/@]+@#://#' | head -5
     echo
     echo "To add this vault as a separate profile, run:"
-    echo "  SX_PROFILE=<name> sx init --type git --repo-url \"$VAULT_URL\""
+    echo "  sx profile add <name>   # enter this vault URL when prompted:"
+    echo "  #   $VAULT_URL"
     echo "  sx profile activate <name>"
     echo
     echo "See docs/profiles.md in the sx repository for details."

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -122,11 +122,21 @@ EOF
     while IFS= read -r configured_url; do
         [ -n "$configured_url" ] || continue
         if [ "$(normalize_vault_url "$configured_url")" = "$VAULT_URL_NORM" ]; then
-            echo "sx CLI has a profile for this vault, but it is not active,"
-            echo "so 'sx install' will not install this vault's assets."
-            echo "Activate it with:"
-            echo "  sx profile list"
-            echo "  sx profile activate <name>"
+            # Two distinct causes need two distinct remedies: an
+            # SX_PROFILE override excludes the profile (activating is a
+            # no-op — the override keeps winning), or the profile is
+            # genuinely not in activeProfiles.
+            if [ -n "${SX_PROFILE:-}" ]; then
+                echo "sx CLI has a profile for this vault, but SX_PROFILE=$SX_PROFILE"
+                echo "excludes it, so 'sx install' will not install this vault's assets."
+                echo "Add the profile to SX_PROFILE (comma-separated) or unset SX_PROFILE."
+            else
+                echo "sx CLI has a profile for this vault, but it is not active,"
+                echo "so 'sx install' will not install this vault's assets."
+                echo "Activate it with:"
+                echo "  sx profile list"
+                echo "  sx profile activate <name>"
+            fi
             exit 1
         fi
     done <<EOF

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -13,10 +13,16 @@ if [ -n "$SX_CONFIG_DIR" ]; then
     SX_CONFIG_FILE="$SX_CONFIG_DIR/config.json"
 elif [ -n "$SKILLS_CONFIG_DIR" ]; then
     SX_CONFIG_FILE="$SKILLS_CONFIG_DIR/config.json"
-elif [ "$(uname)" = "Darwin" ]; then
-    SX_CONFIG_FILE="$HOME/Library/Application Support/sx/config.json"
 else
-    SX_CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/sx/config.json"
+    case "$(uname -s)" in
+        Darwin)
+            SX_CONFIG_FILE="$HOME/Library/Application Support/sx/config.json" ;;
+        MINGW*|MSYS*|CYGWIN*)
+            # Git Bash / MSYS2 / Cygwin: the CLI uses %AppData%\sx
+            SX_CONFIG_FILE="${APPDATA:-$HOME/AppData/Roaming}/sx/config.json" ;;
+        *)
+            SX_CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/sx/config.json" ;;
+    esac
 fi
 
 # Check if sx CLI is already installed

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -45,18 +45,30 @@ else
     echo "✓ sx CLI installed successfully"
 fi
 
-# Check if already configured
+# The asset vault URL this script configures
+VAULT_URL="{{.REPO_URL}}"
+
+# Check if already configured for THIS vault. config.json stores every
+# profile's repositoryUrl, so a plain match covers all profiles. Mere
+# existence of the file is not enough: being configured for a different
+# vault must not read as success, and running sx init here would
+# silently overwrite that other vault's config.
 if [ -f "$SX_CONFIG_FILE" ]; then
-    echo "✓ sx CLI is already configured"
-    exit 0
+    if grep -qF "$VAULT_URL" "$SX_CONFIG_FILE"; then
+        echo "✓ sx CLI is already configured for this vault"
+        exit 0
+    fi
+    echo "sx CLI is already configured, but for a different vault:"
+    grep -o '"repositoryUrl"[^,}]*' "$SX_CONFIG_FILE" | head -5 || true
+    echo
+    echo "To add this vault as a separate profile, run:"
+    echo "  SX_PROFILE=<name> sx init --type git --repo-url \"$VAULT_URL\""
+    exit 1
 fi
 
 echo
 echo "Configuring sx CLI for this vault..."
 echo
-
-# Use the asset vault URL
-VAULT_URL="{{.REPO_URL}}"
 
 echo "Using vault: $VAULT_URL"
 echo

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -66,16 +66,46 @@ normalize_vault_url() {
 # vault's config.
 if [ -n "$VAULT_URL" ] && [ -f "$SX_CONFIG_FILE" ]; then
     VAULT_URL_NORM="$(normalize_vault_url "$VAULT_URL")"
-    # The top-level repositoryUrl (exactly two spaces of indent in sx's
-    # pretty-printed config) is the ACTIVE profile's URL; profile blocks
-    # are indented deeper. Only an active match is success — a matching
-    # profile that isn't active still installs nothing, so it must say
-    # so rather than green-check.
-    ACTIVE_URL="$(grep -E '^  "repositoryUrl"' "$SX_CONFIG_FILE" | sed -E 's#.*:[[:space:]]*"([^"]*)".*#\1#' | head -1 || true)"
-    if [ -n "$ACTIVE_URL" ] && [ "$(normalize_vault_url "$ACTIVE_URL")" = "$VAULT_URL_NORM" ]; then
-        echo "✓ sx CLI is already configured for this vault"
-        exit 0
-    fi
+    # URLs of ACTIVE profiles only. sx merges assets from every profile
+    # in activeProfiles — not just the default — so a match in ANY
+    # active profile is success, while a match in an inactive profile
+    # still installs nothing and must not green-check. Parsed from sx's
+    # pretty-printed config: activeProfiles is a flat name array, each
+    # 4-space-indented profile block carries its own repositoryUrl, and
+    # when no active profile resolves we fall back to the top-level
+    # (default-profile) URL sx writes for old binaries.
+    ACTIVE_URLS="$(awk '
+        /^  "activeProfiles": \[/ { inlist = 1; next }
+        inlist && /^  \]/         { inlist = 0; next }
+        inlist {
+            name = $0; sub(/^[ \t]+/, "", name); sub(/,$/, "", name); gsub(/"/, "", name)
+            active[name] = 1; next
+        }
+        /^  "repositoryUrl"/ {
+            url = $0; sub(/^[^:]*: *"/, "", url); sub(/".*$/, "", url); top = url; next
+        }
+        /^    "/ && /\{[ \t]*$/ {
+            prof = $0; sub(/^[ \t]+"/, "", prof); sub(/": *\{[ \t]*$/, "", prof); next
+        }
+        /^    \}/ { prof = ""; next }
+        prof != "" && /^      "repositoryUrl"/ {
+            url = $0; sub(/^[^:]*: *"/, "", url); sub(/".*$/, "", url); urls[prof] = url; next
+        }
+        END {
+            found = 0
+            for (p in urls) if (p in active) { print urls[p]; found = 1 }
+            if (!found && top != "") print top
+        }
+    ' "$SX_CONFIG_FILE" || true)"
+    while IFS= read -r active_url; do
+        [ -n "$active_url" ] || continue
+        if [ "$(normalize_vault_url "$active_url")" = "$VAULT_URL_NORM" ]; then
+            echo "✓ sx CLI is already configured for this vault"
+            exit 0
+        fi
+    done <<EOF
+$ACTIVE_URLS
+EOF
     CONFIGURED_URLS="$(grep -o '"repositoryUrl"[[:space:]]*:[[:space:]]*"[^"]*"' "$SX_CONFIG_FILE" | sed -E 's#.*:[[:space:]]*"([^"]*)"#\1#' || true)"
     while IFS= read -r configured_url; do
         [ -n "$configured_url" ] || continue

--- a/internal/vault/templates/install.sh.tmpl
+++ b/internal/vault/templates/install.sh.tmpl
@@ -69,13 +69,25 @@ if [ -n "$VAULT_URL" ] && [ -f "$SX_CONFIG_FILE" ]; then
     # URLs of ACTIVE profiles only. sx merges assets from every profile
     # in activeProfiles — not just the default — so a match in ANY
     # active profile is success, while a match in an inactive profile
-    # still installs nothing and must not green-check. Parsed from sx's
+    # still installs nothing and must not green-check. A comma-separated
+    # SX_PROFILE overrides the active set outright, exactly as sx's own
+    # read side resolves it (GetActiveProfileNames). Parsed from sx's
     # pretty-printed config: activeProfiles is a flat name array, each
     # 4-space-indented profile block carries its own repositoryUrl, and
-    # when no active profile resolves we fall back to the top-level
-    # (default-profile) URL sx writes for old binaries.
-    ACTIVE_URLS="$(awk '
-        /^  "activeProfiles": \[/ { inlist = 1; next }
+    # when nothing resolves (and no override is set) we fall back to the
+    # top-level (default-profile) URL sx writes for old binaries.
+    ACTIVE_URLS="$(awk -v override="${SX_PROFILE:-}" '
+        BEGIN {
+            if (override != "") {
+                n = split(override, parts, ",")
+                for (i = 1; i <= n; i++) {
+                    p = parts[i]; gsub(/^[ \t]+|[ \t]+$/, "", p)
+                    if (p != "") { active[p] = 1 }
+                }
+                haveOverride = 1
+            }
+        }
+        !haveOverride && /^  "activeProfiles": \[/ { inlist = 1; next }
         inlist && /^  \]/         { inlist = 0; next }
         inlist {
             name = $0; sub(/^[ \t]+/, "", name); sub(/,$/, "", name); gsub(/"/, "", name)
@@ -94,7 +106,7 @@ if [ -n "$VAULT_URL" ] && [ -f "$SX_CONFIG_FILE" ]; then
         END {
             found = 0
             for (p in urls) if (p in active) { print urls[p]; found = 1 }
-            if (!found && top != "") print top
+            if (!found && !haveOverride && top != "") print top
         }
     ' "$SX_CONFIG_FILE" || true)"
     while IFS= read -r active_url; do


### PR DESCRIPTION
## Summary
- Add `docs/environment-variables.md` documenting `SX_CONFIG_DIR`, its legacy alias `SKILLS_CONFIG_DIR`, and `SX_CACHE_DIR`, with an isolation recipe and an explicit note that `SX_CONFIG` is not an sx env var
- Rename the misleading script-local `SX_CONFIG` in `install.sh.tmpl` to `SX_CONFIG_FILE` and resolve the real config path (honoring `SX_CONFIG_DIR`/`SKILLS_CONFIG_DIR`, macOS vs XDG defaults) instead of the stale `~/.config/sleuth/skills` path
- Bump the install script template version to 2 so existing vaults regenerate the script
- List the env vars in `sx config --help` and link the doc from CLAUDE.md

Fixes #219

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G59XGDW9DWsyWJFu7XekAi