### PR TITLE
SK-741: Keep symlink path in hook commands

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -56,8 +56,12 @@ For package-manager installs, the recorded path is the stable spelling of the
 binary: Homebrew's `/opt/homebrew/bin/sx` symlink rather than the versioned
 `Cellar/sx/<version>/` target it points at, which upgrades delete. An entry
 pinned to a versioned path by an older sx — including one whose target an
-upgrade already removed — is rewritten to the stable spelling on the next
-`sx install`.
+upgrade already removed — is rewritten to the stable spelling the next time
+`sx install` runs **from a terminal**. The repair is not automatic before
+then: until Homebrew cleans up the old keg, a hook naming it still invokes
+the older CLI, which re-pins itself; once the keg is gone the hook can't run
+at all. Either way, one terminal `sx install` with the current version fixes
+it for good.
 
 ## Web clients (cloud relay)
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -52,6 +52,13 @@ repo-committed hooks.
 `SX_CLI_PATH` overrides the resolved path everywhere. Detection accepts both
 forms, so upgrading between them replaces a hook rather than duplicating it.
 
+For package-manager installs, the recorded path is the stable spelling of the
+binary: Homebrew's `/opt/homebrew/bin/sx` symlink rather than the versioned
+`Cellar/sx/<version>/` target it points at, which upgrades delete. An entry
+pinned to a versioned path by an older sx — including one whose target an
+upgrade already removed — is rewritten to the stable spelling on the next
+`sx install`.
+
 ## Web clients (cloud relay)
 
 claude.ai and chatgpt.com can't read your filesystem, so sx exposes the vault as a custom MCP connector through a relay hosted at skills.new. The relay forwards JSON-RPC over a WebSocket your local `sx cloud serve` process opens — vault content stays on your machine.

