### PR TITLE
SK-754: Make vault list/show manifest-aware

### DIFF
--- a/internal/vault/asset_listing.go
+++ b/internal/vault/asset_listing.go
@@ -354,8 +354,21 @@ func sourcePathContentDir(vaultRoot string, sp *manifest.SourcePath) (string, bo
 	if filepath.IsAbs(sp.Path) || strings.HasPrefix(sp.Path, "~") {
 		return "", false
 	}
-	root := filepath.Clean(vaultRoot)
-	resolved := filepath.Clean(filepath.Join(root, filepath.FromSlash(sp.Path)))
+	// Evaluate symlinks on BOTH sides before the containment check: every
+	// read below follows symlinks, and a committed symlink inside the vault
+	// can point anywhere on the machine — a lexical Rel check alone would
+	// pass it. Evaluating the root too keeps legitimate paths working when
+	// the vault itself sits behind a symlink (e.g. macOS /tmp, synced
+	// folders). EvalSymlinks also errors for missing paths, which are not
+	// discoverable either.
+	root, err := filepath.EvalSymlinks(filepath.Clean(vaultRoot))
+	if err != nil {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(filepath.Join(root, filepath.FromSlash(sp.Path))))
+	if err != nil {
+		return "", false
+	}
 	rel, err := filepath.Rel(root, resolved)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", false

--- a/internal/vault/asset_listing.go
+++ b/internal/vault/asset_listing.go
@@ -301,13 +301,20 @@ func manifestAssetRows(vaultRoot string) (map[string][]manifest.Asset, []string,
 // when absent. Unlike versionListForAsset it never falls back to the
 // manifest: discovery callers already hold the parsed manifest rows and
 // union them via unionVersions, so the fallback would only re-parse
-// sx.toml once per asset for nothing.
+// sx.toml once per asset for nothing. The synced-folder conflict warning
+// is preserved — list/show are where users browsing a synced vault would
+// notice a conflicted copy.
 func storedVersionList(vaultRoot string, l layout.Layout, name string) ([]string, error) {
-	versions, err := readVersionListFile(filepath.Join(vaultRoot, l.VersionListPath(name)))
+	listPath := filepath.Join(vaultRoot, l.VersionListPath(name))
+	versions, err := readVersionListFile(listPath)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
-	return versions, err
+	if err != nil {
+		return nil, err
+	}
+	warnVersionListConflicts(listPath, name)
+	return versions, nil
 }
 
 // unionVersions merges stored list.txt versions with the versions declared

--- a/internal/vault/asset_listing.go
+++ b/internal/vault/asset_listing.go
@@ -1,0 +1,305 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sleuth-io/sx/v2/internal/manifest"
+	"github.com/sleuth-io/sx/v2/internal/metadata"
+	"github.com/sleuth-io/sx/v2/internal/utils"
+	"github.com/sleuth-io/sx/v2/internal/vault/layout"
+	"github.com/sleuth-io/sx/v2/internal/version"
+)
+
+// This file implements asset discovery (list/show) shared by the
+// file-backed vaults (GitVault, PathVault). Discovery merges two sources:
+//
+//   - the stored assets/ tree (published layout, v1 or v2)
+//   - manifest [[assets]] rows with no stored files — the install-in-place
+//     model where a source-path row points at files elsewhere in the vault,
+//     or a source-http/git row points outside it entirely
+//
+// Install resolution is manifest-driven (manifest.Resolve), so a listing
+// that only scanned assets/ silently hid every asset the vault would in
+// fact install (issue #228).
+
+// listFileVaultAssets implements ListAssets over a synced vault root.
+func listFileVaultAssets(vaultRoot string, l layout.Layout, opts ListAssetsOptions) (*ListAssetsResult, error) {
+	assets, seen, err := storedAssetSummaries(vaultRoot, l, opts)
+	if err != nil {
+		return nil, err
+	}
+	manifestOnly, err := manifestOnlyAssetSummaries(vaultRoot, seen, opts)
+	if err != nil {
+		return nil, err
+	}
+	assets = append(assets, manifestOnly...)
+	// Stored entries arrive in directory order and manifest entries in
+	// manifest order; sort the merged view so output stays stable.
+	sort.Slice(assets, func(i, j int) bool { return assets[i].Name < assets[j].Name })
+
+	if search := strings.TrimSpace(opts.Search); search != "" {
+		assets = filterBySearch(assets, search)
+	}
+	if opts.Limit > 0 && len(assets) > opts.Limit {
+		assets = assets[:opts.Limit]
+	}
+	return &ListAssetsResult{Assets: assets}, nil
+}
+
+// storedAssetSummaries scans the layout's assets/ tree. The returned set
+// records every directory-backed name — including ones a type filter
+// discarded — so the manifest merge never duplicates a stored asset.
+func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOptions) ([]AssetSummary, map[string]bool, error) {
+	seen := map[string]bool{}
+	entries, err := os.ReadDir(filepath.Join(vaultRoot, l.AssetsRoot()))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, seen, nil
+		}
+		return nil, nil, fmt.Errorf("failed to read assets directory: %w", err)
+	}
+
+	var assets []AssetSummary
+	for _, entry := range filterScanEntries(entries) {
+		if !entry.IsDir() {
+			continue
+		}
+		versions, err := versionListForAsset(vaultRoot, l, entry.Name())
+		if err != nil || len(versions) == 0 {
+			continue // Skip if no versions
+		}
+		seen[entry.Name()] = true
+
+		latestVersion := versions[len(versions)-1]
+		summary := AssetSummary{
+			Name:          entry.Name(),
+			LatestVersion: latestVersion,
+			VersionsCount: len(versions),
+		}
+		if metaData, err := os.ReadFile(filepath.Join(vaultRoot, l.MetadataPath(entry.Name(), latestVersion))); err == nil {
+			if meta, err := metadata.Parse(metaData); err == nil {
+				summary.Type = meta.Asset.Type
+				summary.Description = meta.Asset.Description
+			}
+		}
+		if info, _ := entry.Info(); info != nil {
+			summary.CreatedAt = info.ModTime()
+			summary.UpdatedAt = info.ModTime()
+		}
+
+		if opts.Type != "" && summary.Type.Key != opts.Type {
+			continue
+		}
+		// AFTER the type filter: this fallback reads files, and a
+		// filtered listing must not pay it for assets it discards.
+		if summary.Description == "" {
+			// Assets published without a metadata description usually
+			// still declare one in markdown frontmatter — show it.
+			summary.Description = markdownDescription(
+				filepath.Join(vaultRoot, l.VersionDir(entry.Name(), latestVersion)))
+		}
+		assets = append(assets, summary)
+	}
+	return assets, seen, nil
+}
+
+// manifestOnlyAssetSummaries builds summaries for manifest [[assets]] rows
+// whose names have no stored directory under assets/ — install-in-place
+// source-path assets and http/git-sourced rows.
+func manifestOnlyAssetSummaries(vaultRoot string, seen map[string]bool, opts ListAssetsOptions) ([]AssetSummary, error) {
+	m, ok, err := manifest.Load(vaultRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vault manifest: %w", err)
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	grouped := map[string][]manifest.Asset{}
+	var order []string
+	for _, a := range m.Assets {
+		if seen[a.Name] || strings.TrimSpace(a.Version) == "" {
+			continue
+		}
+		if _, dup := grouped[a.Name]; !dup {
+			order = append(order, a.Name)
+		}
+		grouped[a.Name] = append(grouped[a.Name], a)
+	}
+
+	var out []AssetSummary
+	for _, name := range order {
+		rows := grouped[name]
+		versions := make([]string, 0, len(rows))
+		for _, r := range rows {
+			versions = append(versions, r.Version)
+		}
+		versions = version.Sort(versions)
+		latest := versions[len(versions)-1]
+		row := rows[0]
+		for _, r := range rows {
+			if r.Version == latest {
+				row = r
+				break
+			}
+		}
+
+		summary := AssetSummary{
+			Name:          name,
+			Type:          row.Type,
+			LatestVersion: latest,
+			VersionsCount: len(versions),
+		}
+		if opts.Type != "" && summary.Type.Key != opts.Type {
+			continue
+		}
+		// File reads only after the type filter, mirroring the stored scan.
+		if dir, ok := sourcePathContentDir(vaultRoot, row.SourcePath); ok {
+			if metaData, err := os.ReadFile(filepath.Join(dir, "metadata.toml")); err == nil {
+				if meta, err := metadata.Parse(metaData); err == nil {
+					summary.Description = meta.Asset.Description
+				}
+			}
+			if summary.Description == "" {
+				summary.Description = markdownDescription(dir)
+			}
+			if info, err := os.Stat(dir); err == nil {
+				summary.CreatedAt = info.ModTime()
+				summary.UpdatedAt = info.ModTime()
+			}
+		}
+		out = append(out, summary)
+	}
+	return out, nil
+}
+
+// fileVaultAssetDetails implements GetAssetDetails over a synced vault root.
+// An asset is found if it has a stored directory under assets/ OR versions
+// discoverable through the manifest (versionListForAsset falls back there).
+func fileVaultAssetDetails(vaultRoot string, l layout.Layout, name string) (*AssetDetails, error) {
+	assetDir := filepath.Join(vaultRoot, l.AssetDir(name))
+	_, statErr := os.Stat(assetDir)
+	dirExists := statErr == nil
+
+	versions, err := versionListForAsset(vaultRoot, l, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get version list: %w", err)
+	}
+	if len(versions) == 0 {
+		if dirExists {
+			return nil, fmt.Errorf("asset '%s' has no versions", name)
+		}
+		return nil, fmt.Errorf("asset '%s' not found", name)
+	}
+
+	rowsByVersion := manifestRowsForAsset(vaultRoot, name)
+	// contentDir locates the on-disk files for one version: the stored
+	// archive when present, else the manifest row's source-path.
+	contentDir := func(v string) (string, bool) {
+		stored := filepath.Join(vaultRoot, l.VersionDir(name, v))
+		if info, err := os.Stat(stored); err == nil && info.IsDir() {
+			return stored, true
+		}
+		if row, ok := rowsByVersion[v]; ok {
+			return sourcePathContentDir(vaultRoot, row.SourcePath)
+		}
+		return "", false
+	}
+
+	var versionList []AssetVersion
+	for _, v := range versions {
+		entry := AssetVersion{Version: v}
+		if dir, ok := contentDir(v); ok {
+			if info, err := os.Stat(dir); err == nil {
+				entry.CreatedAt = info.ModTime()
+			}
+			if entries, err := os.ReadDir(dir); err == nil {
+				fileCount := 0
+				for _, e := range entries {
+					if !e.IsDir() && !utils.IsSyncArtifact(e.Name()) {
+						fileCount++
+					}
+				}
+				entry.FilesCount = fileCount
+			}
+		}
+		versionList = append(versionList, entry)
+	}
+
+	latest := versions[len(versions)-1]
+	details := &AssetDetails{
+		Name:     name,
+		Versions: versionList,
+	}
+	if dir, ok := contentDir(latest); ok {
+		if metaData, err := os.ReadFile(filepath.Join(dir, "metadata.toml")); err == nil {
+			if meta, err := metadata.Parse(metaData); err == nil {
+				details.Type = meta.Asset.Type
+				details.Description = meta.Asset.Description
+				details.Metadata = meta
+			}
+		}
+		if details.Description == "" {
+			details.Description = markdownDescription(dir)
+		}
+	}
+	// The manifest is authoritative for install; fall back to its type when
+	// no stored metadata declares one.
+	if details.Type.Key == "" {
+		if row, ok := rowsByVersion[latest]; ok {
+			details.Type = row.Type
+		}
+	}
+
+	tsDir := assetDir
+	if !dirExists {
+		if dir, ok := contentDir(latest); ok {
+			tsDir = dir
+		}
+	}
+	if info, err := os.Stat(tsDir); err == nil {
+		details.CreatedAt = info.ModTime()
+		details.UpdatedAt = info.ModTime()
+	}
+	return details, nil
+}
+
+// manifestRowsForAsset returns the manifest [[assets]] rows for name keyed
+// by version. Missing or unreadable manifests yield an empty map — stored
+// discovery works without one, and a corrupt manifest already fails
+// detectLayout before discovery runs.
+func manifestRowsForAsset(vaultRoot, name string) map[string]manifest.Asset {
+	rows := map[string]manifest.Asset{}
+	m, ok, err := manifest.Load(vaultRoot)
+	if err != nil || !ok {
+		return rows
+	}
+	for _, a := range m.Assets {
+		if a.Name == name && strings.TrimSpace(a.Version) != "" {
+			rows[a.Version] = a
+		}
+	}
+	return rows
+}
+
+// sourcePathContentDir resolves a manifest source-path row to a readable
+// content directory. Zip-file sources and unresolvable paths return false —
+// discovery then falls back to manifest-only data.
+func sourcePathContentDir(vaultRoot string, sp *manifest.SourcePath) (string, bool) {
+	if sp == nil {
+		return "", false
+	}
+	resolved, err := NewPathSourceHandler(vaultRoot).ResolvePath(sp.Path)
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	return resolved, true
+}

--- a/internal/vault/asset_listing.go
+++ b/internal/vault/asset_listing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -138,7 +139,9 @@ func manifestOnlyAssetSummaries(vaultRoot string, seen map[string]bool, opts Lis
 		for _, r := range rows {
 			versions = append(versions, r.Version)
 		}
-		versions = version.Sort(versions)
+		// Sorted duplicates are adjacent; hand-edited manifests can carry
+		// duplicate rows and must not inflate the version count.
+		versions = slices.Compact(version.Sort(versions))
 		latest := versions[len(versions)-1]
 		row := rows[0]
 		for _, r := range rows {

--- a/internal/vault/asset_listing.go
+++ b/internal/vault/asset_listing.go
@@ -39,7 +39,7 @@ func listFileVaultAssets(vaultRoot string, l layout.Layout, opts ListAssetsOptio
 	if err != nil {
 		return nil, err
 	}
-	assets = append(assets, manifestOnlyAssetSummaries(vaultRoot, seen, opts, rowsByName, rowOrder)...)
+	assets = append(assets, manifestOnlyAssetSummaries(vaultRoot, l, seen, opts, rowsByName, rowOrder)...)
 	// Stored entries arrive in directory order and manifest entries in
 	// manifest order; sort the merged view so output stays stable.
 	sort.Slice(assets, func(i, j int) bool { return assets[i].Name < assets[j].Name })
@@ -72,7 +72,7 @@ func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOpti
 			continue
 		}
 		name := entry.Name()
-		stored, err := versionListForAsset(vaultRoot, l, name)
+		stored, err := storedVersionList(vaultRoot, l, name)
 		if err != nil {
 			continue // Skip if versions are unreadable
 		}
@@ -123,16 +123,24 @@ func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOpti
 }
 
 // manifestOnlyAssetSummaries builds summaries for manifest [[assets]] rows
-// whose names have no stored directory under assets/ — install-in-place
-// source-path assets and http/git-sourced rows.
-func manifestOnlyAssetSummaries(vaultRoot string, seen map[string]bool, opts ListAssetsOptions, rowsByName map[string][]manifest.Asset, rowOrder []string) []AssetSummary {
+// whose names have no directory found by the top-level assets/ scan —
+// install-in-place source-path assets, http/git-sourced rows, and
+// namespaced assets ("opsx/apply") whose top-level entry is only a
+// namespace directory. Namespaced assets can still have stored versions,
+// so this unions list.txt with the manifest rows and resolves content
+// through the same layout-aware lookup vault show uses.
+func manifestOnlyAssetSummaries(vaultRoot string, l layout.Layout, seen map[string]bool, opts ListAssetsOptions, rowsByName map[string][]manifest.Asset, rowOrder []string) []AssetSummary {
 	var out []AssetSummary
 	for _, name := range rowOrder {
 		if seen[name] {
 			continue
 		}
 		rows := rowsByName[name]
-		versions := unionVersions(nil, rows)
+		stored, err := storedVersionList(vaultRoot, l, name)
+		if err != nil {
+			stored = nil // degrade to manifest data
+		}
+		versions := unionVersions(stored, rows)
 		if len(versions) == 0 {
 			continue
 		}
@@ -148,7 +156,7 @@ func manifestOnlyAssetSummaries(vaultRoot string, seen map[string]bool, opts Lis
 			LatestVersion: latest,
 			VersionsCount: len(versions),
 		}
-		contentDir, hasContent := sourcePathContentDir(vaultRoot, row.SourcePath)
+		contentDir, hasContent := versionContentDir(vaultRoot, l, rows, name, latest)
 		var meta *metadata.Metadata
 		if summary.Type.Key == "" && hasContent {
 			// A hand-authored row may omit type while its source
@@ -196,7 +204,7 @@ func fileVaultAssetDetails(vaultRoot string, l layout.Layout, name string) (*Ass
 	_, statErr := os.Stat(assetDir)
 	dirExists := statErr == nil
 
-	stored, err := versionListForAsset(vaultRoot, l, name)
+	stored, err := storedVersionList(vaultRoot, l, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get version list: %w", err)
 	}
@@ -287,6 +295,19 @@ func manifestAssetRows(vaultRoot string) (map[string][]manifest.Asset, []string,
 		rows[a.Name] = append(rows[a.Name], a)
 	}
 	return rows, order, nil
+}
+
+// storedVersionList reads an asset's list.txt through the layout, empty
+// when absent. Unlike versionListForAsset it never falls back to the
+// manifest: discovery callers already hold the parsed manifest rows and
+// union them via unionVersions, so the fallback would only re-parse
+// sx.toml once per asset for nothing.
+func storedVersionList(vaultRoot string, l layout.Layout, name string) ([]string, error) {
+	versions, err := readVersionListFile(filepath.Join(vaultRoot, l.VersionListPath(name)))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return versions, err
 }
 
 // unionVersions merges stored list.txt versions with the versions declared

--- a/internal/vault/asset_listing.go
+++ b/internal/vault/asset_listing.go
@@ -25,19 +25,21 @@ import (
 //
 // Install resolution is manifest-driven (manifest.Resolve), so a listing
 // that only scanned assets/ silently hid every asset the vault would in
-// fact install (issue #228).
+// fact install (issue #228). Versions are the union of stored list.txt
+// entries and manifest rows per name, so a manifest row for a version the
+// storage doesn't know still surfaces.
 
 // listFileVaultAssets implements ListAssets over a synced vault root.
 func listFileVaultAssets(vaultRoot string, l layout.Layout, opts ListAssetsOptions) (*ListAssetsResult, error) {
-	assets, seen, err := storedAssetSummaries(vaultRoot, l, opts)
+	rowsByName, rowOrder, err := manifestAssetRows(vaultRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vault manifest: %w", err)
+	}
+	assets, seen, err := storedAssetSummaries(vaultRoot, l, opts, rowsByName)
 	if err != nil {
 		return nil, err
 	}
-	manifestOnly, err := manifestOnlyAssetSummaries(vaultRoot, seen, opts)
-	if err != nil {
-		return nil, err
-	}
-	assets = append(assets, manifestOnly...)
+	assets = append(assets, manifestOnlyAssetSummaries(vaultRoot, seen, opts, rowsByName, rowOrder)...)
 	// Stored entries arrive in directory order and manifest entries in
 	// manifest order; sort the merged view so output stays stable.
 	sort.Slice(assets, func(i, j int) bool { return assets[i].Name < assets[j].Name })
@@ -54,7 +56,7 @@ func listFileVaultAssets(vaultRoot string, l layout.Layout, opts ListAssetsOptio
 // storedAssetSummaries scans the layout's assets/ tree. The returned set
 // records every directory-backed name — including ones a type filter
 // discarded — so the manifest merge never duplicates a stored asset.
-func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOptions) ([]AssetSummary, map[string]bool, error) {
+func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOptions, rowsByName map[string][]manifest.Asset) ([]AssetSummary, map[string]bool, error) {
 	seen := map[string]bool{}
 	entries, err := os.ReadDir(filepath.Join(vaultRoot, l.AssetsRoot()))
 	if err != nil {
@@ -69,22 +71,35 @@ func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOpti
 		if !entry.IsDir() {
 			continue
 		}
-		versions, err := versionListForAsset(vaultRoot, l, entry.Name())
-		if err != nil || len(versions) == 0 {
+		name := entry.Name()
+		stored, err := versionListForAsset(vaultRoot, l, name)
+		if err != nil {
+			continue // Skip if versions are unreadable
+		}
+		versions := unionVersions(stored, rowsByName[name])
+		if len(versions) == 0 {
 			continue // Skip if no versions
 		}
-		seen[entry.Name()] = true
+		seen[name] = true
 
 		latestVersion := versions[len(versions)-1]
 		summary := AssetSummary{
-			Name:          entry.Name(),
+			Name:          name,
 			LatestVersion: latestVersion,
 			VersionsCount: len(versions),
 		}
-		if metaData, err := os.ReadFile(filepath.Join(vaultRoot, l.MetadataPath(entry.Name(), latestVersion))); err == nil {
-			if meta, err := metadata.Parse(metaData); err == nil {
+		contentDir, hasContent := versionContentDir(vaultRoot, l, rowsByName[name], name, latestVersion)
+		if hasContent {
+			if meta := readSourceMetadata(contentDir); meta != nil {
 				summary.Type = meta.Asset.Type
 				summary.Description = meta.Asset.Description
+			}
+		}
+		// The manifest is authoritative for install; fall back to its type
+		// when no stored metadata declares one.
+		if summary.Type.Key == "" {
+			if row, ok := rowForVersion(rowsByName[name], latestVersion); ok {
+				summary.Type = row.Type
 			}
 		}
 		if info, _ := entry.Info(); info != nil {
@@ -97,11 +112,10 @@ func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOpti
 		}
 		// AFTER the type filter: this fallback reads files, and a
 		// filtered listing must not pay it for assets it discards.
-		if summary.Description == "" {
+		if summary.Description == "" && hasContent {
 			// Assets published without a metadata description usually
 			// still declare one in markdown frontmatter — show it.
-			summary.Description = markdownDescription(
-				filepath.Join(vaultRoot, l.VersionDir(entry.Name(), latestVersion)))
+			summary.Description = markdownDescription(contentDir)
 		}
 		assets = append(assets, summary)
 	}
@@ -111,44 +125,21 @@ func storedAssetSummaries(vaultRoot string, l layout.Layout, opts ListAssetsOpti
 // manifestOnlyAssetSummaries builds summaries for manifest [[assets]] rows
 // whose names have no stored directory under assets/ — install-in-place
 // source-path assets and http/git-sourced rows.
-func manifestOnlyAssetSummaries(vaultRoot string, seen map[string]bool, opts ListAssetsOptions) ([]AssetSummary, error) {
-	m, ok, err := manifest.Load(vaultRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read vault manifest: %w", err)
-	}
-	if !ok {
-		return nil, nil
-	}
-
-	grouped := map[string][]manifest.Asset{}
-	var order []string
-	for _, a := range m.Assets {
-		if seen[a.Name] || strings.TrimSpace(a.Version) == "" {
+func manifestOnlyAssetSummaries(vaultRoot string, seen map[string]bool, opts ListAssetsOptions, rowsByName map[string][]manifest.Asset, rowOrder []string) []AssetSummary {
+	var out []AssetSummary
+	for _, name := range rowOrder {
+		if seen[name] {
 			continue
 		}
-		if _, dup := grouped[a.Name]; !dup {
-			order = append(order, a.Name)
+		rows := rowsByName[name]
+		versions := unionVersions(nil, rows)
+		if len(versions) == 0 {
+			continue
 		}
-		grouped[a.Name] = append(grouped[a.Name], a)
-	}
-
-	var out []AssetSummary
-	for _, name := range order {
-		rows := grouped[name]
-		versions := make([]string, 0, len(rows))
-		for _, r := range rows {
-			versions = append(versions, r.Version)
-		}
-		// Sorted duplicates are adjacent; hand-edited manifests can carry
-		// duplicate rows and must not inflate the version count.
-		versions = slices.Compact(version.Sort(versions))
 		latest := versions[len(versions)-1]
 		row := rows[0]
-		for _, r := range rows {
-			if r.Version == latest {
-				row = r
-				break
-			}
+		if r, ok := rowForVersion(rows, latest); ok {
+			row = r
 		}
 
 		summary := AssetSummary{
@@ -157,41 +148,59 @@ func manifestOnlyAssetSummaries(vaultRoot string, seen map[string]bool, opts Lis
 			LatestVersion: latest,
 			VersionsCount: len(versions),
 		}
+		contentDir, hasContent := sourcePathContentDir(vaultRoot, row.SourcePath)
+		var meta *metadata.Metadata
+		if summary.Type.Key == "" && hasContent {
+			// A hand-authored row may omit type while its source
+			// metadata.toml declares one; resolve before the filter so
+			// --type doesn't hide the asset. Typed rows keep the
+			// no-file-reads-before-filter fast path.
+			if meta = readSourceMetadata(contentDir); meta != nil {
+				summary.Type = meta.Asset.Type
+			}
+		}
 		if opts.Type != "" && summary.Type.Key != opts.Type {
 			continue
 		}
-		// File reads only after the type filter, mirroring the stored scan.
-		if dir, ok := sourcePathContentDir(vaultRoot, row.SourcePath); ok {
-			if metaData, err := os.ReadFile(filepath.Join(dir, "metadata.toml")); err == nil {
-				if meta, err := metadata.Parse(metaData); err == nil {
-					summary.Description = meta.Asset.Description
-				}
+		if hasContent {
+			if meta == nil {
+				meta = readSourceMetadata(contentDir)
+			}
+			if meta != nil {
+				summary.Description = meta.Asset.Description
 			}
 			if summary.Description == "" {
-				summary.Description = markdownDescription(dir)
+				summary.Description = markdownDescription(contentDir)
 			}
-			if info, err := os.Stat(dir); err == nil {
+			if info, err := os.Stat(contentDir); err == nil {
 				summary.CreatedAt = info.ModTime()
 				summary.UpdatedAt = info.ModTime()
 			}
 		}
 		out = append(out, summary)
 	}
-	return out, nil
+	return out
 }
 
 // fileVaultAssetDetails implements GetAssetDetails over a synced vault root.
 // An asset is found if it has a stored directory under assets/ OR versions
-// discoverable through the manifest (versionListForAsset falls back there).
+// discoverable through the manifest.
 func fileVaultAssetDetails(vaultRoot string, l layout.Layout, name string) (*AssetDetails, error) {
+	rowsByName, _, err := manifestAssetRows(vaultRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vault manifest: %w", err)
+	}
+	rows := rowsByName[name]
+
 	assetDir := filepath.Join(vaultRoot, l.AssetDir(name))
 	_, statErr := os.Stat(assetDir)
 	dirExists := statErr == nil
 
-	versions, err := versionListForAsset(vaultRoot, l, name)
+	stored, err := versionListForAsset(vaultRoot, l, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get version list: %w", err)
 	}
+	versions := unionVersions(stored, rows)
 	if len(versions) == 0 {
 		if dirExists {
 			return nil, fmt.Errorf("asset '%s' has no versions", name)
@@ -199,24 +208,10 @@ func fileVaultAssetDetails(vaultRoot string, l layout.Layout, name string) (*Ass
 		return nil, fmt.Errorf("asset '%s' not found", name)
 	}
 
-	rowsByVersion := manifestRowsForAsset(vaultRoot, name)
-	// contentDir locates the on-disk files for one version: the stored
-	// archive when present, else the manifest row's source-path.
-	contentDir := func(v string) (string, bool) {
-		stored := filepath.Join(vaultRoot, l.VersionDir(name, v))
-		if info, err := os.Stat(stored); err == nil && info.IsDir() {
-			return stored, true
-		}
-		if row, ok := rowsByVersion[v]; ok {
-			return sourcePathContentDir(vaultRoot, row.SourcePath)
-		}
-		return "", false
-	}
-
 	var versionList []AssetVersion
 	for _, v := range versions {
 		entry := AssetVersion{Version: v}
-		if dir, ok := contentDir(v); ok {
+		if dir, ok := versionContentDir(vaultRoot, l, rows, name, v); ok {
 			if info, err := os.Stat(dir); err == nil {
 				entry.CreatedAt = info.ModTime()
 			}
@@ -238,31 +233,28 @@ func fileVaultAssetDetails(vaultRoot string, l layout.Layout, name string) (*Ass
 		Name:     name,
 		Versions: versionList,
 	}
-	if dir, ok := contentDir(latest); ok {
-		if metaData, err := os.ReadFile(filepath.Join(dir, "metadata.toml")); err == nil {
-			if meta, err := metadata.Parse(metaData); err == nil {
-				details.Type = meta.Asset.Type
-				details.Description = meta.Asset.Description
-				details.Metadata = meta
-			}
+	latestDir, hasLatest := versionContentDir(vaultRoot, l, rows, name, latest)
+	if hasLatest {
+		if meta := readSourceMetadata(latestDir); meta != nil {
+			details.Type = meta.Asset.Type
+			details.Description = meta.Asset.Description
+			details.Metadata = meta
 		}
 		if details.Description == "" {
-			details.Description = markdownDescription(dir)
+			details.Description = markdownDescription(latestDir)
 		}
 	}
 	// The manifest is authoritative for install; fall back to its type when
 	// no stored metadata declares one.
 	if details.Type.Key == "" {
-		if row, ok := rowsByVersion[latest]; ok {
+		if row, ok := rowForVersion(rows, latest); ok {
 			details.Type = row.Type
 		}
 	}
 
 	tsDir := assetDir
-	if !dirExists {
-		if dir, ok := contentDir(latest); ok {
-			tsDir = dir
-		}
+	if !dirExists && hasLatest {
+		tsDir = latestDir
 	}
 	if info, err := os.Stat(tsDir); err == nil {
 		details.CreatedAt = info.ModTime()
@@ -271,33 +263,101 @@ func fileVaultAssetDetails(vaultRoot string, l layout.Layout, name string) (*Ass
 	return details, nil
 }
 
-// manifestRowsForAsset returns the manifest [[assets]] rows for name keyed
-// by version. Missing or unreadable manifests yield an empty map — stored
-// discovery works without one, and a corrupt manifest already fails
-// detectLayout before discovery runs.
-func manifestRowsForAsset(vaultRoot, name string) map[string]manifest.Asset {
-	rows := map[string]manifest.Asset{}
+// manifestAssetRows loads the manifest once and groups its asset rows by
+// name, preserving first-appearance order. Rows with an empty version are
+// dropped (they cannot be listed or resolved). A missing manifest yields an
+// empty map; a corrupt one already fails detectLayout before discovery runs.
+func manifestAssetRows(vaultRoot string) (map[string][]manifest.Asset, []string, error) {
+	rows := map[string][]manifest.Asset{}
 	m, ok, err := manifest.Load(vaultRoot)
-	if err != nil || !ok {
-		return rows
+	if err != nil {
+		return nil, nil, err
 	}
+	if !ok {
+		return rows, nil, nil
+	}
+	var order []string
 	for _, a := range m.Assets {
-		if a.Name == name && strings.TrimSpace(a.Version) != "" {
-			rows[a.Version] = a
+		if strings.TrimSpace(a.Version) == "" {
+			continue
+		}
+		if _, dup := rows[a.Name]; !dup {
+			order = append(order, a.Name)
+		}
+		rows[a.Name] = append(rows[a.Name], a)
+	}
+	return rows, order, nil
+}
+
+// unionVersions merges stored list.txt versions with the versions declared
+// by an asset's manifest rows, semver-sorted and deduplicated. Install
+// resolution is manifest-driven, so a manifest row's version must surface
+// even when the stored list doesn't know it — and duplicate hand-edited
+// rows must not inflate the count.
+func unionVersions(stored []string, rows []manifest.Asset) []string {
+	merged := append([]string(nil), stored...)
+	for _, r := range rows {
+		if strings.TrimSpace(r.Version) != "" {
+			merged = append(merged, r.Version)
 		}
 	}
-	return rows
+	return slices.Compact(version.Sort(merged))
+}
+
+// rowForVersion returns the first manifest row matching a version.
+func rowForVersion(rows []manifest.Asset, v string) (manifest.Asset, bool) {
+	for _, r := range rows {
+		if r.Version == v {
+			return r, true
+		}
+	}
+	return manifest.Asset{}, false
+}
+
+// versionContentDir locates the on-disk files for one version of an asset:
+// the stored archive when present, else the manifest row's source-path.
+func versionContentDir(vaultRoot string, l layout.Layout, rows []manifest.Asset, name, v string) (string, bool) {
+	stored := filepath.Join(vaultRoot, l.VersionDir(name, v))
+	if info, err := os.Stat(stored); err == nil && info.IsDir() {
+		return stored, true
+	}
+	if row, ok := rowForVersion(rows, v); ok {
+		return sourcePathContentDir(vaultRoot, row.SourcePath)
+	}
+	return "", false
+}
+
+// readSourceMetadata parses dir/metadata.toml, returning nil when the file
+// is absent or unparseable.
+func readSourceMetadata(dir string) *metadata.Metadata {
+	data, err := os.ReadFile(filepath.Join(dir, "metadata.toml"))
+	if err != nil {
+		return nil
+	}
+	meta, err := metadata.Parse(data)
+	if err != nil {
+		return nil
+	}
+	return meta
 }
 
 // sourcePathContentDir resolves a manifest source-path row to a readable
-// content directory. Zip-file sources and unresolvable paths return false —
-// discovery then falls back to manifest-only data.
+// content directory for discovery. Discovery is a read-only browse over a
+// possibly third-party vault, so unlike install it refuses to follow the
+// path outside the vault root: absolute and ~ paths, and relative paths
+// escaping the root, return false and the listing degrades to manifest-only
+// data. Zip-file sources and missing paths return false too.
 func sourcePathContentDir(vaultRoot string, sp *manifest.SourcePath) (string, bool) {
 	if sp == nil {
 		return "", false
 	}
-	resolved, err := NewPathSourceHandler(vaultRoot).ResolvePath(sp.Path)
-	if err != nil {
+	if filepath.IsAbs(sp.Path) || strings.HasPrefix(sp.Path, "~") {
+		return "", false
+	}
+	root := filepath.Clean(vaultRoot)
+	resolved := filepath.Clean(filepath.Join(root, filepath.FromSlash(sp.Path)))
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", false
 	}
 	info, err := os.Stat(resolved)

--- a/internal/vault/asset_listing_test.go
+++ b/internal/vault/asset_listing_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -459,6 +460,41 @@ func TestListAssetsNamespacedAssetUsesStoredVersions(t *testing.T) {
 	}
 	if len(details.Versions) != summary.VersionsCount {
 		t.Errorf("show has %d versions, list says %d — they must agree", len(details.Versions), summary.VersionsCount)
+	}
+}
+
+// Discovery must keep the documented synced-folder warning: a conflicted
+// list.txt copy is ignored (versions come from the real file) but the
+// warning tells the user it exists (docs/synced-folders.md).
+func TestDiscoveryWarnsAboutConflictedListFile(t *testing.T) {
+	dir := t.TempDir()
+	v := seedV2PathVault(t, dir)
+	conflicted := filepath.Join(dir, ".sx", "versions", "chat", "list.txt (1)")
+	if err := os.WriteFile(conflicted, []byte("9.9\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	list, listErr := v.ListAssets(context.Background(), ListAssetsOptions{})
+	_ = w.Close()
+	os.Stderr = oldStderr
+	captured, _ := io.ReadAll(r)
+
+	if listErr != nil {
+		t.Fatalf("ListAssets: %v", listErr)
+	}
+	for _, a := range list.Assets {
+		if a.Name == "chat" && a.LatestVersion != "2.0" {
+			t.Errorf("chat latest = %q, want 2.0 from the real list.txt", a.LatestVersion)
+		}
+	}
+	if !strings.Contains(string(captured), "sync-conflicted copy") {
+		t.Errorf("stderr = %q, want the sync-conflict warning", captured)
 	}
 }
 

--- a/internal/vault/asset_listing_test.go
+++ b/internal/vault/asset_listing_test.go
@@ -393,6 +393,75 @@ func TestNewerManifestOnlyVersionOfStoredAsset(t *testing.T) {
 	}
 }
 
+// A namespaced asset's top-level entry under assets/ is only a namespace
+// directory, so it reaches the manifest merge — which must still surface
+// its stored versions and content, agreeing with vault show.
+func TestListAssetsNamespacedAssetUsesStoredVersions(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// v2 layout: materialized root view + two archived versions.
+	write("assets/opsx/apply/SKILL.md", "# apply 1.1\n")
+	for _, v := range []string{"1.0", "1.1"} {
+		write(".sx/versions/opsx/apply/"+v+"/SKILL.md", "# apply "+v+"\n")
+		write(".sx/versions/opsx/apply/"+v+"/metadata.toml",
+			"[asset]\nname = \"opsx/apply\"\nversion = \""+v+"\"\ntype = \"skill\"\ndescription = \"Apply things\"\n")
+	}
+	write(".sx/versions/opsx/apply/list.txt", "1.0\n1.1\n")
+	m := &manifest.Manifest{
+		SchemaVersion: 2,
+		Assets: []manifest.Asset{
+			{Name: "opsx/apply", Version: "1.1", Type: asset.TypeSkill,
+				SourcePath: &manifest.SourcePath{Path: ".sx/versions/opsx/apply/1.1"}},
+		},
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	list, err := v.ListAssets(ctx, ListAssetsOptions{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	var summary AssetSummary
+	for _, a := range list.Assets {
+		if a.Name == "opsx/apply" {
+			summary = a
+		}
+	}
+	if summary.Name == "" {
+		t.Fatalf("opsx/apply missing from %+v", list.Assets)
+	}
+	if summary.VersionsCount != 2 || summary.LatestVersion != "1.1" {
+		t.Errorf("summary = %+v, want 2 stored versions with latest 1.1", summary)
+	}
+	if summary.Type.Key != "skill" || summary.Description != "Apply things" {
+		t.Errorf("summary = %+v, want type/description from stored metadata", summary)
+	}
+
+	details, err := v.GetAssetDetails(ctx, "opsx/apply")
+	if err != nil {
+		t.Fatalf("GetAssetDetails: %v", err)
+	}
+	if len(details.Versions) != summary.VersionsCount {
+		t.Errorf("show has %d versions, list says %d — they must agree", len(details.Versions), summary.VersionsCount)
+	}
+}
+
 // Renaming a manifest-only asset must fail with a clear explanation, not a
 // raw filesystem error; renaming an unknown asset says not found.
 func TestRenameManifestOnlyAssetFailsClearly(t *testing.T) {

--- a/internal/vault/asset_listing_test.go
+++ b/internal/vault/asset_listing_test.go
@@ -162,6 +162,238 @@ func TestGetAssetDetailsSourcePathManifestVault(t *testing.T) {
 	}
 }
 
+// Duplicate name+version rows in a hand-edited manifest must not inflate
+// counts anywhere: list, show, and GetVersionList have to agree.
+func TestDuplicateManifestRowsCountOnce(t *testing.T) {
+	dir := t.TempDir()
+	seedSourcePathVault(t, dir)
+	// Append a duplicate of an existing row plus a second distinct version.
+	dup := `
+[[assets]]
+name = "open-source-preparation"
+version = "1.2.0"
+type = "skill"
+
+[assets.source-path]
+path = "skills/open-source-preparation"
+
+[[assets]]
+name = "open-source-preparation"
+version = "1.3.0"
+type = "skill"
+
+[assets.source-path]
+path = "skills/open-source-preparation"
+`
+	f, err := os.OpenFile(filepath.Join(dir, "sx.toml"), os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(dup); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	list, err := v.ListAssets(ctx, ListAssetsOptions{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	var summary AssetSummary
+	for _, a := range list.Assets {
+		if a.Name == "open-source-preparation" {
+			summary = a
+		}
+	}
+	if summary.VersionsCount != 2 || summary.LatestVersion != "1.3.0" {
+		t.Errorf("summary = %+v, want 2 versions with latest 1.3.0", summary)
+	}
+
+	details, err := v.GetAssetDetails(ctx, "open-source-preparation")
+	if err != nil {
+		t.Fatalf("GetAssetDetails: %v", err)
+	}
+	if len(details.Versions) != summary.VersionsCount {
+		t.Errorf("show has %d versions, list says %d — they must agree", len(details.Versions), summary.VersionsCount)
+	}
+
+	versions, err := v.GetVersionList(ctx, "open-source-preparation")
+	if err != nil {
+		t.Fatalf("GetVersionList: %v", err)
+	}
+	if strings.Join(versions, ",") != "1.2.0,1.3.0" {
+		t.Errorf("GetVersionList = %v, want deduped [1.2.0 1.3.0]", versions)
+	}
+}
+
+// A hand-authored row that omits type but whose source metadata.toml
+// declares one must be typed (and type-filterable) in listings.
+func TestManifestRowWithoutTypeUsesSourceMetadata(t *testing.T) {
+	dir := t.TempDir()
+	seedSourcePathVault(t, dir)
+	m, _, err := manifest.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range m.Assets {
+		if m.Assets[i].Name == "open-source-preparation" {
+			m.Assets[i].Type = asset.Type{}
+		}
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := v.ListAssets(context.Background(), ListAssetsOptions{Type: "skill"})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	if len(list.Assets) != 1 || list.Assets[0].Name != "open-source-preparation" {
+		t.Fatalf("filtered ListAssets = %+v, want open-source-preparation via metadata.toml type", list.Assets)
+	}
+	if list.Assets[0].Type.Key != "skill" {
+		t.Errorf("type = %q, want skill from source metadata.toml", list.Assets[0].Type.Key)
+	}
+}
+
+// Discovery must not follow source paths out of the vault root (absolute,
+// tilde, or ../ escapes): the listing degrades to manifest-only data
+// instead of reading arbitrary local files.
+func TestDiscoverySkipsSourcePathsOutsideVaultRoot(t *testing.T) {
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "metadata.toml"),
+		[]byte("[asset]\nname = \"evil\"\nversion = \"1.0.0\"\ntype = \"skill\"\ndescription = \"secret local data\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	m := &manifest.Manifest{
+		SchemaVersion: 2,
+		Assets: []manifest.Asset{
+			{Name: "abs", Version: "1.0.0", Type: asset.TypeSkill,
+				SourcePath: &manifest.SourcePath{Path: outside}},
+			{Name: "escape", Version: "1.0.0", Type: asset.TypeSkill,
+				SourcePath: &manifest.SourcePath{Path: "../" + filepath.Base(outside)}},
+			{Name: "tilde", Version: "1.0.0", Type: asset.TypeSkill,
+				SourcePath: &manifest.SourcePath{Path: "~/secrets"}},
+		},
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	list, err := v.ListAssets(ctx, ListAssetsOptions{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	if len(list.Assets) != 3 {
+		t.Fatalf("ListAssets = %+v, want all 3 assets (manifest-only data)", list.Assets)
+	}
+	for _, a := range list.Assets {
+		if a.Description != "" {
+			t.Errorf("asset %q description = %q, must not be read from outside the vault", a.Name, a.Description)
+		}
+	}
+	details, err := v.GetAssetDetails(ctx, "abs")
+	if err != nil {
+		t.Fatalf("GetAssetDetails: %v", err)
+	}
+	if details.Description != "" || details.Versions[0].FilesCount != 0 {
+		t.Errorf("details = %+v, must not expose files outside the vault", details)
+	}
+}
+
+// A manifest row can declare a newer version than the stored list.txt
+// knows (hand-edited install-in-place vaults). Install resolves it, so
+// list/show must surface it too.
+func TestNewerManifestOnlyVersionOfStoredAsset(t *testing.T) {
+	dir := t.TempDir()
+	v := seedV2PathVault(t, dir)
+
+	// chat has stored versions 1.0 and 2.0; declare a 3.0 living outside
+	// assets/.
+	if err := os.MkdirAll(filepath.Join(dir, "wip", "chat"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wip", "chat", "SKILL.md"), []byte("# chat 3.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m, _, err := manifest.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Assets = append(m.Assets, manifest.Asset{
+		Name: "chat", Version: "3.0", Type: asset.TypeSkill,
+		SourcePath: &manifest.SourcePath{Path: "wip/chat"},
+	})
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	list, err := v.ListAssets(ctx, ListAssetsOptions{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	var chat AssetSummary
+	for _, a := range list.Assets {
+		if a.Name == "chat" {
+			chat = a
+		}
+	}
+	if chat.LatestVersion != "3.0" || chat.VersionsCount != 3 {
+		t.Errorf("chat summary = %+v, want latest 3.0 of 3 versions", chat)
+	}
+
+	details, err := v.GetAssetDetails(ctx, "chat")
+	if err != nil {
+		t.Fatalf("GetAssetDetails: %v", err)
+	}
+	if len(details.Versions) != 3 || details.Versions[2].Version != "3.0" {
+		t.Errorf("versions = %+v, want [1.0 2.0 3.0]", details.Versions)
+	}
+	if details.Versions[2].FilesCount != 1 {
+		t.Errorf("3.0 FilesCount = %d, want 1 (SKILL.md from wip/chat)", details.Versions[2].FilesCount)
+	}
+}
+
+// Renaming a manifest-only asset must fail with a clear explanation, not a
+// raw filesystem error; renaming an unknown asset says not found.
+func TestRenameManifestOnlyAssetFailsClearly(t *testing.T) {
+	dir := t.TempDir()
+	seedSourcePathVault(t, dir)
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	err = v.RenameAsset(ctx, "open-source-preparation", "osp")
+	if err == nil || !strings.Contains(err.Error(), "no stored files") {
+		t.Errorf("RenameAsset = %v, want a clear no-stored-files error", err)
+	}
+	err = v.RenameAsset(ctx, "nope", "nope2")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("RenameAsset(nope) = %v, want not-found error", err)
+	}
+}
+
 // The end-to-end repro from issue #228: a git vault whose manifest declares
 // source-path assets outside assets/ must list and show them.
 func TestGitVaultSourcePathManifestDiscovery(t *testing.T) {

--- a/internal/vault/asset_listing_test.go
+++ b/internal/vault/asset_listing_test.go
@@ -1,0 +1,209 @@
+package vault
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/v2/internal/asset"
+	"github.com/sleuth-io/sx/v2/internal/manifest"
+	"github.com/sleuth-io/sx/v2/internal/mgmt"
+)
+
+// seedSourcePathVault builds a hand-authored install-in-place vault (the
+// issue #228 layout): a schema_version = 2 manifest whose [[assets]] rows
+// point via source-path at files outside assets/ — no assets/ directory at
+// all.
+func seedSourcePathVault(t *testing.T, dir string) {
+	t.Helper()
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// One asset with a metadata.toml description, one relying on markdown
+	// frontmatter only.
+	write("skills/open-source-preparation/SKILL.md", "# open-source-preparation\n\nBody.\n")
+	write("skills/open-source-preparation/metadata.toml",
+		"[asset]\nname = \"open-source-preparation\"\nversion = \"1.2.0\"\ntype = \"skill\"\ndescription = \"Prepare a repo for open sourcing\"\n")
+	write("rules/style-rules/RULE.md", "---\ndescription: House style rules\n---\n# style-rules\n")
+
+	m := &manifest.Manifest{
+		SchemaVersion: 2,
+		Assets: []manifest.Asset{
+			{
+				Name: "open-source-preparation", Version: "1.2.0", Type: asset.TypeSkill,
+				SourcePath: &manifest.SourcePath{Path: "skills/open-source-preparation"},
+			},
+			{
+				Name: "style-rules", Version: "2.1.0", Type: asset.TypeRule,
+				SourcePath: &manifest.SourcePath{Path: "rules/style-rules"},
+			},
+		},
+	}
+	if err := manifest.Save(dir, m); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListAssetsSourcePathManifestVault(t *testing.T) {
+	dir := t.TempDir()
+	seedSourcePathVault(t, dir)
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := v.ListAssets(context.Background(), ListAssetsOptions{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	if len(list.Assets) != 2 {
+		t.Fatalf("ListAssets = %+v, want 2 assets", list.Assets)
+	}
+	byName := map[string]AssetSummary{}
+	for _, a := range list.Assets {
+		byName[a.Name] = a
+	}
+
+	skill, ok := byName["open-source-preparation"]
+	if !ok {
+		t.Fatalf("open-source-preparation missing from %+v", list.Assets)
+	}
+	if skill.Type.Key != "skill" || skill.LatestVersion != "1.2.0" || skill.VersionsCount != 1 {
+		t.Errorf("skill summary = %+v", skill)
+	}
+	if skill.Description != "Prepare a repo for open sourcing" {
+		t.Errorf("skill description = %q, want the metadata.toml description", skill.Description)
+	}
+	if skill.UpdatedAt.IsZero() {
+		t.Error("skill timestamps should come from the source directory")
+	}
+
+	rule, ok := byName["style-rules"]
+	if !ok {
+		t.Fatalf("style-rules missing from %+v", list.Assets)
+	}
+	if rule.Type.Key != "rule" || rule.LatestVersion != "2.1.0" {
+		t.Errorf("rule summary = %+v", rule)
+	}
+	if rule.Description != "House style rules" {
+		t.Errorf("rule description = %q, want the frontmatter description", rule.Description)
+	}
+}
+
+func TestListAssetsSourcePathManifestTypeFilter(t *testing.T) {
+	dir := t.TempDir()
+	seedSourcePathVault(t, dir)
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := v.ListAssets(context.Background(), ListAssetsOptions{Type: "skill"})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	if len(list.Assets) != 1 || list.Assets[0].Name != "open-source-preparation" {
+		t.Errorf("filtered ListAssets = %+v, want only open-source-preparation", list.Assets)
+	}
+}
+
+func TestGetAssetDetailsSourcePathManifestVault(t *testing.T) {
+	dir := t.TempDir()
+	seedSourcePathVault(t, dir)
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	details, err := v.GetAssetDetails(ctx, "open-source-preparation")
+	if err != nil {
+		t.Fatalf("GetAssetDetails: %v", err)
+	}
+	if details.Type.Key != "skill" || details.Description != "Prepare a repo for open sourcing" {
+		t.Errorf("details = %+v", details)
+	}
+	if len(details.Versions) != 1 || details.Versions[0].Version != "1.2.0" {
+		t.Fatalf("versions = %+v, want [1.2.0]", details.Versions)
+	}
+	if details.Versions[0].FilesCount != 2 {
+		t.Errorf("FilesCount = %d, want 2 (SKILL.md + metadata.toml)", details.Versions[0].FilesCount)
+	}
+	if details.Metadata == nil {
+		t.Error("Metadata should be parsed from the source directory")
+	}
+
+	// A rule with no metadata.toml still resolves type (manifest) and
+	// description (frontmatter).
+	details, err = v.GetAssetDetails(ctx, "style-rules")
+	if err != nil {
+		t.Fatalf("GetAssetDetails(style-rules): %v", err)
+	}
+	if details.Type.Key != "rule" {
+		t.Errorf("style-rules type = %q, want manifest type \"rule\"", details.Type.Key)
+	}
+	if details.Description != "House style rules" {
+		t.Errorf("style-rules description = %q", details.Description)
+	}
+
+	// Unknown assets still error clearly.
+	if _, err := v.GetAssetDetails(ctx, "nope"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("GetAssetDetails(nope) = %v, want not-found error", err)
+	}
+}
+
+// The end-to-end repro from issue #228: a git vault whose manifest declares
+// source-path assets outside assets/ must list and show them.
+func TestGitVaultSourcePathManifestDiscovery(t *testing.T) {
+	mgmt.ResetActorCache()
+	t.Setenv("SX_CACHE_DIR", t.TempDir())
+
+	remoteDir := filepath.Join(t.TempDir(), "vault.git")
+	gitRun(t, "", "init", "--bare", "-b", "main", remoteDir)
+
+	writerDir := filepath.Join(t.TempDir(), "writer")
+	gitRun(t, "", "init", "-b", "main", writerDir)
+	gitRun(t, writerDir, "config", "user.email", "writer@example.com")
+	gitRun(t, writerDir, "config", "user.name", "Writer")
+	seedSourcePathVault(t, writerDir)
+	gitRun(t, writerDir, "add", ".")
+	gitRun(t, writerDir, "commit", "-m", "seed")
+	gitRun(t, writerDir, "remote", "add", "origin", remoteDir)
+	gitRun(t, writerDir, "push", "origin", "main")
+
+	v, err := NewGitVault("file://" + remoteDir)
+	if err != nil {
+		t.Fatalf("NewGitVault: %v", err)
+	}
+	ctx := context.Background()
+
+	list, err := v.ListAssets(ctx, ListAssetsOptions{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	var names []string
+	for _, a := range list.Assets {
+		names = append(names, a.Name)
+	}
+	if strings.Join(names, ",") != "open-source-preparation,style-rules" {
+		t.Fatalf("ListAssets = %v, want the two manifest assets", names)
+	}
+
+	details, err := v.GetAssetDetails(ctx, "open-source-preparation")
+	if err != nil {
+		t.Fatalf("GetAssetDetails: %v", err)
+	}
+	if details.Type.Key != "skill" || len(details.Versions) != 1 {
+		t.Errorf("details = %+v", details)
+	}
+}

--- a/internal/vault/asset_listing_test.go
+++ b/internal/vault/asset_listing_test.go
@@ -289,6 +289,16 @@ func TestDiscoverySkipsSourcePathsOutsideVaultRoot(t *testing.T) {
 				SourcePath: &manifest.SourcePath{Path: "~/secrets"}},
 		},
 	}
+	// A committed symlink inside the vault pointing outside it: the
+	// vault-relative path looks contained, but resolution must not follow
+	// it out of the root.
+	symlinkOK := os.Symlink(outside, filepath.Join(dir, "wip")) == nil
+	if symlinkOK {
+		m.Assets = append(m.Assets, manifest.Asset{
+			Name: "symlink", Version: "1.0.0", Type: asset.TypeSkill,
+			SourcePath: &manifest.SourcePath{Path: "wip"},
+		})
+	}
 	if err := manifest.Save(dir, m); err != nil {
 		t.Fatal(err)
 	}
@@ -302,20 +312,30 @@ func TestDiscoverySkipsSourcePathsOutsideVaultRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAssets: %v", err)
 	}
-	if len(list.Assets) != 3 {
-		t.Fatalf("ListAssets = %+v, want all 3 assets (manifest-only data)", list.Assets)
+	wantAssets := 3
+	if symlinkOK {
+		wantAssets = 4
+	}
+	if len(list.Assets) != wantAssets {
+		t.Fatalf("ListAssets = %+v, want all %d assets (manifest-only data)", list.Assets, wantAssets)
 	}
 	for _, a := range list.Assets {
 		if a.Description != "" {
 			t.Errorf("asset %q description = %q, must not be read from outside the vault", a.Name, a.Description)
 		}
 	}
-	details, err := v.GetAssetDetails(ctx, "abs")
-	if err != nil {
-		t.Fatalf("GetAssetDetails: %v", err)
+	names := []string{"abs"}
+	if symlinkOK {
+		names = append(names, "symlink")
 	}
-	if details.Description != "" || details.Versions[0].FilesCount != 0 {
-		t.Errorf("details = %+v, must not expose files outside the vault", details)
+	for _, name := range names {
+		details, err := v.GetAssetDetails(ctx, name)
+		if err != nil {
+			t.Fatalf("GetAssetDetails(%s): %v", name, err)
+		}
+		if details.Description != "" || details.Versions[0].FilesCount != 0 {
+			t.Errorf("details for %q = %+v, must not expose files outside the vault", name, details)
+		}
 	}
 }
 

--- a/internal/vault/gitrepo.go
+++ b/internal/vault/gitrepo.go
@@ -1041,98 +1041,25 @@ func (g *GitVault) RenameAsset(ctx context.Context, oldName, newName string) err
 	return nil
 }
 
-// ListAssets returns a list of all assets in the vault by reading the assets/ directory
+// ListAssets lists the vault's assets — stored under assets/ or declared
+// in the manifest. See listFileVaultAssets.
 func (g *GitVault) ListAssets(ctx context.Context, opts ListAssetsOptions) (*ListAssetsResult, error) {
 	start := time.Now()
 	// Clone or update repository
 	if err := g.cloneOrUpdate(ctx); err != nil {
 		return nil, fmt.Errorf("failed to clone/update repository: %w", err)
 	}
-	log := logger.Get()
-	log.Debug("cloneOrUpdate completed", "duration", time.Since(start))
+	logger.Get().Debug("cloneOrUpdate completed", "duration", time.Since(start))
 
 	l, err := detectLayout(g.repoPath)
 	if err != nil {
 		return nil, err
 	}
-
-	// Read assets/ directory
-	assetsDir := filepath.Join(g.repoPath, l.AssetsRoot())
-	entries, err := os.ReadDir(assetsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// No assets directory means no assets
-			return &ListAssetsResult{Assets: []AssetSummary{}}, nil
-		}
-		return nil, fmt.Errorf("failed to read assets directory: %w", err)
-	}
-
-	var assets []AssetSummary
-	for _, entry := range filterScanEntries(entries) {
-		if !entry.IsDir() {
-			continue
-		}
-
-		// Read list.txt for versions
-		versions, err := g.GetVersionList(ctx, entry.Name())
-		if err != nil || len(versions) == 0 {
-			continue // Skip if no versions
-		}
-
-		// Get metadata for latest version
-		latestVersion := versions[len(versions)-1]
-		metadataPath := filepath.Join(g.repoPath, l.MetadataPath(entry.Name(), latestVersion))
-
-		assetSummary := AssetSummary{
-			Name:          entry.Name(),
-			LatestVersion: latestVersion,
-			VersionsCount: len(versions),
-		}
-
-		// Try to read metadata
-		if metaData, err := os.ReadFile(metadataPath); err == nil {
-			if meta, err := metadata.Parse(metaData); err == nil {
-				assetSummary.Type = meta.Asset.Type
-				assetSummary.Description = meta.Asset.Description
-			}
-		}
-		// Get file timestamps
-		assetDirInfo, _ := entry.Info()
-		if assetDirInfo != nil {
-			assetSummary.CreatedAt = assetDirInfo.ModTime()
-			assetSummary.UpdatedAt = assetDirInfo.ModTime()
-		}
-
-		// Apply type filter if specified
-		if opts.Type != "" && assetSummary.Type.Key != opts.Type {
-			continue
-		}
-
-		// AFTER the type filter: this fallback reads files, and a
-		// filtered listing must not pay it for assets it discards.
-		if assetSummary.Description == "" {
-			// Assets published without a metadata description usually
-			// still declare one in markdown frontmatter — show it.
-			assetSummary.Description = markdownDescription(
-				filepath.Join(g.repoPath, l.VersionDir(entry.Name(), latestVersion)))
-		}
-
-		assets = append(assets, assetSummary)
-	}
-
-	if search := strings.TrimSpace(opts.Search); search != "" {
-		assets = filterBySearch(assets, search)
-	}
-
-	// Apply limit if specified
-	if opts.Limit > 0 && len(assets) > opts.Limit {
-		assets = assets[:opts.Limit]
-	}
-
-	return &ListAssetsResult{Assets: assets}, nil
+	return listFileVaultAssets(g.repoPath, l, opts)
 }
 
-// GetAssetDetails returns detailed information about a specific asset
+// GetAssetDetails returns detailed information about a specific asset —
+// stored under assets/ or declared in the manifest. See fileVaultAssetDetails.
 func (g *GitVault) GetAssetDetails(ctx context.Context, name string) (*AssetDetails, error) {
 	// Clone or update repository
 	if err := g.cloneOrUpdate(ctx); err != nil {
@@ -1143,77 +1070,7 @@ func (g *GitVault) GetAssetDetails(ctx context.Context, name string) (*AssetDeta
 	if err != nil {
 		return nil, err
 	}
-
-	// Check if asset directory exists
-	assetDir := filepath.Join(g.repoPath, l.AssetDir(name))
-	if _, err := os.Stat(assetDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("asset '%s' not found", name)
-	}
-
-	// Get version list
-	versions, err := g.GetVersionList(ctx, name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get version list: %w", err)
-	}
-
-	if len(versions) == 0 {
-		return nil, fmt.Errorf("asset '%s' has no versions", name)
-	}
-
-	// Build version list with file info
-	var versionList []AssetVersion
-	for _, v := range versions {
-		versionDir := filepath.Join(g.repoPath, l.VersionDir(name, v))
-		versionInfo, err := os.Stat(versionDir)
-
-		versionEntry := AssetVersion{Version: v}
-		if err == nil {
-			versionEntry.CreatedAt = versionInfo.ModTime()
-
-			// Count files in version directory
-			if entries, err := os.ReadDir(versionDir); err == nil {
-				fileCount := 0
-				for _, e := range entries {
-					if !e.IsDir() {
-						fileCount++
-					}
-				}
-				versionEntry.FilesCount = fileCount
-			}
-		}
-
-		versionList = append(versionList, versionEntry)
-	}
-
-	// Get metadata for latest version
-	latestVersion := versions[len(versions)-1]
-	metadataPath := filepath.Join(g.repoPath, l.MetadataPath(name, latestVersion))
-
-	details := &AssetDetails{
-		Name:     name,
-		Versions: versionList,
-	}
-
-	// Try to read metadata
-	if metaData, err := os.ReadFile(metadataPath); err == nil {
-		if meta, err := metadata.Parse(metaData); err == nil {
-			details.Type = meta.Asset.Type
-			details.Description = meta.Asset.Description
-			details.Metadata = meta
-		}
-	}
-	if details.Description == "" {
-		details.Description = markdownDescription(
-			filepath.Join(g.repoPath, l.VersionDir(name, latestVersion)))
-	}
-
-	// Get directory timestamps
-	if assetDirInfo, err := os.Stat(assetDir); err == nil {
-		details.CreatedAt = assetDirInfo.ModTime()
-		details.UpdatedAt = assetDirInfo.ModTime()
-	}
-
-	return details, nil
+	return fileVaultAssetDetails(g.repoPath, l, name)
 }
 
 // GetMCPTools returns the asset-shim registrar so callers (notably the cloud

--- a/internal/vault/manifest_download.go
+++ b/internal/vault/manifest_download.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sleuth-io/sx/v2/internal/lockfile"
@@ -33,7 +34,10 @@ func manifestAssetVersions(vaultRoot, name string) ([]string, error) {
 		}
 		versions = append(versions, asset.Version)
 	}
-	return version.Sort(versions), nil
+	// Sorted duplicates are adjacent; hand-edited manifests can carry
+	// duplicate name+version rows, which must not surface twice in
+	// GetVersionList or vault show.
+	return slices.Compact(version.Sort(versions)), nil
 }
 
 func findAssetVersionInManifest(vaultRoot, name, version string) (*lockfile.Asset, bool, error) {

--- a/internal/vault/migratev2_test.go
+++ b/internal/vault/migratev2_test.go
@@ -242,8 +242,9 @@ func TestPathVaultReadsAfterMigration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAssets: %v", err)
 	}
-	if len(list.Assets) != 2 {
-		t.Errorf("ListAssets = %d assets, want 2 (%+v)", len(list.Assets), list.Assets)
+	// chat and rules from storage, remote-only from its manifest row.
+	if len(list.Assets) != 3 {
+		t.Errorf("ListAssets = %d assets, want 3 (%+v)", len(list.Assets), list.Assets)
 	}
 }
 

--- a/internal/vault/pathrepo.go
+++ b/internal/vault/pathrepo.go
@@ -325,166 +325,24 @@ func (p *PathVault) RenameAsset(ctx context.Context, oldName, newName string) er
 	return renameAssetInManifest(p.repoPath, l, oldName, newName)
 }
 
-// ListAssets returns a list of all assets in the vault by reading the assets/ directory
+// ListAssets lists the vault's assets — stored under assets/ or declared
+// in the manifest. See listFileVaultAssets.
 func (p *PathVault) ListAssets(ctx context.Context, opts ListAssetsOptions) (*ListAssetsResult, error) {
 	l, err := detectLayout(p.repoPath)
 	if err != nil {
 		return nil, err
 	}
-
-	// Read assets/ directory
-	assetsDir := filepath.Join(p.repoPath, l.AssetsRoot())
-	entries, err := os.ReadDir(assetsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// No assets directory means no assets
-			return &ListAssetsResult{Assets: []AssetSummary{}}, nil
-		}
-		return nil, fmt.Errorf("failed to read assets directory: %w", err)
-	}
-
-	var assets []AssetSummary
-	for _, entry := range filterScanEntries(entries) {
-		if !entry.IsDir() {
-			continue
-		}
-
-		// Read list.txt for versions
-		versions, err := p.GetVersionList(ctx, entry.Name())
-		if err != nil || len(versions) == 0 {
-			continue // Skip if no versions
-		}
-
-		// Get metadata for latest version
-		latestVersion := versions[len(versions)-1]
-		metadataPath := filepath.Join(p.repoPath, l.MetadataPath(entry.Name(), latestVersion))
-
-		assetSummary := AssetSummary{
-			Name:          entry.Name(),
-			LatestVersion: latestVersion,
-			VersionsCount: len(versions),
-		}
-
-		// Try to read metadata
-		if metaData, err := os.ReadFile(metadataPath); err == nil {
-			if meta, err := metadata.Parse(metaData); err == nil {
-				assetSummary.Type = meta.Asset.Type
-				assetSummary.Description = meta.Asset.Description
-			}
-		}
-		// Get file timestamps
-		assetDirInfo, _ := entry.Info()
-		if assetDirInfo != nil {
-			assetSummary.CreatedAt = assetDirInfo.ModTime()
-			assetSummary.UpdatedAt = assetDirInfo.ModTime()
-		}
-
-		// Apply type filter if specified
-		if opts.Type != "" && assetSummary.Type.Key != opts.Type {
-			continue
-		}
-
-		// AFTER the type filter: this fallback reads files, and a
-		// filtered listing must not pay it for assets it discards.
-		if assetSummary.Description == "" {
-			// Assets published without a metadata description usually
-			// still declare one in markdown frontmatter — show it.
-			assetSummary.Description = markdownDescription(
-				filepath.Join(p.repoPath, l.VersionDir(entry.Name(), latestVersion)))
-		}
-
-		assets = append(assets, assetSummary)
-	}
-
-	if search := strings.TrimSpace(opts.Search); search != "" {
-		assets = filterBySearch(assets, search)
-	}
-
-	// Apply limit if specified
-	if opts.Limit > 0 && len(assets) > opts.Limit {
-		assets = assets[:opts.Limit]
-	}
-
-	return &ListAssetsResult{Assets: assets}, nil
+	return listFileVaultAssets(p.repoPath, l, opts)
 }
 
-// GetAssetDetails returns detailed information about a specific asset
+// GetAssetDetails returns detailed information about a specific asset —
+// stored under assets/ or declared in the manifest. See fileVaultAssetDetails.
 func (p *PathVault) GetAssetDetails(ctx context.Context, name string) (*AssetDetails, error) {
 	l, err := detectLayout(p.repoPath)
 	if err != nil {
 		return nil, err
 	}
-
-	// Check if asset directory exists
-	assetDir := filepath.Join(p.repoPath, l.AssetDir(name))
-	if _, err := os.Stat(assetDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("asset '%s' not found", name)
-	}
-
-	// Get version list
-	versions, err := p.GetVersionList(ctx, name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get version list: %w", err)
-	}
-
-	if len(versions) == 0 {
-		return nil, fmt.Errorf("asset '%s' has no versions", name)
-	}
-
-	// Build version list with file info
-	var versionList []AssetVersion
-	for _, v := range versions {
-		versionDir := filepath.Join(p.repoPath, l.VersionDir(name, v))
-		versionInfo, err := os.Stat(versionDir)
-
-		versionEntry := AssetVersion{Version: v}
-		if err == nil {
-			versionEntry.CreatedAt = versionInfo.ModTime()
-
-			// Count files in version directory
-			if entries, err := os.ReadDir(versionDir); err == nil {
-				fileCount := 0
-				for _, e := range entries {
-					if !e.IsDir() && !utils.IsSyncArtifact(e.Name()) {
-						fileCount++
-					}
-				}
-				versionEntry.FilesCount = fileCount
-			}
-		}
-
-		versionList = append(versionList, versionEntry)
-	}
-
-	// Get metadata for latest version
-	latestVersion := versions[len(versions)-1]
-	metadataPath := filepath.Join(p.repoPath, l.MetadataPath(name, latestVersion))
-
-	details := &AssetDetails{
-		Name:     name,
-		Versions: versionList,
-	}
-
-	// Try to read metadata
-	if metaData, err := os.ReadFile(metadataPath); err == nil {
-		if meta, err := metadata.Parse(metaData); err == nil {
-			details.Type = meta.Asset.Type
-			details.Description = meta.Asset.Description
-			details.Metadata = meta
-		}
-	}
-	if details.Description == "" {
-		details.Description = markdownDescription(
-			filepath.Join(p.repoPath, l.VersionDir(name, latestVersion)))
-	}
-
-	// Get directory timestamps
-	if assetDirInfo, err := os.Stat(assetDir); err == nil {
-		details.CreatedAt = assetDirInfo.ModTime()
-		details.UpdatedAt = assetDirInfo.ModTime()
-	}
-
-	return details, nil
+	return fileVaultAssetDetails(p.repoPath, l, name)
 }
 
 // GetMCPTools returns the asset-shim registrar so callers (notably the cloud

--- a/internal/vault/pathrepo_test.go
+++ b/internal/vault/pathrepo_test.go
@@ -57,9 +57,10 @@ func TestListAssetsSkipsSyncArtifacts(t *testing.T) {
 	for _, a := range list.Assets {
 		names = append(names, a.Name)
 	}
-	want := map[string]bool{"chat": true, "rules": true, "report (1)": true}
+	// remote-only has no stored files; it is listed from its manifest row.
+	want := map[string]bool{"chat": true, "rules": true, "report (1)": true, "remote-only": true}
 	if len(names) != len(want) {
-		t.Fatalf("ListAssets = %v, want exactly chat, rules, report (1)", names)
+		t.Fatalf("ListAssets = %v, want exactly chat, rules, report (1), remote-only", names)
 	}
 	for _, n := range names {
 		if !want[n] {

--- a/internal/vault/storage.go
+++ b/internal/vault/storage.go
@@ -149,6 +149,15 @@ func deleteAssetStorage(vaultRoot string, l layout.Layout, name, ver string) err
 func renameAssetStorage(vaultRoot string, l layout.Layout, oldName, newName string) error {
 	oldDir := filepath.Join(vaultRoot, l.AssetDir(oldName))
 	newDir := filepath.Join(vaultRoot, l.AssetDir(newName))
+	if _, err := os.Stat(oldDir); os.IsNotExist(err) {
+		// Manifest-declared assets with no stored files (install-in-place
+		// source-path rows) are visible in listings but have nothing under
+		// assets/ to rename; fail clearly instead of with a raw fs error.
+		if _, ok := findAssetInManifest(vaultRoot, oldName); ok {
+			return fmt.Errorf("asset '%s' has no stored files in this vault; rename its manifest entry in sx.toml instead", oldName)
+		}
+		return fmt.Errorf("asset '%s' not found", oldName)
+	}
 	if _, err := os.Stat(newDir); err == nil {
 		return fmt.Errorf("target asset directory already exists: %s", newName)
 	}

--- a/internal/vault/storage.go
+++ b/internal/vault/storage.go
@@ -195,12 +195,21 @@ func versionListForAsset(vaultRoot string, l layout.Layout, name string) ([]stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to read version list: %w", err)
 	}
-	if copies, err := utils.FindConflictCopies(listPath); err == nil && len(copies) > 0 {
-		fmt.Fprintf(os.Stderr, "Warning: ignoring sync-conflicted copy %q for asset %s; using list.txt. Delete it once the folder has synced.\n", copies[0], name)
-	}
+	warnVersionListConflicts(listPath, name)
 	// Callers take the last element as "latest": keep every derivation
 	// semver-sorted regardless of the order versions were appended.
 	return version.Sort(parseVersionList(data)), nil
+}
+
+// warnVersionListConflicts prints the documented synced-folder warning when
+// a conflicted copy of list.txt sits next to the real one (see
+// docs/synced-folders.md): the copy is ignored and the user should delete
+// it once the folder has synced. Every reader that surfaces a version list
+// to the user must call this so the conflict stays visible.
+func warnVersionListConflicts(listPath, name string) {
+	if copies, err := utils.FindConflictCopies(listPath); err == nil && len(copies) > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: ignoring sync-conflicted copy %q for asset %s; using list.txt. Delete it once the folder has synced.\n", copies[0], name)
+	}
 }
 
 // readVersionListFile reads and semver-sorts a list.txt. Returns the


### PR DESCRIPTION
## Summary

Fixes #228: for a `source-path` git vault (schema_version 2 `sx.toml` whose `[[assets]]` rows point at files outside `assets/`), `sx vault list` printed an empty listing and `sx vault show <name>` reported "asset not found" — while `sx install` resolved every asset. Install is manifest-driven; list/show only scanned the `assets/` directory.

The fix extracts the duplicated GitVault/PathVault `ListAssets`/`GetAssetDetails` implementations into one shared, manifest-aware implementation (`internal/vault/asset_listing.go`):

- The `assets/` directory scan (published layout, v1/v2) works exactly as before and takes precedence.
- Manifest `[[assets]]` rows are merged in: per-name versions are the **union** of stored `list.txt` entries and manifest rows (deduplicated), so listing matches install resolution even for hand-edited manifests. Type comes from source `metadata.toml` or the manifest row; description from `metadata.toml`, then markdown frontmatter.
- `http`/`git`-sourced rows with no stored files (previously also invisible) now list from their manifest data.
- `GetAssetDetails` treats an asset as found if it has a stored directory **or** manifest-discoverable versions; per-version file counts and timestamps fall back to the source-path directory.
- Discovery is read-only over possibly third-party vaults, so unlike install it refuses to follow source paths outside the vault root (absolute, `~`, or `../` escapes) — those degrade to manifest-only data.
- The merged listing is name-sorted; search/limit behavior unchanged.

Verified against the issue's exact repro (bare git remote, `sx init --type git`, `sx vault list` / `sx vault show`) — both now show the assets install resolves.

## Testing

- [x] `make prepush`

New tests: PathVault list/show/type-filter over a hand-authored source-path vault, manifest-type + frontmatter-description fallbacks, duplicate-row dedup agreement between list/show/GetVersionList, newer manifest-only version of a stored asset, vault-root escape protection, clear rename error, and a bare-remote GitVault end-to-end test mirroring the #228 repro. Updated two existing tests whose expected counts now include the previously-invisible `remote-only` (source-http) fixture asset.

## Notes

- All findings from the PR review are addressed in the third commit: version dedup unified in `manifestAssetVersions`, per-version (not per-name) manifest merge, typeless-row type resolution before the `--type` filter, vault-root containment for discovery reads, and `sx vault rename` of a manifest-only asset now fails with a clear "no stored files; rename its manifest entry in sx.toml instead" error.
- Behavior notes: GitVault `FilesCount` now filters sync artifacts like PathVault always did, and `ListAssets` no longer re-runs `cloneOrUpdate` per asset directory (once per call instead).
- Relevant to #217 (selective install): consumer-side enumeration can now build on this same manifest-driven listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeo2Skm5xEQ14qmSxJ2zcz