### PR TITLE
SK-762: Fix uninstall confirm rejecting typed 'y'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/charmbracelet/colorprofile v0.4.3
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/coder/websocket v1.8.15
 	github.com/creativeprojects/go-selfupdate v1.6.0
 	github.com/gofrs/flock v0.13.0
@@ -82,7 +83,6 @@ require (
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be // indirect
-	github.com/charmbracelet/x/ansi v0.11.8 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/internal/commands/confirm_input_test.go
+++ b/internal/commands/confirm_input_test.go
@@ -33,6 +33,8 @@ func TestConfirmUninstall(t *testing.T) {
 		{"yes with stray terminal responses", strayTerminalResponses + "y\n", true},
 		{"no with stray terminal responses", strayTerminalResponses + "n\n", false},
 		{"only stray responses defaults to no", strayTerminalResponses + "\n", false},
+		{"yes with bare control residue from torn reply", "\x07y\n", true},
+		{"yes without trailing newline", "y", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/commands/confirm_input_test.go
+++ b/internal/commands/confirm_input_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -63,6 +64,55 @@ func TestConfirmSelfUninstall(t *testing.T) {
 			got := confirmSelfUninstall(discardOutput(), strings.NewReader(tt.input))
 			if got != tt.want {
 				t.Errorf("confirmSelfUninstall(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// setupUninstallSandbox isolates HOME/config/cache so the uninstall command
+// finds no config, which with --all routes through handleAllFlagWithoutAssets
+// and its confirmation prompt.
+func setupUninstallSandbox(t *testing.T) {
+	t.Helper()
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(homeDir, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(homeDir, ".cache"))
+	t.Setenv("SX_CONFIG_DIR", filepath.Join(homeDir, ".config", "sx"))
+	t.Setenv("SX_CACHE_DIR", filepath.Join(homeDir, ".cache", "sx"))
+}
+
+// TestUninstallCommandReadsConfirmationFromCommandInput pins the cobra
+// wiring: the confirmation must read from cmd.SetIn (not os.Stdin) and
+// tolerate stray terminal replies before the typed answer.
+func TestUninstallCommandReadsConfirmationFromCommandInput(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantCancelled bool
+	}{
+		{"stray responses then yes proceeds", strayTerminalResponses + "y\n", false},
+		{"stray responses then no cancels", strayTerminalResponses + "n\n", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupUninstallSandbox(t)
+
+			cmd := NewUninstallCommand()
+			var out, errOut bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&errOut)
+			cmd.SetIn(strings.NewReader(tt.input))
+			cmd.SetArgs([]string{"--all"})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute returned error: %v\nstdout: %s\nstderr: %s", err, out.String(), errOut.String())
+			}
+
+			cancelled := strings.Contains(out.String(), "Uninstall cancelled")
+			if cancelled != tt.wantCancelled {
+				t.Errorf("cancelled = %v, want %v\nstdout: %s", cancelled, tt.wantCancelled, out.String())
 			}
 		})
 	}

--- a/internal/commands/confirm_input_test.go
+++ b/internal/commands/confirm_input_test.go
@@ -66,6 +66,21 @@ func TestConfirmSelfUninstall(t *testing.T) {
 	}
 }
 
+func TestStdPrompterSequentialPromptsShareBufferedInput(t *testing.T) {
+	p := NewStdPrompter(strings.NewReader("Alice\ny\n"), &bytes.Buffer{})
+	name, err := p.Prompt("Name? ")
+	if err != nil || name != "Alice" {
+		t.Fatalf("first Prompt = %q, %v; want \"Alice\", nil", name, err)
+	}
+	ok, err := p.Confirm("Proceed?")
+	if err != nil {
+		t.Fatalf("Confirm returned error: %v", err)
+	}
+	if !ok {
+		t.Errorf("Confirm after Prompt = false, want true (second line lost to a discarded buffer)")
+	}
+}
+
 func TestStdPrompterConfirmWithStrayTerminalResponses(t *testing.T) {
 	p := NewStdPrompter(strings.NewReader(strayTerminalResponses+"y\n"), &bytes.Buffer{})
 	got, err := p.Confirm("Proceed?")

--- a/internal/commands/confirm_input_test.go
+++ b/internal/commands/confirm_input_test.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sleuth-io/sx/v2/internal/ui"
+)
+
+// Terminal responses to the OSC 11 (background color) and DA1 (device
+// attributes) queries that lipgloss sends when resolving theme colors. When
+// the terminal answers after lipgloss's query timeout, these bytes are left
+// unread in the tty input queue and get prepended to the user's typed
+// response. Captured from a real reproduction of SK-762.
+const strayTerminalResponses = "\x1b]11;rgb:1e1e/1e1e/1e1e\x1b\\\x1b[?65;4;6;18;22c" +
+	"\x1b]11;rgb:1e1e/1e1e/1e1e\x1b\\\x1b[?65;4;6;18;22c"
+
+func discardOutput() *ui.Output {
+	return ui.NewOutput(&bytes.Buffer{}, &bytes.Buffer{})
+}
+
+func TestConfirmUninstall(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"plain yes", "y\n", true},
+		{"plain yes word", "yes\n", true},
+		{"plain no", "n\n", false},
+		{"empty defaults to no", "\n", false},
+		{"yes with stray terminal responses", strayTerminalResponses + "y\n", true},
+		{"no with stray terminal responses", strayTerminalResponses + "n\n", false},
+		{"only stray responses defaults to no", strayTerminalResponses + "\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := confirmUninstall(discardOutput(), strings.NewReader(tt.input))
+			if got != tt.want {
+				t.Errorf("confirmUninstall(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfirmSelfUninstall(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"plain yes", "y\n", true},
+		{"yes with stray terminal responses", strayTerminalResponses + "y\n", true},
+		{"only stray responses defaults to no", strayTerminalResponses + "\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := confirmSelfUninstall(discardOutput(), strings.NewReader(tt.input))
+			if got != tt.want {
+				t.Errorf("confirmSelfUninstall(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStdPrompterConfirmWithStrayTerminalResponses(t *testing.T) {
+	p := NewStdPrompter(strings.NewReader(strayTerminalResponses+"y\n"), &bytes.Buffer{})
+	got, err := p.Confirm("Proceed?")
+	if err != nil {
+		t.Fatalf("Confirm returned error: %v", err)
+	}
+	if !got {
+		t.Errorf("Confirm with stray terminal responses before 'y' = false, want true")
+	}
+}

--- a/internal/commands/confirm_input_test.go
+++ b/internal/commands/confirm_input_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -36,6 +37,11 @@ func TestConfirmUninstall(t *testing.T) {
 		{"only stray responses defaults to no", strayTerminalResponses + "\n", false},
 		{"yes with bare control residue from torn reply", "\x07y\n", true},
 		{"yes without trailing newline", "y", true},
+		// A bare 8-bit OSC introducer (\x9d) is not tested as recoverable:
+		// ansi.Strip correctly parses everything after it as escape-sequence
+		// payload, so the answer is formally ambiguous and the prompt fails
+		// closed to No — the safe default for a destructive operation.
+		{"8-bit C1 introducer swallows the line, defaults to no", "\x9dy\n", false},
 	}
 
 	for _, tt := range tests {
@@ -66,6 +72,42 @@ func TestConfirmSelfUninstall(t *testing.T) {
 				t.Errorf("confirmSelfUninstall(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// errAfterReader yields its data, then fails with a non-EOF error.
+type errAfterReader struct {
+	data string
+	done bool
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, errors.New("tty read failed")
+	}
+	r.done = true
+	return copy(p, r.data), errors.New("tty read failed")
+}
+
+// TestConfirmUninstallFailsClosedOnReadError: a partial answer followed by a
+// real read error (not EOF) must not confirm a destructive operation.
+func TestConfirmUninstallFailsClosedOnReadError(t *testing.T) {
+	if confirmUninstall(discardOutput(), &errAfterReader{data: "y"}) {
+		t.Error("confirmUninstall = true on partial read with non-EOF error, want false (fail closed)")
+	}
+}
+
+// TestStdPrompterPromptPreservesNonUTF8Bytes: free-text prompt responses
+// must round-trip verbatim (minus escape sequences), not be rewritten to
+// U+FFFD replacement runes.
+func TestStdPrompterPromptPreservesNonUTF8Bytes(t *testing.T) {
+	p := NewStdPrompter(strings.NewReader("caf\xe9\n"), &bytes.Buffer{})
+	got, err := p.Prompt("Name? ")
+	if err != nil {
+		t.Fatalf("Prompt returned error: %v", err)
+	}
+	if got != "caf\xe9" {
+		t.Errorf("Prompt = %q, want %q (latin-1 byte mangled)", got, "caf\xe9")
 	}
 }
 

--- a/internal/commands/prompter.go
+++ b/internal/commands/prompter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/charmbracelet/x/ansi"
 
@@ -40,17 +41,28 @@ func NewStdPrompter(in io.Reader, out io.Writer) *StdPrompter {
 // readPromptLine reads one line of user input. Terminal replies to queries
 // (OSC 11 background color, DA1) that arrive after lipgloss's query timeout
 // are left unread in the tty input queue and end up prepended to the typed
-// line, so strip escape sequences before interpreting it (SK-762).
+// line, so strip escape sequences before interpreting it (SK-762). Bare
+// control bytes (e.g. a BEL terminator severed from its sequence when the
+// query timeout tears a reply in two) survive ansi.Strip, so drop those too.
 func readPromptLine(in io.Reader) (string, error) {
 	reader, ok := in.(*bufio.Reader)
 	if !ok {
 		reader = bufio.NewReader(in)
 	}
 	response, err := reader.ReadString('\n')
-	if err != nil {
+	// EOF with a partial line still carries the user's answer (e.g.
+	// `printf 'y' | sx uninstall`); only fail when nothing was read.
+	if err != nil && response == "" {
 		return "", err
 	}
-	return strings.TrimSpace(ansi.Strip(response)), nil
+	response = ansi.Strip(response)
+	response = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, response)
+	return strings.TrimSpace(response), nil
 }
 
 // Prompt displays a prompt and reads user input

--- a/internal/commands/prompter.go
+++ b/internal/commands/prompter.go
@@ -30,7 +30,9 @@ type StdPrompter struct {
 // NewStdPrompter creates a new standard I/O prompter
 func NewStdPrompter(in io.Reader, out io.Writer) *StdPrompter {
 	return &StdPrompter{
-		in:  in,
+		// Wrap once so buffered lookahead survives across sequential
+		// prompts instead of being discarded with a per-call reader.
+		in:  bufio.NewReader(in),
 		out: out,
 	}
 }

--- a/internal/commands/prompter.go
+++ b/internal/commands/prompter.go
@@ -2,10 +2,10 @@ package commands
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
-	"unicode"
 
 	"github.com/charmbracelet/x/ansi"
 
@@ -51,18 +51,27 @@ func readPromptLine(in io.Reader) (string, error) {
 	}
 	response, err := reader.ReadString('\n')
 	// EOF with a partial line still carries the user's answer (e.g.
-	// `printf 'y' | sx uninstall`); only fail when nothing was read.
-	if err != nil && response == "" {
+	// `printf 'y' | sx uninstall`); any other error fails closed even if
+	// bytes were read — a torn tty read must not confirm anything.
+	if err != nil && (!errors.Is(err, io.EOF) || response == "") {
 		return "", err
 	}
-	response = ansi.Strip(response)
-	response = strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return -1
+	return strings.TrimSpace(ansi.Strip(response)), nil
+}
+
+// confirmAnswer reduces a prompt line to the ASCII answer a y/N prompt
+// expects. Escape-sequence residue that ansi.Strip cannot attribute (bare
+// C0 terminators, 8-bit C1 introducers from torn terminal replies) is not
+// valid UTF-8 text, so anything outside printable ASCII is dropped. Only
+// for yes/no answers — free-text responses must round-trip verbatim.
+func confirmAnswer(line string) string {
+	var b strings.Builder
+	for i := range len(line) {
+		if line[i] >= 0x20 && line[i] <= 0x7e {
+			b.WriteByte(line[i])
 		}
-		return r
-	}, response)
-	return strings.TrimSpace(response), nil
+	}
+	return strings.ToLower(strings.TrimSpace(b.String()))
 }
 
 // Prompt displays a prompt and reads user input
@@ -91,6 +100,6 @@ func (p *StdPrompter) Confirm(message string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	response = strings.ToLower(response)
+	response = confirmAnswer(response)
 	return response == "" || response == "y" || response == "yes", nil
 }

--- a/internal/commands/prompter.go
+++ b/internal/commands/prompter.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/sleuth-io/sx/v2/internal/ui/theme"
 )
 
@@ -33,15 +35,26 @@ func NewStdPrompter(in io.Reader, out io.Writer) *StdPrompter {
 	}
 }
 
-// Prompt displays a prompt and reads user input
-func (p *StdPrompter) Prompt(message string) (string, error) {
-	fmt.Fprint(p.out, message)
-	reader := bufio.NewReader(p.in)
+// readPromptLine reads one line of user input. Terminal replies to queries
+// (OSC 11 background color, DA1) that arrive after lipgloss's query timeout
+// are left unread in the tty input queue and end up prepended to the typed
+// line, so strip escape sequences before interpreting it (SK-762).
+func readPromptLine(in io.Reader) (string, error) {
+	reader, ok := in.(*bufio.Reader)
+	if !ok {
+		reader = bufio.NewReader(in)
+	}
 	response, err := reader.ReadString('\n')
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(response), nil
+	return strings.TrimSpace(ansi.Strip(response)), nil
+}
+
+// Prompt displays a prompt and reads user input
+func (p *StdPrompter) Prompt(message string) (string, error) {
+	fmt.Fprint(p.out, message)
+	return readPromptLine(p.in)
 }
 
 // PromptWithDefault displays a prompt with a default value

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"runtime"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -284,6 +283,6 @@ func confirmSelfUninstall(styledOut *ui.Output, in io.Reader) bool {
 	if err != nil {
 		return false
 	}
-	response = strings.ToLower(response)
+	response = confirmAnswer(response)
 	return response == "y" || response == "yes"
 }

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -121,6 +122,8 @@ func resolveSelfUninstallPaths() selfUninstallPaths {
 
 func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	// One buffered reader for every prompt in this run (see runUninstall).
+	stdin := bufio.NewReader(cmd.InOrStdin())
 
 	// --force only matters during asset cleanup; with --keep-assets that step
 	// is skipped entirely, so the combination is a silent no-op. Reject it
@@ -160,7 +163,7 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 
 	// Confirm.
 	if !opts.Yes && !opts.skipConfirm {
-		if !confirmSelfUninstall(styledOut, cmd.InOrStdin()) {
+		if !confirmSelfUninstall(styledOut, stdin) {
 			styledOut.Muted("Cancelled. Nothing was removed.")
 			return nil
 		}

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -160,7 +160,7 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 
 	// Confirm.
 	if !opts.Yes && !opts.skipConfirm {
-		if !confirmSelfUninstall(styledOut, os.Stdin) {
+		if !confirmSelfUninstall(styledOut, cmd.InOrStdin()) {
 			styledOut.Muted("Cancelled. Nothing was removed.")
 			return nil
 		}

--- a/internal/commands/self_uninstall.go
+++ b/internal/commands/self_uninstall.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -160,7 +160,7 @@ func runSelfUninstall(cmd *cobra.Command, opts SelfUninstallOptions) error {
 
 	// Confirm.
 	if !opts.Yes && !opts.skipConfirm {
-		if !confirmSelfUninstall(styledOut) {
+		if !confirmSelfUninstall(styledOut, os.Stdin) {
 			styledOut.Muted("Cancelled. Nothing was removed.")
 			return nil
 		}
@@ -274,14 +274,13 @@ func displayPath(path string, err error) string {
 }
 
 // confirmSelfUninstall prompts the user; default is No.
-func confirmSelfUninstall(styledOut *ui.Output) bool {
-	reader := bufio.NewReader(os.Stdin)
+func confirmSelfUninstall(styledOut *ui.Output, in io.Reader) bool {
 	styledOut.Printf("Continue with self-uninstall? [y/N]: ")
 
-	response, err := reader.ReadString('\n')
+	response, err := readPromptLine(in)
 	if err != nil {
 		return false
 	}
-	response = strings.ToLower(strings.TrimSpace(response))
+	response = strings.ToLower(response)
 	return response == "y" || response == "yes"
 }

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -721,7 +721,7 @@ func confirmUninstall(styledOut *ui.Output, in io.Reader) bool {
 		return false
 	}
 
-	response = strings.ToLower(response)
+	response = confirmAnswer(response)
 	return response == "y" || response == "yes"
 }
 

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -142,6 +143,9 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 
 	out := newOutputHelper(cmd)
 	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	// One buffered reader for every prompt in this run, from cobra's input
+	// so tests can drive confirmation via cmd.SetIn.
+	stdin := bufio.NewReader(cmd.InOrStdin())
 
 	// Step 1: Load lock file
 	lockFile, err := loadLockFileForUninstall(ctx, out)
@@ -149,7 +153,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 		// If --all is passed, we should still remove system hooks even if lock file fails
 		if opts.All {
 			styledOut.Warning(fmt.Sprintf("Warning: %v", err))
-			return handleAllFlagWithoutAssets(ctx, opts, styledOut)
+			return handleAllFlagWithoutAssets(ctx, opts, styledOut, stdin)
 		}
 		return err
 	}
@@ -160,7 +164,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 		// If --all is passed, we should still remove system hooks even if tracker fails
 		if opts.All {
 			styledOut.Warning(fmt.Sprintf("Warning: %v", err))
-			return handleAllFlagWithoutAssets(ctx, opts, styledOut)
+			return handleAllFlagWithoutAssets(ctx, opts, styledOut, stdin)
 		}
 		return err
 	}
@@ -168,7 +172,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 	if len(tracker.Assets) == 0 {
 		// No assets, but if --all is passed, still remove system hooks
 		if opts.All {
-			return handleAllFlagWithoutAssets(ctx, opts, styledOut)
+			return handleAllFlagWithoutAssets(ctx, opts, styledOut, stdin)
 		}
 		styledOut.Info("No assets installed")
 		return nil
@@ -192,7 +196,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 	if len(plan.Assets) == 0 {
 		// No assets to uninstall, but if --all is passed, still remove system hooks
 		if opts.All {
-			return handleAllFlagWithoutAssets(ctx, opts, styledOut)
+			return handleAllFlagWithoutAssets(ctx, opts, styledOut, stdin)
 		}
 		if !gitContext.IsRepo {
 			styledOut.Info("Not in a repository. Use --all to uninstall from all scopes.")
@@ -219,7 +223,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 	}
 
 	if !opts.Yes && !opts.DryRun {
-		if !confirmUninstall(styledOut, os.Stdin) {
+		if !confirmUninstall(styledOut, stdin) {
 			styledOut.Muted("Uninstall cancelled")
 			return nil
 		}
@@ -256,12 +260,12 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 }
 
 // handleAllFlagWithoutAssets handles the --all flag when there are no assets to uninstall
-func handleAllFlagWithoutAssets(ctx context.Context, opts UninstallOptions, styledOut *ui.Output) error {
+func handleAllFlagWithoutAssets(ctx context.Context, opts UninstallOptions, styledOut *ui.Output, stdin io.Reader) error {
 	styledOut.Info("No assets to uninstall")
 
 	if !opts.Yes && !opts.DryRun {
 		styledOut.Info("System hooks will be removed (--all flag)")
-		if !confirmUninstall(styledOut, os.Stdin) {
+		if !confirmUninstall(styledOut, stdin) {
 			styledOut.Muted("Uninstall cancelled")
 			return nil
 		}

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -219,7 +219,7 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 	}
 
 	if !opts.Yes && !opts.DryRun {
-		if !confirmUninstall(styledOut) {
+		if !confirmUninstall(styledOut, os.Stdin) {
 			styledOut.Muted("Uninstall cancelled")
 			return nil
 		}
@@ -261,7 +261,7 @@ func handleAllFlagWithoutAssets(ctx context.Context, opts UninstallOptions, styl
 
 	if !opts.Yes && !opts.DryRun {
 		styledOut.Info("System hooks will be removed (--all flag)")
-		if !confirmUninstall(styledOut) {
+		if !confirmUninstall(styledOut, os.Stdin) {
 			styledOut.Muted("Uninstall cancelled")
 			return nil
 		}
@@ -706,16 +706,15 @@ func displayUninstallPlan(plan UninstallPlan, styledOut *ui.Output) {
 }
 
 // confirmUninstall prompts user for confirmation
-func confirmUninstall(styledOut *ui.Output) bool {
-	reader := bufio.NewReader(os.Stdin)
+func confirmUninstall(styledOut *ui.Output, in io.Reader) bool {
 	styledOut.Printf("Continue with uninstall? [y/N]: ")
 
-	response, err := reader.ReadString('\n')
+	response, err := readPromptLine(in)
 	if err != nil {
 		return false
 	}
 
-	response = strings.ToLower(strings.TrimSpace(response))
+	response = strings.ToLower(response)
 	return response == "y" || response == "yes"
 }
 

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -144,7 +144,10 @@ func runUninstall(cmd *cobra.Command, args []string, opts UninstallOptions) erro
 	out := newOutputHelper(cmd)
 	styledOut := ui.NewOutput(cmd.OutOrStdout(), cmd.ErrOrStderr())
 	// One buffered reader for every prompt in this run, from cobra's input
-	// so tests can drive confirmation via cmd.SetIn.
+	// so tests can drive confirmation via cmd.SetIn. out.prompter wraps the
+	// same input separately but is never used on this path — route any new
+	// prompt through this reader, not the prompter, or lookahead can be
+	// split between the two buffers.
 	stdin := bufio.NewReader(cmd.InOrStdin())
 
 	// Step 1: Load lock file

--- a/internal/ui/components/confirm.go
+++ b/internal/ui/components/confirm.go
@@ -147,7 +147,14 @@ func Confirm(message string, defaultYes bool) (bool, error) {
 
 // ConfirmWithIO displays an interactive confirmation prompt using custom IO.
 func ConfirmWithIO(message string, defaultYes bool, in io.Reader, out io.Writer) (bool, error) {
-	// Fall back to simple prompt for non-TTY
+	// Fall back to simple prompt for non-TTY.
+	//
+	// The raw ReadString in confirmSimple (and the equivalent fallbacks in
+	// input.go, select.go, multiselect.go) is only safe because this non-TTY
+	// guard matches the one in theme.detect(): terminal queries (OSC 11/DA1)
+	// are never issued without a TTY on both ends, so no stray replies can
+	// pollute stdin here. If either guard is relaxed, these readers need the
+	// escape-stripping treatment from SK-762 (see commands.readPromptLine).
 	if !ui.IsStdoutTTY() || !ui.IsStdinTTY() {
 		return confirmSimple(message, defaultYes, in, out)
 	}

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -50,6 +50,13 @@ func detect() {
 		if profile >= colorprofile.ANSI &&
 			isTTY(os.Stdin) && isTTY(os.Stdout) &&
 			isForeground() {
+			// TODO(SK-762): replies arriving after this query's timeout are
+			// left in the tty input queue. commands.readPromptLine strips
+			// whole sequences and control bytes from later reads, but a reply
+			// torn mid-sequence by the timeout leaves printable residue no
+			// read-site filter can distinguish from typed input. Draining
+			// here races with reply arrival, so the residual case is
+			// accepted until lipgloss offers a synchronous drain.
 			darkBG = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 		}
 	})


### PR DESCRIPTION
## Summary
- `sx uninstall` (and `sx self-uninstall`) could reject a typed `y` and print "Uninstall cancelled": when the terminal answers lipgloss's OSC 11/DA1 background-color queries after the 2s query timeout, the unread reply bytes sit in the tty input queue and get prepended to the user's typed line (`"\x1b]11;rgb:...cy\n"` instead of `"y\n"`), so the y/N comparison fails
- Reproduced deterministically with a PTY harness emulating a slow-responding terminal
- Fix: route the raw stdin prompts (`confirmUninstall`, `confirmSelfUninstall`, `StdPrompter.Prompt`) through a shared `readPromptLine` helper that strips ANSI escape sequences from the line before interpreting it
- Regression tests cover clean input, escape-polluted input (exact captured bytes), and the No-default

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)