--- a/internal/clipath/clipath.go
+++ b/internal/clipath/clipath.go
@@ -112,23 +112,35 @@ func candidates() []string {
 	if exe, err := executable(); err == nil {
 		// Resolve symlinks so a shim in ~/.local/bin does not hide the real
 		// layout, but keep the original path when it cannot be resolved. The
-		// resolved path is used only for layout detection below — never as the
-		// path that gets written.
+		// resolved path anchors layout detection below; it is written into
+		// configs only when no stabler spelling of the same binary exists.
 		resolved := exe
 		if r, err := filepath.EvalSymlinks(exe); err == nil {
 			resolved = r
 		}
 
-		// Already running as the CLI. Prefer the invocation path over the
-		// resolved one: package managers that version their install directory
-		// expose a stable symlink (Homebrew's /opt/homebrew/bin/sx points into
-		// Cellar/sx/<version>/), and writing the resolved target into a hook
-		// leaves the hook pointing at a directory the next upgrade deletes.
-		if filepath.Base(exe) == binaryName() {
+		// Already running as the CLI. Prefer a stable spelling over the
+		// resolved target: package managers that version their install
+		// directory expose a stable symlink (Homebrew's /opt/homebrew/bin/sx
+		// points into Cellar/sx/<version>/), and writing the versioned target
+		// into a hook leaves the hook pointing at a directory the next
+		// upgrade deletes. On macOS the invocation path preserves that
+		// symlink, but Linux (/proc/self/exe) and Windows hand back the
+		// already-resolved target no matter how the process was invoked — so
+		// also probe the stable locations for an alias of this same binary.
+		// Comparisons use normalizedBase: the CLI may be invoked as "SX" on a
+		// case-insensitive filesystem.
+		if normalizedBase(exe) == binaryName() {
+			if alias := stableAlias(exe); alias != "" {
+				out = append(out, alias)
+			}
 			out = append(out, exe)
-		} else if filepath.Base(resolved) == binaryName() {
+		} else if normalizedBase(resolved) == binaryName() {
 			// Invoked through a differently-named symlink ("skills" -> sx):
 			// only the resolved path is recognizably the CLI.
+			if alias := stableAlias(resolved); alias != "" {
+				out = append(out, alias)
+			}
 			out = append(out, resolved)
 		}
 
@@ -143,6 +155,54 @@ func candidates() []string {
 		out = append(out, filepath.Join(dir, binaryName()))
 	}
 	return out
+}
+
+// stableAlias looks for a stable path — PATH, then the installer
+// directories — that resolves to the same binary as target, and returns
+// it, or "" when none exists. It never returns target's own spelling,
+// so callers can append it as a strictly-preferred candidate.
+func stableAlias(target string) string {
+	canon, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return ""
+	}
+
+	var probes []string
+	if p, err := exec.LookPath(binaryName()); err == nil {
+		probes = append(probes, p)
+	}
+	for _, dir := range installDirs() {
+		probes = append(probes, filepath.Join(dir, binaryName()))
+	}
+
+	for _, p := range probes {
+		if !isExecutableFile(p) {
+			continue
+		}
+		r, err := filepath.EvalSymlinks(p)
+		if err != nil || !samePath(r, canon) {
+			continue
+		}
+		if abs, err := filepath.Abs(p); err == nil {
+			p = abs
+		}
+		if samePath(p, target) {
+			// The probe IS the target's spelling — nothing gained.
+			continue
+		}
+		return p
+	}
+	return ""
+}
+
+// samePath reports whether two paths are the same spelling, honoring
+// Windows case-insensitivity. It does not resolve symlinks.
+func samePath(a, b string) bool {
+	a, b = filepath.Clean(a), filepath.Clean(b)
+	if goos == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
 }
 
 // installDirs are where sx's own installers put the CLI. A GUI-launched client
@@ -349,11 +409,16 @@ func repairVerdict(argv0 string) (verdict, owned bool) {
 // ShouldRewrite reports whether an existing config command should be replaced
 // with the current one.
 //
-// That is NeedsRepair plus one upgrade case it deliberately excludes: a bare
-// "sx", which was written when no CLI could be found. It still works wherever
-// PATH has one, so it is not broken — but once a CLI is resolvable, an absolute
+// That is NeedsRepair plus two upgrade cases it deliberately excludes. A bare
+// "sx" was written when no CLI could be found; it still works wherever PATH
+// has one, so it is not broken — but once a CLI is resolvable, an absolute
 // path is strictly better, and without this a degraded first install stays
-// degraded forever.
+// degraded forever. And an absolute sx path that resolves to the same binary
+// as the current resolution but spells it differently — a versioned Homebrew
+// Cellar path recorded before the stable-alias preference existed — still
+// works today but dies on the next upgrade, so it is upgraded to the current
+// spelling. Distinct binaries (a terminal-installed CLI vs the app's bundled
+// one) are left alone to avoid rewrite thrash.
 func ShouldRewrite(cmd string) bool {
 	if NeedsRepair(cmd) {
 		return true
@@ -363,12 +428,24 @@ func ShouldRewrite(cmd string) bool {
 		return false
 	}
 	argv0 := fields[0]
-	if argv0 != normalizedBase(argv0) || !slices.Contains(legacyBinaryNames, strings.ToLower(argv0)) {
+	if !slices.Contains(legacyBinaryNames, normalizedBase(argv0)) {
 		return false
 	}
-	// Bare name: worth upgrading only if there is something better to point at.
-	_, err := Resolve()
-	return err == nil
+	if argv0 == normalizedBase(argv0) {
+		// Bare name: worth upgrading only if there is something better to point at.
+		_, err := Resolve()
+		return err == nil
+	}
+	if !isAbsolutePath(argv0) {
+		return false
+	}
+	resolved, err := Resolve()
+	if err != nil || samePath(argv0, resolved) {
+		return false
+	}
+	a, errA := filepath.EvalSymlinks(argv0)
+	b, errB := filepath.EvalSymlinks(resolved)
+	return errA == nil && errB == nil && samePath(a, b)
 }
 
 // MCPEntryNeedsRewrite reports whether an existing MCP server entry should be
@@ -506,11 +583,7 @@ func isResolvedCLI(argv0 string) bool {
 	if err != nil {
 		return false
 	}
-	a, b := filepath.Clean(argv0), filepath.Clean(resolved)
-	if goos == "windows" {
-		return strings.EqualFold(a, b)
-	}
-	return a == b
+	return samePath(argv0, resolved)
 }
 
 // normalizedBase returns argv[0]'s lowercased file name with separators

--- a/internal/clipath/clipath.go
+++ b/internal/clipath/clipath.go
@@ -107,7 +107,10 @@ var resolveCache struct {
 
 // resetResolveCache clears the memoized Resolve result. Tests re-stub the
 // executable/installDirs seams and change env vars, so the stub helpers call
-// this on both stub and cleanup.
+// this on both stub and cleanup. Note the cache's inputs also include PATH —
+// a test that changes PATH between two Resolve calls must reset explicitly.
+// SX_CLI_PATH is NOT cached (checked before the cache in Resolve), so
+// changing the override mid-test needs no reset.
 func resetResolveCache() {
 	resolveCache.Lock()
 	defer resolveCache.Unlock()
@@ -280,7 +283,14 @@ func isStableSpelling(path string) bool {
 			return true
 		}
 	}
-	for _, d := range filepath.SplitList(os.Getenv("PATH")) {
+	// Split PATH with the seam's separator, not the host's
+	// (filepath.SplitList keys off the real runtime.GOOS), so
+	// Windows-shaped behavior stays testable from any host.
+	sep := ":"
+	if goos == "windows" {
+		sep = ";"
+	}
+	for d := range strings.SplitSeq(os.Getenv("PATH"), sep) {
 		if d != "" && samePath(dir, d) {
 			return true
 		}
@@ -559,7 +569,20 @@ func ShouldRewrite(cmd string) bool {
 	// downgrading a stable entry to a versioned Cellar path when a
 	// GUI-launched client's minimal PATH skews resolution, or flapping
 	// between two equally stable aliases with PATH order.
-	if isStableSpelling(argv0) || stableAlias(argv0) == "" {
+	if isStableSpelling(argv0) {
+		return false
+	}
+	// A Cellar-tree path with a live stable alias is fragile no matter
+	// which version it names. This must not require same-file identity
+	// with the current resolution: after a brew upgrade the recorded
+	// path still exists (brew cleanup is deferred) but names the OLD
+	// binary, which is exactly the entry that needs upgrading. sx never
+	// writes a Cellar path itself, so this cannot thrash against sx's
+	// own output.
+	if a := brewCellarAlias(argv0); a != "" && isExecutableFile(a) {
+		return true
+	}
+	if stableAlias(argv0) == "" {
 		return false
 	}
 	return sameFile(argv0, resolved)

--- a/internal/clipath/clipath.go
+++ b/internal/clipath/clipath.go
@@ -216,7 +216,39 @@ func versionedTreeAlias(path string) string {
 	if alias == "" || !isExecutableFile(alias) || samePath(alias, path) {
 		return ""
 	}
+	// The alias must actually be a spelling of this same formula: its
+	// target is the running keg, or another keg of the same formula
+	// (version skew from a pending upgrade is expected — brew's link
+	// points at the newest keg). A standalone binary that merely
+	// occupies <prefix>/bin — Intel macOS, where brew's prefix and
+	// install.sh's target are both /usr/local — is a different CLI and
+	// must not displace the one that is running.
+	target, err := filepath.EvalSymlinks(alias)
+	if err != nil {
+		return ""
+	}
+	if samePath(target, canon) {
+		return alias
+	}
+	tree := formulaTree(canon)
+	if tree == "" || !strings.HasPrefix(filepath.ToSlash(target), tree) {
+		return ""
+	}
 	return alias
+}
+
+// formulaTree returns the "<prefix>/Cellar/<formula>/" prefix a Cellar
+// path belongs to, or "" for non-Cellar paths.
+func formulaTree(canon string) string {
+	prefix, rest, found := strings.Cut(filepath.ToSlash(canon), "/Cellar/")
+	if !found {
+		return ""
+	}
+	formula, _, ok := strings.Cut(rest, "/")
+	if !ok || formula == "" {
+		return ""
+	}
+	return prefix + "/Cellar/" + formula + "/"
 }
 
 // brewCellarAlias derives the stable bin path a Homebrew-style Cellar

--- a/internal/clipath/clipath.go
+++ b/internal/clipath/clipath.go
@@ -111,16 +111,28 @@ func candidates() []string {
 
 	if exe, err := executable(); err == nil {
 		// Resolve symlinks so a shim in ~/.local/bin does not hide the real
-		// layout, but keep the original path when it cannot be resolved.
-		if resolved, err := filepath.EvalSymlinks(exe); err == nil {
-			exe = resolved
+		// layout, but keep the original path when it cannot be resolved. The
+		// resolved path is used only for layout detection below — never as the
+		// path that gets written.
+		resolved := exe
+		if r, err := filepath.EvalSymlinks(exe); err == nil {
+			resolved = r
 		}
-		dir := filepath.Dir(exe)
 
-		// Already running as the CLI.
+		// Already running as the CLI. Prefer the invocation path over the
+		// resolved one: package managers that version their install directory
+		// expose a stable symlink (Homebrew's /opt/homebrew/bin/sx points into
+		// Cellar/sx/<version>/), and writing the resolved target into a hook
+		// leaves the hook pointing at a directory the next upgrade deletes.
 		if filepath.Base(exe) == binaryName() {
 			out = append(out, exe)
+		} else if filepath.Base(resolved) == binaryName() {
+			// Invoked through a differently-named symlink ("skills" -> sx):
+			// only the resolved path is recognizably the CLI.
+			out = append(out, resolved)
 		}
+
+		dir := filepath.Dir(resolved)
 
 		// macOS: .../sx.app/Contents/MacOS/sx-app -> .../Contents/Resources/sx
 		if filepath.Base(dir) == "MacOS" {

--- a/internal/clipath/clipath.go
+++ b/internal/clipath/clipath.go
@@ -162,34 +162,25 @@ func candidates() []string {
 			resolved = r
 		}
 
-		// Already running as the CLI. Prefer a stable spelling over the
-		// resolved target: package managers that version their install
-		// directory expose a stable symlink (Homebrew's /opt/homebrew/bin/sx
-		// points into Cellar/sx/<version>/), and writing the versioned target
-		// into a hook leaves the hook pointing at a directory the next
-		// upgrade deletes. On macOS the invocation path preserves that
-		// symlink, but Linux (/proc/self/exe) and Windows hand back the
-		// already-resolved target no matter how the process was invoked — so
-		// when the known path is not itself a stable spelling, probe the
-		// stable locations for an alias of this same binary. An
-		// already-stable invocation path is kept as-is: a user shim earlier
-		// on PATH must not displace the spelling that was actually invoked.
-		// Comparisons use normalizedBase: the CLI may be invoked as "SX" on a
-		// case-insensitive filesystem.
+		// Already running as the CLI. Exactly one shape is traded for an
+		// alias: a versioned package-manager tree (Homebrew's Cellar),
+		// whose stable bin/ symlink the next upgrade preserves while
+		// deleting the versioned target. Everything else is recorded as
+		// invoked — deliberately without consulting PATH, which differs
+		// between a terminal and a GUI-launched client and would make the
+		// recorded spelling alternate between installs of the same binary.
+		// Comparisons use normalizedBase: the CLI may be invoked as "SX" on
+		// a case-insensitive filesystem.
 		if normalizedBase(exe) == binaryName() {
-			if !isStableSpelling(exe) {
-				if alias := stableAlias(exe); alias != "" {
-					out = append(out, alias)
-				}
+			if alias := versionedTreeAlias(exe); alias != "" {
+				out = append(out, alias)
 			}
 			out = append(out, exe)
 		} else if normalizedBase(resolved) == binaryName() {
 			// Invoked through a differently-named symlink ("skills" -> sx):
 			// only the resolved path is recognizably the CLI.
-			if !isStableSpelling(resolved) {
-				if alias := stableAlias(resolved); alias != "" {
-					out = append(out, alias)
-				}
+			if alias := versionedTreeAlias(resolved); alias != "" {
+				out = append(out, alias)
 			}
 			out = append(out, resolved)
 		}
@@ -207,53 +198,25 @@ func candidates() []string {
 	return out
 }
 
-// stableAlias looks for a stable path that names the same binary as
-// target, and returns it, or "" when none exists. It never returns
-// target's own spelling, so callers can append it as a strictly-preferred
-// candidate.
-//
-// Probe order matters. A Homebrew Cellar target names its own stable
-// prefix, so that alias is derived directly from the path and cannot
-// depend on PATH — GUI-launched clients run hooks under launchd's
-// minimal PATH, where a LookPath-only probe would fail and the hook
-// would be rewritten back to the fragile versioned path. PATH and the
-// installer directories are consulted after.
-func stableAlias(target string) string {
-	canon, err := filepath.EvalSymlinks(target)
-	if err != nil {
+// versionedTreeAlias returns the stable spelling implied by a versioned
+// package-manager tree, when that alias exists on disk. A Homebrew-style
+// Cellar target names its own prefix — /opt/homebrew/Cellar/sx/2.3.1/bin/sx
+// implies /opt/homebrew/bin/sx — so the alias derives from the path alone,
+// with no PATH or installDirs consultation. That restraint is the point:
+// PATH differs between a terminal and a GUI-launched client, and any
+// PATH-dependent preference would make the recorded spelling alternate
+// between installs of the same binary. Only the versioned-tree shape is
+// fragile enough to trade away; every other path returns "".
+func versionedTreeAlias(path string) string {
+	canon := path
+	if r, err := filepath.EvalSymlinks(path); err == nil {
+		canon = r
+	}
+	alias := brewCellarAlias(canon)
+	if alias == "" || !isExecutableFile(alias) || samePath(alias, path) {
 		return ""
 	}
-
-	var probes []string
-	if alias := brewCellarAlias(canon); alias != "" {
-		probes = append(probes, alias)
-	}
-	if p, err := exec.LookPath(binaryName()); err == nil {
-		probes = append(probes, p)
-	}
-	for _, dir := range installDirs() {
-		probes = append(probes, filepath.Join(dir, binaryName()))
-	}
-
-	for _, p := range probes {
-		if !isExecutableFile(p) {
-			continue
-		}
-		// Identity, not spelling: stat follows symlinks, and os.SameFile
-		// sidesteps case differences on case-insensitive filesystems.
-		if !sameFile(p, canon) {
-			continue
-		}
-		if abs, err := filepath.Abs(p); err == nil {
-			p = abs
-		}
-		if samePath(p, target) {
-			// The probe IS the target's spelling — nothing gained.
-			continue
-		}
-		return p
-	}
-	return ""
+	return alias
 }
 
 // brewCellarAlias derives the stable bin path a Homebrew-style Cellar
@@ -269,59 +232,14 @@ func brewCellarAlias(canon string) string {
 	return filepath.Join(canon[:idx], "bin", binaryName())
 }
 
-// isStableSpelling reports whether path already lives somewhere durable:
-// a PATH directory or an installer directory, and not inside a versioned
-// Cellar tree. Such a path is kept as-is rather than traded for whatever
-// alias happens to probe first.
-func isStableSpelling(path string) bool {
-	if strings.Contains(filepath.ToSlash(path), "/Cellar/") {
-		return false
-	}
-	dir := filepath.Dir(path)
-	for _, d := range installDirs() {
-		if d != "" && samePath(dir, d) {
-			return true
-		}
-	}
-	// Split PATH with the seam's separator, not the host's
-	// (filepath.SplitList keys off the real runtime.GOOS), so
-	// Windows-shaped behavior stays testable from any host.
-	sep := ":"
-	if goos == "windows" {
-		sep = ";"
-	}
-	for d := range strings.SplitSeq(os.Getenv("PATH"), sep) {
-		if d != "" && samePath(dir, d) {
-			return true
-		}
-	}
-	return false
-}
-
 // samePath reports whether two paths are the same spelling, honoring
-// Windows case-insensitivity. It does not resolve symlinks; use
-// sameFile to compare identity.
+// Windows case-insensitivity. It does not resolve symlinks.
 func samePath(a, b string) bool {
 	a, b = filepath.Clean(a), filepath.Clean(b)
 	if goos == "windows" {
 		return strings.EqualFold(a, b)
 	}
 	return a == b
-}
-
-// sameFile reports whether two paths name the same file on disk. Stat
-// follows symlinks, so this compares final targets and is immune to
-// case and separator differences string comparison would trip on.
-func sameFile(a, b string) bool {
-	ai, err := os.Stat(a)
-	if err != nil {
-		return false
-	}
-	bi, err := os.Stat(b)
-	if err != nil {
-		return false
-	}
-	return os.SameFile(ai, bi)
 }
 
 // installDirs are where sx's own installers put the CLI. A GUI-launched client
@@ -533,12 +451,12 @@ func repairVerdict(argv0 string) (verdict, owned bool) {
 // "sx" was written when no CLI could be found; it still works wherever PATH
 // has one, so it is not broken — but once a CLI is resolvable, an absolute
 // path is strictly better, and without this a degraded first install stays
-// degraded forever. And an absolute sx path that resolves to the same binary
-// as the current resolution but spells it differently — a versioned Homebrew
-// Cellar path recorded before the stable-alias preference existed — still
-// works today but dies on the next upgrade, so it is upgraded to the current
-// spelling. Distinct binaries (a terminal-installed CLI vs the app's bundled
-// one) are left alone to avoid rewrite thrash.
+// degraded forever. And an sx path inside a versioned package-manager tree
+// (a Homebrew Cellar keg, recorded before the stable-alias preference
+// existed) still works today but dies on the next upgrade, so it is upgraded
+// while its stable alias exists. Every other absolute spelling — including a
+// different spelling of the same binary — is left alone to avoid rewrite
+// thrash.
 func ShouldRewrite(cmd string) bool {
 	if NeedsRepair(cmd) {
 		return true
@@ -563,29 +481,17 @@ func ShouldRewrite(cmd string) bool {
 	if err != nil || samePath(argv0, resolved) {
 		return false
 	}
-	// One-directional on purpose: only a spelling that is itself fragile
-	// and has a stabler alias gets upgraded. Without this the branch
-	// would adopt whatever Resolve currently says in either direction —
-	// downgrading a stable entry to a versioned Cellar path when a
-	// GUI-launched client's minimal PATH skews resolution, or flapping
-	// between two equally stable aliases with PATH order.
-	if isStableSpelling(argv0) {
-		return false
-	}
-	// A Cellar-tree path with a live stable alias is fragile no matter
-	// which version it names. This must not require same-file identity
-	// with the current resolution: after a brew upgrade the recorded
-	// path still exists (brew cleanup is deferred) but names the OLD
-	// binary, which is exactly the entry that needs upgrading. sx never
-	// writes a Cellar path itself, so this cannot thrash against sx's
-	// own output.
-	if a := brewCellarAlias(argv0); a != "" && isExecutableFile(a) {
-		return true
-	}
-	if stableAlias(argv0) == "" {
-		return false
-	}
-	return sameFile(argv0, resolved)
+	// Only the versioned-tree shape is upgraded, and it needs no
+	// same-file identity with the current resolution: after a brew
+	// upgrade the recorded old keg still exists (cleanup is deferred)
+	// but names the OLD binary, which is exactly the entry that needs
+	// upgrading. Any other absolute spelling is the user's own choice
+	// and is left alone — including a different spelling of the same
+	// binary, which would otherwise thrash with PATH order between
+	// terminal and GUI launches. sx never writes a Cellar path itself,
+	// so this cannot flap against sx's own output.
+	a := brewCellarAlias(argv0)
+	return a != "" && isExecutableFile(a)
 }
 
 // MCPEntryNeedsRewrite reports whether an existing MCP server entry should be

--- a/internal/clipath/clipath.go
+++ b/internal/clipath/clipath.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 )
 
 // ErrNotFound means no sx CLI could be located. Callers should degrade rather
@@ -66,15 +67,54 @@ var legacyBinaryNames = []string{"sx", "sx.exe", "skills", "skills.exe"}
 // stays forward-only.
 //
 // It is not a global guarantee. Running your own `sx install` from a terminal
-// bakes *that* CLI's path in, which is the least surprising outcome — the CLI
-// you invoked is the one that gets recorded — but it does mean alternating
-// between a terminal install and an app install rewrites the stored path each
-// way. Both paths work; only the version they pin differs. SX_CLI_PATH
-// overrides all of it.
+// bakes *that* CLI's path in — more precisely, the most stable known spelling
+// of the binary you invoked (a versioned Homebrew Cellar target is recorded
+// as the stable bin/ symlink that points at it, never the Cellar path an
+// upgrade deletes). Alternating between a terminal install and an app install
+// still rewrites the stored path each way. Both paths work; only the version
+// they pin differs. SX_CLI_PATH overrides all of it.
 //
 // This only decides what goes into hook and MCP configuration. What happens
 // when the user types "sx" in a terminal is their shell's PATH, untouched.
+//
+// The result is memoized for the process lifetime: Managed and friends call
+// this once per config entry they inspect, and the probe work (PATH lookups,
+// stats, symlink resolution) is not free.
 func Resolve() (string, error) {
+	// The override stays outside the memoized path: it is one env read,
+	// and callers may set or change it between calls.
+	if override := strings.TrimSpace(os.Getenv(EnvOverride)); override != "" && isExecutableFile(override) {
+		if abs, err := filepath.Abs(override); err == nil {
+			return abs, nil
+		}
+		return override, nil
+	}
+	resolveCache.Lock()
+	defer resolveCache.Unlock()
+	if !resolveCache.done {
+		resolveCache.path, resolveCache.err = resolve()
+		resolveCache.done = true
+	}
+	return resolveCache.path, resolveCache.err
+}
+
+var resolveCache struct {
+	sync.Mutex
+	done bool
+	path string
+	err  error
+}
+
+// resetResolveCache clears the memoized Resolve result. Tests re-stub the
+// executable/installDirs seams and change env vars, so the stub helpers call
+// this on both stub and cleanup.
+func resetResolveCache() {
+	resolveCache.Lock()
+	defer resolveCache.Unlock()
+	resolveCache.done = false
+}
+
+func resolve() (string, error) {
 	for _, candidate := range candidates() {
 		if isExecutableFile(candidate) {
 			if abs, err := filepath.Abs(candidate); err == nil {
@@ -86,7 +126,7 @@ func Resolve() (string, error) {
 	// PATH before the guessed install directories: PATH reflects what the user
 	// actually set up, while installDirs is a last-ditch guess for the
 	// GUI-launched case where PATH is launchd's minimal set.
-	if p, err := exec.LookPath("sx"); err == nil {
+	if p, err := exec.LookPath(binaryName()); err == nil {
 		if abs, err := filepath.Abs(p); err == nil {
 			return abs, nil
 		}
@@ -127,19 +167,26 @@ func candidates() []string {
 		// upgrade deletes. On macOS the invocation path preserves that
 		// symlink, but Linux (/proc/self/exe) and Windows hand back the
 		// already-resolved target no matter how the process was invoked — so
-		// also probe the stable locations for an alias of this same binary.
+		// when the known path is not itself a stable spelling, probe the
+		// stable locations for an alias of this same binary. An
+		// already-stable invocation path is kept as-is: a user shim earlier
+		// on PATH must not displace the spelling that was actually invoked.
 		// Comparisons use normalizedBase: the CLI may be invoked as "SX" on a
 		// case-insensitive filesystem.
 		if normalizedBase(exe) == binaryName() {
-			if alias := stableAlias(exe); alias != "" {
-				out = append(out, alias)
+			if !isStableSpelling(exe) {
+				if alias := stableAlias(exe); alias != "" {
+					out = append(out, alias)
+				}
 			}
 			out = append(out, exe)
 		} else if normalizedBase(resolved) == binaryName() {
 			// Invoked through a differently-named symlink ("skills" -> sx):
 			// only the resolved path is recognizably the CLI.
-			if alias := stableAlias(resolved); alias != "" {
-				out = append(out, alias)
+			if !isStableSpelling(resolved) {
+				if alias := stableAlias(resolved); alias != "" {
+					out = append(out, alias)
+				}
 			}
 			out = append(out, resolved)
 		}
@@ -157,10 +204,17 @@ func candidates() []string {
 	return out
 }
 
-// stableAlias looks for a stable path — PATH, then the installer
-// directories — that resolves to the same binary as target, and returns
-// it, or "" when none exists. It never returns target's own spelling,
-// so callers can append it as a strictly-preferred candidate.
+// stableAlias looks for a stable path that names the same binary as
+// target, and returns it, or "" when none exists. It never returns
+// target's own spelling, so callers can append it as a strictly-preferred
+// candidate.
+//
+// Probe order matters. A Homebrew Cellar target names its own stable
+// prefix, so that alias is derived directly from the path and cannot
+// depend on PATH — GUI-launched clients run hooks under launchd's
+// minimal PATH, where a LookPath-only probe would fail and the hook
+// would be rewritten back to the fragile versioned path. PATH and the
+// installer directories are consulted after.
 func stableAlias(target string) string {
 	canon, err := filepath.EvalSymlinks(target)
 	if err != nil {
@@ -168,6 +222,9 @@ func stableAlias(target string) string {
 	}
 
 	var probes []string
+	if alias := brewCellarAlias(canon); alias != "" {
+		probes = append(probes, alias)
+	}
 	if p, err := exec.LookPath(binaryName()); err == nil {
 		probes = append(probes, p)
 	}
@@ -179,8 +236,9 @@ func stableAlias(target string) string {
 		if !isExecutableFile(p) {
 			continue
 		}
-		r, err := filepath.EvalSymlinks(p)
-		if err != nil || !samePath(r, canon) {
+		// Identity, not spelling: stat follows symlinks, and os.SameFile
+		// sidesteps case differences on case-insensitive filesystems.
+		if !sameFile(p, canon) {
 			continue
 		}
 		if abs, err := filepath.Abs(p); err == nil {
@@ -195,14 +253,65 @@ func stableAlias(target string) string {
 	return ""
 }
 
+// brewCellarAlias derives the stable bin path a Homebrew-style Cellar
+// target implies: /opt/homebrew/Cellar/sx/2.3.1/bin/sx names
+// /opt/homebrew/bin/sx. Works for any prefix — /usr/local,
+// /home/linuxbrew/.linuxbrew, a custom --prefix — with one rule and no
+// PATH dependency. Returns "" for non-Cellar paths.
+func brewCellarAlias(canon string) string {
+	idx := strings.Index(filepath.ToSlash(canon), "/Cellar/")
+	if idx < 0 {
+		return ""
+	}
+	return filepath.Join(canon[:idx], "bin", binaryName())
+}
+
+// isStableSpelling reports whether path already lives somewhere durable:
+// a PATH directory or an installer directory, and not inside a versioned
+// Cellar tree. Such a path is kept as-is rather than traded for whatever
+// alias happens to probe first.
+func isStableSpelling(path string) bool {
+	if strings.Contains(filepath.ToSlash(path), "/Cellar/") {
+		return false
+	}
+	dir := filepath.Dir(path)
+	for _, d := range installDirs() {
+		if d != "" && samePath(dir, d) {
+			return true
+		}
+	}
+	for _, d := range filepath.SplitList(os.Getenv("PATH")) {
+		if d != "" && samePath(dir, d) {
+			return true
+		}
+	}
+	return false
+}
+
 // samePath reports whether two paths are the same spelling, honoring
-// Windows case-insensitivity. It does not resolve symlinks.
+// Windows case-insensitivity. It does not resolve symlinks; use
+// sameFile to compare identity.
 func samePath(a, b string) bool {
 	a, b = filepath.Clean(a), filepath.Clean(b)
 	if goos == "windows" {
 		return strings.EqualFold(a, b)
 	}
 	return a == b
+}
+
+// sameFile reports whether two paths name the same file on disk. Stat
+// follows symlinks, so this compares final targets and is immune to
+// case and separator differences string comparison would trip on.
+func sameFile(a, b string) bool {
+	ai, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(ai, bi)
 }
 
 // installDirs are where sx's own installers put the CLI. A GUI-launched client
@@ -215,9 +324,10 @@ var installDirs = func() []string {
 		}
 		return nil
 	}
-	dirs := []string{"/usr/local/bin", "/opt/homebrew/bin"}
+	dirs := []string{"/usr/local/bin", "/opt/homebrew/bin", "/home/linuxbrew/.linuxbrew/bin"}
 	if home, err := os.UserHomeDir(); err == nil {
 		dirs = append([]string{filepath.Join(home, ".local", "bin")}, dirs...)
+		dirs = append(dirs, filepath.Join(home, ".linuxbrew", "bin"))
 	}
 	return dirs
 }
@@ -443,9 +553,16 @@ func ShouldRewrite(cmd string) bool {
 	if err != nil || samePath(argv0, resolved) {
 		return false
 	}
-	a, errA := filepath.EvalSymlinks(argv0)
-	b, errB := filepath.EvalSymlinks(resolved)
-	return errA == nil && errB == nil && samePath(a, b)
+	// One-directional on purpose: only a spelling that is itself fragile
+	// and has a stabler alias gets upgraded. Without this the branch
+	// would adopt whatever Resolve currently says in either direction —
+	// downgrading a stable entry to a versioned Cellar path when a
+	// GUI-launched client's minimal PATH skews resolution, or flapping
+	// between two equally stable aliases with PATH order.
+	if isStableSpelling(argv0) || stableAlias(argv0) == "" {
+		return false
+	}
+	return sameFile(argv0, resolved)
 }
 
 // MCPEntryNeedsRewrite reports whether an existing MCP server entry should be

--- a/internal/clipath/clipath_test.go
+++ b/internal/clipath/clipath_test.go
@@ -158,6 +158,94 @@ func TestResolveKeepsInvocationSymlinkPath(t *testing.T) {
 	}
 }
 
+// On Linux (/proc/self/exe) and Windows the OS reports the running
+// executable's fully resolved path no matter how it was invoked, so the
+// invocation path alone cannot preserve a package manager's stable
+// symlink. Resolve must find the stable alias by probing the install
+// locations (the Linuxbrew shape of issue #222).
+func TestResolvePrefersStableAliasWhenRunningResolvedTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	t.Setenv("PATH", root) // keep the host's own sx out of the probe
+	target := writeFakeCLI(t, filepath.Join(root, "Cellar", "sx", "2.3.1", "bin"), binaryName())
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "bin", binaryName())
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	// The OS hands back the resolved target, not the symlink.
+	stubExecutable(t, target)
+	stubInstallDirs(t, []string{filepath.Join(root, "bin")})
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != link {
+		t.Fatalf("Resolve = %q, want stable alias %q, not the versioned target", got, link)
+	}
+}
+
+// Case-insensitive filesystems can report the running CLI as "SX"; the
+// running-CLI branch must still recognize it instead of falling through.
+func TestResolveMixedCaseInvocation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("binary name differs on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	dir := tempRoot(t)
+	t.Setenv("PATH", dir)
+	want := writeFakeCLI(t, dir, "SX")
+	stubExecutable(t, want)
+	stubInstallDirs(t, nil)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Resolve = %q, want running binary %q", got, want)
+	}
+}
+
+// A hook pinned to a still-live versioned path must be upgraded once a
+// stabler spelling of the same binary resolves, while a hook already on
+// the stable spelling — or naming a different binary — is left alone.
+func TestShouldRewriteUpgradesSameBinaryDifferentSpelling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	t.Setenv("PATH", root)
+	target := writeFakeCLI(t, filepath.Join(root, "Cellar", "sx", "2.3.1", "bin"), binaryName())
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "bin", binaryName())
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	stubExecutable(t, target)
+	stubInstallDirs(t, []string{filepath.Join(root, "bin")})
+
+	if !ShouldRewrite(target + " install --hook-mode") {
+		t.Fatal("still-live versioned spelling of the resolved binary must be upgraded")
+	}
+	if ShouldRewrite(link + " install --hook-mode") {
+		t.Fatal("the stable spelling must not be rewritten")
+	}
+	other := writeFakeCLI(t, filepath.Join(root, "other"), binaryName())
+	if ShouldRewrite(other + " install --hook-mode") {
+		t.Fatal("a different binary must be left alone")
+	}
+}
+
 // A symlink whose name is not the CLI's ("skills" -> sx) is only recognizable
 // as the CLI after resolution, so the resolved path is used there.
 func TestResolveDifferentlyNamedSymlinkFallsBackToTarget(t *testing.T) {

--- a/internal/clipath/clipath_test.go
+++ b/internal/clipath/clipath_test.go
@@ -35,11 +35,16 @@ func tempRoot(t *testing.T) string {
 }
 
 // stubExecutable makes the package believe it is running as the given binary.
+// Resolve memoizes, so the cache resets with the stub and again on cleanup.
 func stubExecutable(t *testing.T, path string) {
 	t.Helper()
 	prev := executable
 	executable = func() (string, error) { return path, nil }
-	t.Cleanup(func() { executable = prev })
+	resetResolveCache()
+	t.Cleanup(func() {
+		executable = prev
+		resetResolveCache()
+	})
 }
 
 // stubInstallDirs isolates the search from whatever the host machine has in
@@ -48,7 +53,11 @@ func stubInstallDirs(t *testing.T, dirs []string) {
 	t.Helper()
 	prev := installDirs
 	installDirs = func() []string { return dirs }
-	t.Cleanup(func() { installDirs = prev })
+	resetResolveCache()
+	t.Cleanup(func() {
+		installDirs = prev
+		resetResolveCache()
+	})
 }
 
 func TestResolvePrefersEnvOverride(t *testing.T) {
@@ -138,6 +147,7 @@ func TestResolveKeepsInvocationSymlinkPath(t *testing.T) {
 	}
 	t.Setenv(EnvOverride, "")
 	root := tempRoot(t)
+	t.Setenv("PATH", root) // keep the host's own sx out of the probe
 	target := writeFakeCLI(t, filepath.Join(root, "Cellar", "sx", "2.3.1", "bin"), binaryName())
 	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
 		t.Fatal(err)
@@ -155,6 +165,66 @@ func TestResolveKeepsInvocationSymlinkPath(t *testing.T) {
 	}
 	if got != link {
 		t.Fatalf("Resolve = %q, want stable symlink %q, not the versioned target", got, link)
+	}
+}
+
+// The Linuxbrew prefix is not in installDirs and a GUI-launched client
+// has no useful PATH, so the stable spelling must be derivable from the
+// Cellar path alone.
+func TestResolveDerivesBrewPrefixWithoutPATH(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	t.Setenv("PATH", filepath.Join(root, "empty"))
+	prefix := filepath.Join(root, ".linuxbrew")
+	target := writeFakeCLI(t, filepath.Join(prefix, "Cellar", "sx", "2.3.1", "bin"), binaryName())
+	if err := os.MkdirAll(filepath.Join(prefix, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(prefix, "bin", binaryName())
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	stubExecutable(t, target)
+	stubInstallDirs(t, nil)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != link {
+		t.Fatalf("Resolve = %q, want brew-prefix alias %q", got, link)
+	}
+}
+
+// The same-binary upgrade must be one-directional: a spelling that is
+// not itself fragile is never traded for whatever Resolve currently
+// says, even when both name the same binary.
+func TestShouldRewriteIsOneDirectional(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	t.Setenv("PATH", filepath.Join(root, "empty"))
+	real := writeFakeCLI(t, filepath.Join(root, "real"), binaryName())
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "bin", binaryName())
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	// Resolve() sees the real path; the recorded entry is the symlink.
+	// They name the same binary and differ in spelling, but the recorded
+	// spelling has no stabler alias — so no rewrite.
+	stubExecutable(t, real)
+	stubInstallDirs(t, nil)
+
+	if ShouldRewrite(link + " install --hook-mode") {
+		t.Fatal("a spelling with no stabler alias must not be rewritten")
 	}
 }
 
@@ -404,7 +474,11 @@ func stubGOOS(t *testing.T, name string) {
 	t.Helper()
 	prev := goos
 	goos = name
-	t.Cleanup(func() { goos = prev })
+	resetResolveCache()
+	t.Cleanup(func() {
+		goos = prev
+		resetResolveCache()
+	})
 }
 
 // A Windows path is full of backslashes; quoting on that alone produced hook

--- a/internal/clipath/clipath_test.go
+++ b/internal/clipath/clipath_test.go
@@ -230,18 +230,34 @@ func TestShouldRewriteUpgradesStaleCellarVersion(t *testing.T) {
 	}
 }
 
-// isStableSpelling must split PATH with the goos seam's separator so the
-// Windows shape is testable from any host.
-func TestIsStableSpellingWindowsPath(t *testing.T) {
-	stubGOOS(t, "windows")
-	stubInstallDirs(t, nil)
-	t.Setenv("PATH", `C:/tools;C:/bin`)
-
-	if !isStableSpelling(`C:/tools/` + binaryName()) {
-		t.Fatal("a binary in a Windows PATH directory must count as stable")
+// The alias trade keys purely on the versioned-tree shape: a CLI outside
+// installDirs is recorded as invoked, even when an installDirs symlink to
+// the same binary exists. Anything else would make the recorded spelling
+// depend on PATH, which differs between terminal and GUI launches, and
+// alternate between installs of the same binary.
+func TestResolveKeepsNonBrewInvocationDespiteAlias(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
 	}
-	if isStableSpelling(`C:/elsewhere/` + binaryName()) {
-		t.Fatal("a binary outside PATH and installDirs must not count as stable")
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	t.Setenv("PATH", filepath.Join(root, "empty"))
+	want := writeFakeCLI(t, filepath.Join(root, "tools"), binaryName())
+	if err := os.MkdirAll(filepath.Join(root, "localbin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(want, filepath.Join(root, "localbin", binaryName())); err != nil {
+		t.Fatal(err)
+	}
+	stubExecutable(t, want)
+	stubInstallDirs(t, []string{filepath.Join(root, "localbin")})
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Resolve = %q, want the invoked path %q, not the installDirs alias", got, want)
 	}
 }
 

--- a/internal/clipath/clipath_test.go
+++ b/internal/clipath/clipath_test.go
@@ -128,6 +128,64 @@ func TestResolveUsesRunningCLI(t *testing.T) {
 	}
 }
 
+// A Homebrew-style install exposes a stable symlink (bin/sx) into a versioned
+// directory (Cellar/sx/<version>/bin/sx) that upgrades delete. The invocation
+// path must be what Resolve returns, or every hook written from it dies on the
+// next upgrade (issue #222).
+func TestResolveKeepsInvocationSymlinkPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	target := writeFakeCLI(t, filepath.Join(root, "Cellar", "sx", "2.3.1", "bin"), binaryName())
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "bin", binaryName())
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	stubExecutable(t, link)
+	stubInstallDirs(t, nil)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != link {
+		t.Fatalf("Resolve = %q, want stable symlink %q, not the versioned target", got, link)
+	}
+}
+
+// A symlink whose name is not the CLI's ("skills" -> sx) is only recognizable
+// as the CLI after resolution, so the resolved path is used there.
+func TestResolveDifferentlyNamedSymlinkFallsBackToTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	target := writeFakeCLI(t, filepath.Join(root, "real"), binaryName())
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "bin", "skills")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	stubExecutable(t, link)
+	stubInstallDirs(t, nil)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != target {
+		t.Fatalf("Resolve = %q, want resolved target %q", got, target)
+	}
+}
+
 func TestCommandQuotesPathsWithSpaces(t *testing.T) {
 	dir := filepath.Join(tempRoot(t), "Application Support")
 	path := writeFakeCLI(t, dir, binaryName())

--- a/internal/clipath/clipath_test.go
+++ b/internal/clipath/clipath_test.go
@@ -199,6 +199,52 @@ func TestResolveDerivesBrewPrefixWithoutPATH(t *testing.T) {
 	}
 }
 
+// The realistic Cellar migration: the recorded entry names the OLD keg,
+// which still exists (brew cleanup is deferred), while resolution now
+// yields the new version. Same-file identity can never hold there, so
+// the upgrade must key on the Cellar shape itself.
+func TestShouldRewriteUpgradesStaleCellarVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	t.Setenv("PATH", filepath.Join(root, "empty"))
+	oldKeg := writeFakeCLI(t, filepath.Join(root, "Cellar", "sx", "2.3.0", "bin"), binaryName())
+	newKeg := writeFakeCLI(t, filepath.Join(root, "Cellar", "sx", "2.3.1", "bin"), binaryName())
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "bin", binaryName())
+	if err := os.Symlink(newKeg, link); err != nil {
+		t.Fatal(err)
+	}
+	stubExecutable(t, newKeg)
+	stubInstallDirs(t, []string{filepath.Join(root, "bin")})
+
+	if !ShouldRewrite(oldKeg + " install --hook-mode") {
+		t.Fatal("an entry pinned to a still-present older keg must be upgraded")
+	}
+	if ShouldRewrite(link + " install --hook-mode") {
+		t.Fatal("the stable spelling must not be rewritten")
+	}
+}
+
+// isStableSpelling must split PATH with the goos seam's separator so the
+// Windows shape is testable from any host.
+func TestIsStableSpellingWindowsPath(t *testing.T) {
+	stubGOOS(t, "windows")
+	stubInstallDirs(t, nil)
+	t.Setenv("PATH", `C:/tools;C:/bin`)
+
+	if !isStableSpelling(`C:/tools/` + binaryName()) {
+		t.Fatal("a binary in a Windows PATH directory must count as stable")
+	}
+	if isStableSpelling(`C:/elsewhere/` + binaryName()) {
+		t.Fatal("a binary outside PATH and installDirs must not count as stable")
+	}
+}
+
 // The same-binary upgrade must be one-directional: a spelling that is
 // not itself fragile is never traded for whatever Resolve currently
 // says, even when both name the same binary.

--- a/internal/clipath/clipath_test.go
+++ b/internal/clipath/clipath_test.go
@@ -230,6 +230,33 @@ func TestShouldRewriteUpgradesStaleCellarVersion(t *testing.T) {
 	}
 }
 
+// Intel-macOS shape: brew's prefix and install.sh's target are both
+// /usr/local, so <prefix>/bin/sx can be a standalone binary unrelated to
+// the running keg. That binary must not displace the keg — pinning hooks
+// to a different (possibly older) CLI is exactly what Resolve's
+// forward-only skew rule forbids.
+func TestResolveKeepsKegWhenPrefixBinIsUnrelated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Cellar layout is not a Windows shape")
+	}
+	t.Setenv(EnvOverride, "")
+	root := tempRoot(t)
+	t.Setenv("PATH", filepath.Join(root, "empty"))
+	keg := writeFakeCLI(t, filepath.Join(root, "Cellar", "sx", "2.3.1", "bin"), binaryName())
+	// A regular file, not a symlink into the Cellar: a separate install.
+	writeFakeCLI(t, filepath.Join(root, "bin"), binaryName())
+	stubExecutable(t, keg)
+	stubInstallDirs(t, nil)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != keg {
+		t.Fatalf("Resolve = %q, want the running keg %q, not the unrelated prefix binary", got, keg)
+	}
+}
+
 // The alias trade keys purely on the versioned-tree shape: a CLI outside
 // installDirs is recorded as invoked, even when an installDirs symlink to
 // the same binary exists. Anything else would make the recorded spelling


### PR DESCRIPTION
## Summary
- Stop resolving the running executable through `EvalSymlinks` when picking the CLI path written into hook and MCP configs — on Homebrew that rewrote the stable `/opt/homebrew/bin/sx` symlink into the versioned `Cellar/sx/<version>/bin/sx` path, which every `brew upgrade` deletes, orphaning the SessionStart hook
- Keep symlink resolution where it is actually needed: detecting the desktop app bundle layout, and recognizing the CLI when invoked through a differently-named symlink (`skills` -> `sx`)
- Existing hooks pinned to a now-dead Cellar path are already caught by `NeedsRepair` and get rewritten to the stable path on the next `sx install`
- Add a Homebrew-shape resolver test (fails without the fix) and a renamed-symlink test

Fixes #222

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G59XGDW9DWsyWJFu7XekAi