### PR TITLE
SK-763: Stop status spinner leaking terminal queries

### DIFF
--- a/internal/ui/components/spinner.go
+++ b/internal/ui/components/spinner.go
@@ -1,92 +1,21 @@
 package components
 
 import (
-	"errors"
-	"fmt"
 	"io"
 	"os"
-	"time"
-
-	"charm.land/bubbles/v2/spinner"
-	tea "charm.land/bubbletea/v2"
-
-	"github.com/sleuth-io/sx/v2/internal/ui"
-	"github.com/sleuth-io/sx/v2/internal/ui/theme"
 )
 
-// spinnerDoneMsg signals that the spinner task is complete.
-type spinnerDoneMsg struct {
-	err error
-}
-
-// spinnerModel is the bubbletea model for the spinner component.
-type spinnerModel struct {
-	spinner spinner.Model
-	message string
-	done    bool
-	err     error
-	styles  theme.Styles
-}
-
-func newSpinnerModel(message string) spinnerModel {
-	th := theme.Current()
-
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = th.Styles().Spinner
-
-	return spinnerModel{
-		spinner: s,
-		message: message,
-		// Resolve styles now: the first resolution may query the terminal,
-		// which must happen before bubbletea takes it over.
-		styles: th.Styles(),
-	}
-}
-
-func (m spinnerModel) Init() tea.Cmd {
-	return m.spinner.Tick
-}
-
-func (m spinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case spinnerDoneMsg:
-		m.done = true
-		m.err = msg.err
-		return m, tea.Quit
-
-	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
-			m.done = true
-			m.err = errors.New("cancelled")
-			return m, tea.Quit
-		}
-
-	case spinner.TickMsg:
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(msg)
-		return m, cmd
-	}
-
-	return m, nil
-}
-
-func (m spinnerModel) View() tea.View {
-	if m.done {
-		return tea.NewView("")
-	}
-
-	return tea.NewView(m.spinner.View() + " " + m.styles.Muted.Render(m.message))
-}
-
-// Spinner displays a spinner with a message.
-// The spinner runs until Stop() is called on the returned Spinner.
+// Spinner displays an animated spinner with a message until stopped.
+//
+// Built on Status (plain in-place ANSI) rather than a bubbletea program:
+// bubbletea queries terminal capabilities at startup, and a short-lived
+// spinner exits before the terminal replies, leaking the reply bytes to the
+// user's terminal (SK-763). Delegating also removes the old implementation's
+// unsynchronized result read when the program quit while the wrapped
+// function was still running.
 type Spinner struct {
-	program *tea.Program
-	model   spinnerModel
-	out     io.Writer
-	noTTY   bool
+	status  *Status
+	message string
 }
 
 // NewSpinner creates a new spinner with the given message.
@@ -96,50 +25,32 @@ func NewSpinner(message string) *Spinner {
 
 // NewSpinnerWithOutput creates a new spinner with custom output.
 func NewSpinnerWithOutput(message string, out io.Writer) *Spinner {
-	noTTY := !ui.IsTTY(out)
-
 	return &Spinner{
-		model: newSpinnerModel(message),
-		out:   out,
-		noTTY: noTTY,
+		status:  NewStatus(out),
+		message: message,
 	}
 }
 
 // Start begins the spinner animation.
 func (s *Spinner) Start() {
-	if s.noTTY {
-		fmt.Fprintf(s.out, "%s...\n", s.model.message)
-		return
-	}
-
-	s.program = tea.NewProgram(s.model, tea.WithOutput(s.out))
-	go func() {
-		_, _ = s.program.Run()
-	}()
-
-	// Give the program time to start
-	time.Sleep(10 * time.Millisecond)
+	s.status.Start(s.message)
 }
 
-// Stop stops the spinner and optionally shows a result message.
+// Stop stops the spinner and clears the line.
 func (s *Spinner) Stop() {
-	if s.noTTY || s.program == nil {
-		return
-	}
-
-	s.program.Send(spinnerDoneMsg{})
-	// Give the program time to quit
-	time.Sleep(10 * time.Millisecond)
+	s.status.Clear()
 }
 
-// StopWithError stops the spinner and records an error.
-func (s *Spinner) StopWithError(err error) {
-	if s.noTTY || s.program == nil {
-		return
-	}
+// StopWithError stops the spinner and clears the line. The error is the
+// caller's to report; the spinner line itself carries no final message.
+func (s *Spinner) StopWithError(_ error) {
+	s.status.Fail("")
+}
 
-	s.program.Send(spinnerDoneMsg{err: err})
-	time.Sleep(10 * time.Millisecond)
+// UpdateMessage updates the spinner message (for long-running operations).
+func (s *Spinner) UpdateMessage(message string) {
+	s.message = message
+	s.status.Update(message)
 }
 
 // RunWithSpinner runs a function while showing a spinner.
@@ -148,44 +59,18 @@ func RunWithSpinner[T any](message string, fn func() (T, error)) (T, error) {
 	return RunWithSpinnerOutput(message, os.Stdout, fn)
 }
 
-// RunWithSpinnerOutput runs a function while showing a spinner on custom output.
-func RunWithSpinnerOutput[T any](message string, out io.Writer, fn func() (T, error)) (T, error) {
-	var result T
-	var fnErr error
-
-	// For non-TTY, just run the function
-	if !ui.IsTTY(out) {
-		fmt.Fprintf(out, "%s...\n", message)
-		return fn()
-	}
-
-	m := newSpinnerModel(message)
-	p := tea.NewProgram(m, tea.WithOutput(out))
-
-	// Run the function in a goroutine
-	go func() {
-		result, fnErr = fn()
-		p.Send(spinnerDoneMsg{err: fnErr})
+// RunWithSpinnerOutput runs a function while showing a spinner on custom
+// output. The spinner is torn down even if fn panics.
+func RunWithSpinnerOutput[T any](message string, out io.Writer, fn func() (T, error)) (result T, err error) {
+	s := NewStatus(out)
+	s.Start(message)
+	defer func() {
+		if err != nil {
+			s.Fail("")
+		} else {
+			s.Done("")
+		}
 	}()
-
-	// Run the spinner until done
-	if _, err := p.Run(); err != nil {
-		return result, fmt.Errorf("spinner failed: %w", err)
-	}
-
-	return result, fnErr
-}
-
-// SpinnerMessage updates the spinner message (for long-running operations).
-type spinnerMsgUpdate struct {
-	message string
-}
-
-// UpdateMessage sends a message update to the spinner.
-func (s *Spinner) UpdateMessage(message string) {
-	if s.noTTY || s.program == nil {
-		fmt.Fprintf(s.out, "%s...\n", message)
-		return
-	}
-	s.program.Send(spinnerMsgUpdate{message: message})
+	result, err = fn()
+	return result, err
 }

--- a/internal/ui/components/spinner_test.go
+++ b/internal/ui/components/spinner_test.go
@@ -1,0 +1,34 @@
+package components
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSpinnerTTYWritesNoTerminalQueries pins SK-763 for the Spinner
+// component: like Status, it must not send terminal capability queries whose
+// replies outlive a short-lived spinner and get echoed as garbage.
+func TestSpinnerTTYWritesNoTerminalQueries(t *testing.T) {
+	buf := &syncBuffer{}
+	s := NewSpinnerWithOutput("Checking authentication", buf)
+	s.status.noTTY = false
+
+	s.Start()
+	time.Sleep(150 * time.Millisecond)
+	s.UpdateMessage("Still checking")
+	time.Sleep(150 * time.Millisecond)
+	s.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	out := buf.String()
+	if strings.Contains(out, "$p") {
+		t.Errorf("spinner output contains a terminal query; replies leak to the user's terminal\noutput: %q", out)
+	}
+	if !strings.Contains(out, "Checking authentication") {
+		t.Errorf("spinner output missing message\noutput: %q", out)
+	}
+	if !strings.Contains(out, "Still checking") {
+		t.Errorf("spinner output missing updated message\noutput: %q", out)
+	}
+}

--- a/internal/ui/components/status.go
+++ b/internal/ui/components/status.go
@@ -7,108 +7,34 @@ import (
 	"sync"
 	"time"
 
-	"charm.land/bubbles/v2/spinner"
-	tea "charm.land/bubbletea/v2"
-
 	"github.com/sleuth-io/sx/v2/internal/ui"
 	"github.com/sleuth-io/sx/v2/internal/ui/theme"
 )
 
-// statusUpdateMsg updates the status message.
-type statusUpdateMsg struct {
-	message string
-}
+// statusFrames are the spinner animation frames (same glyphs as the
+// charmbracelet Dot spinner previously used here).
+var statusFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 
-// statusDoneMsg signals status is complete.
-type statusDoneMsg struct {
-	success bool
-	message string
-}
-
-// statusModel is the bubbletea model for the status line.
-type statusModel struct {
-	spinner spinner.Model
-	message string
-	done    bool
-	success bool
-	final   string
-	theme   theme.Theme
-	styles  theme.Styles
-}
-
-func newStatusModel(message string) statusModel {
-	th := theme.Current()
-
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = th.Styles().Spinner
-
-	return statusModel{
-		spinner: s,
-		message: message,
-		theme:   th,
-		// Resolve styles now: the first resolution may query the terminal,
-		// which must happen before bubbletea takes it over.
-		styles: th.Styles(),
-	}
-}
-
-func (m statusModel) Init() tea.Cmd {
-	return m.spinner.Tick
-}
-
-func (m statusModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case statusUpdateMsg:
-		m.message = msg.message
-		return m, nil
-
-	case statusDoneMsg:
-		m.done = true
-		m.success = msg.success
-		m.final = msg.message
-		return m, tea.Quit
-
-	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
-			m.done = true
-			return m, tea.Quit
-		}
-
-	case spinner.TickMsg:
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(msg)
-		return m, cmd
-	}
-
-	return m, nil
-}
-
-func (m statusModel) View() tea.View {
-	if m.done {
-		if m.final != "" {
-			sym := m.theme.Symbols()
-			if m.success {
-				return tea.NewView(m.styles.Success.Render(sym.Success+" "+m.final) + "\n")
-			}
-			return tea.NewView(m.styles.Error.Render(sym.Error+" "+m.final) + "\n")
-		}
-		return tea.NewView("")
-	}
-
-	return tea.NewView(m.spinner.View() + " " + m.styles.Muted.Render(m.message))
-}
+const statusFrameInterval = 100 * time.Millisecond
 
 // Status provides a transient status line that updates in place.
 // Use for operations where you want to show progress without cluttering output.
+//
+// Rendered with plain ANSI writes rather than a bubbletea program: bubbletea
+// queries the terminal for capabilities at startup, and for a short-lived
+// status the replies arrive after the program has exited and restored echo,
+// so they end up printed to the user's terminal as garbage (SK-763).
 type Status struct {
-	program *tea.Program
-	out     io.Writer
-	noTTY   bool
-	mu      sync.Mutex
+	out    io.Writer
+	noTTY  bool
+	mu     sync.Mutex
+	silent bool
+
 	message string
-	silent  bool
+	frame   int
+	running bool
+	stop    chan struct{}
+	stopped chan struct{}
 }
 
 // NewStatus creates a new status line.
@@ -122,6 +48,19 @@ func NewStatus(out io.Writer) *Status {
 // SetSilent enables silent mode (no output).
 func (s *Status) SetSilent(silent bool) {
 	s.silent = silent
+}
+
+// render writes the current spinner frame and message in place.
+// Caller must hold s.mu.
+func (s *Status) render() {
+	styles := theme.Current().Styles()
+	frame := styles.Spinner.Render(statusFrames[s.frame%len(statusFrames)])
+	fmt.Fprintf(s.out, "\r\x1b[K%s %s", frame, styles.Muted.Render(s.message))
+}
+
+// clearLine erases the in-place status line. Caller must hold s.mu.
+func (s *Status) clearLine() {
+	fmt.Fprint(s.out, "\r\x1b[K")
 }
 
 // Start begins showing a status with spinner.
@@ -140,14 +79,35 @@ func (s *Status) Start(message string) {
 		return
 	}
 
-	m := newStatusModel(message)
-	s.program = tea.NewProgram(m, tea.WithOutput(s.out))
+	if s.running {
+		s.render()
+		return
+	}
 
-	go func() {
-		_, _ = s.program.Run()
-	}()
+	s.running = true
+	s.frame = 0
+	s.stop = make(chan struct{})
+	s.stopped = make(chan struct{})
+	s.render()
 
-	time.Sleep(10 * time.Millisecond)
+	go func(stop, stopped chan struct{}) {
+		defer close(stopped)
+		ticker := time.NewTicker(statusFrameInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				s.mu.Lock()
+				if s.running {
+					s.frame++
+					s.render()
+				}
+				s.mu.Unlock()
+			}
+		}
+	}(s.stop, s.stopped)
 }
 
 // Update changes the status message.
@@ -166,18 +126,18 @@ func (s *Status) Update(message string) {
 		return
 	}
 
-	if s.program != nil {
-		s.program.Send(statusUpdateMsg{message: message})
+	if s.running {
+		s.render()
 	}
 }
 
-// Done completes the status with an optional final message.
-// If finalMessage is empty, the status line is cleared.
-func (s *Status) Done(finalMessage string) {
+// finish stops the animation and replaces the status line with an optional
+// final message.
+func (s *Status) finish(success bool, finalMessage string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if s.silent {
+		s.mu.Unlock()
 		return
 	}
 
@@ -187,33 +147,46 @@ func (s *Status) Done(finalMessage string) {
 		} else {
 			fmt.Fprintln(s.out, " done")
 		}
+		s.mu.Unlock()
 		return
 	}
 
-	if s.program != nil {
-		s.program.Send(statusDoneMsg{success: true, message: finalMessage})
-		time.Sleep(20 * time.Millisecond)
+	var stopped chan struct{}
+	if s.running {
+		s.running = false
+		close(s.stop)
+		stopped = s.stopped
 	}
+	s.mu.Unlock()
+
+	// Wait outside the lock so the animation goroutine can exit.
+	if stopped != nil {
+		<-stopped
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clearLine()
+	if finalMessage != "" {
+		styles := theme.Current().Styles()
+		sym := theme.Current().Symbols()
+		if success {
+			fmt.Fprintln(s.out, styles.Success.Render(sym.Success+" "+finalMessage))
+		} else {
+			fmt.Fprintln(s.out, styles.Error.Render(sym.Error+" "+finalMessage))
+		}
+	}
+}
+
+// Done completes the status with an optional final message.
+// If finalMessage is empty, the status line is cleared.
+func (s *Status) Done(finalMessage string) {
+	s.finish(true, finalMessage)
 }
 
 // Fail completes the status with an error message.
 func (s *Status) Fail(message string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.silent {
-		return
-	}
-
-	if s.noTTY {
-		fmt.Fprintf(s.out, " %s\n", message)
-		return
-	}
-
-	if s.program != nil {
-		s.program.Send(statusDoneMsg{success: false, message: message})
-		time.Sleep(20 * time.Millisecond)
-	}
+	s.finish(false, message)
 }
 
 // Clear clears the status line without showing a final message.
@@ -222,10 +195,8 @@ func (s *Status) Clear() {
 }
 
 // RunStatus runs a function while showing a status spinner.
-// Shows a success/fail message based on the result.
+// The status line is cleared when the function completes.
 func RunStatus[T any](out io.Writer, message string, fn func() (T, error)) (T, error) {
-	var result T
-
 	noTTY := !ui.IsTTY(out)
 
 	if noTTY {
@@ -239,25 +210,15 @@ func RunStatus[T any](out io.Writer, message string, fn func() (T, error)) (T, e
 		return result, err
 	}
 
-	m := newStatusModel(message)
-	p := tea.NewProgram(m, tea.WithOutput(out))
-
-	var fnErr error
-
-	go func() {
-		result, fnErr = fn()
-		if fnErr != nil {
-			p.Send(statusDoneMsg{success: false, message: ""})
-		} else {
-			p.Send(statusDoneMsg{success: true, message: ""})
-		}
-	}()
-
-	if _, err := p.Run(); err != nil {
-		return result, fmt.Errorf("status failed: %w", err)
+	s := NewStatus(out)
+	s.Start(message)
+	result, err := fn()
+	if err != nil {
+		s.Fail("")
+	} else {
+		s.Done("")
 	}
-
-	return result, fnErr
+	return result, err
 }
 
 // StatusLine is a simpler non-animated status that updates in place.

--- a/internal/ui/components/status.go
+++ b/internal/ui/components/status.go
@@ -3,9 +3,13 @@ package components
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/term"
 
 	"github.com/sleuth-io/sx/v2/internal/ui"
 	"github.com/sleuth-io/sx/v2/internal/ui/theme"
@@ -30,8 +34,13 @@ type Status struct {
 	mu     sync.Mutex
 	silent bool
 
+	// termWidth reports the terminal width in cells (0 = unknown).
+	// Overridable in tests.
+	termWidth func() int
+
 	message string
 	frame   int
+	started bool
 	running bool
 	stop    chan struct{}
 	stopped chan struct{}
@@ -40,9 +49,23 @@ type Status struct {
 // NewStatus creates a new status line.
 func NewStatus(out io.Writer) *Status {
 	return &Status{
-		out:   out,
-		noTTY: !ui.IsTTY(out),
+		out:       out,
+		noTTY:     !ui.IsTTY(out),
+		termWidth: func() int { return terminalWidth(out) },
 	}
+}
+
+// terminalWidth returns the terminal width for out, or 0 if unknown.
+func terminalWidth(out io.Writer) int {
+	f, ok := out.(*os.File)
+	if !ok {
+		return 0
+	}
+	w, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || w <= 0 {
+		return 0
+	}
+	return w
 }
 
 // SetSilent enables silent mode (no output).
@@ -55,7 +78,13 @@ func (s *Status) SetSilent(silent bool) {
 func (s *Status) render() {
 	styles := theme.Current().Styles()
 	frame := styles.Spinner.Render(statusFrames[s.frame%len(statusFrames)])
-	fmt.Fprintf(s.out, "\r\x1b[K%s %s", frame, styles.Muted.Render(s.message))
+	line := frame + " " + styles.Muted.Render(s.message)
+	// Keep the line to a single row: in-place erasing (\r + EL) only
+	// covers the current row, so a wrapped line would leave residue.
+	if w := s.termWidth(); w > 0 {
+		line = ansi.Truncate(line, w, "…")
+	}
+	fmt.Fprintf(s.out, "\r\x1b[K%s", line)
 }
 
 // clearLine erases the in-place status line. Caller must hold s.mu.
@@ -84,11 +113,14 @@ func (s *Status) Start(message string) {
 		return
 	}
 
+	s.started = true
 	s.running = true
 	s.frame = 0
 	s.stop = make(chan struct{})
 	s.stopped = make(chan struct{})
-	fmt.Fprint(s.out, "\x1b[?25l") // hide cursor while animating
+	// The cursor is deliberately left visible: hiding it would leave the
+	// user's terminal cursorless if the process dies mid-spin (Ctrl-C,
+	// panic), since nothing here owns signal handling.
 	s.render()
 
 	go func(stop, stopped chan struct{}) {
@@ -155,6 +187,15 @@ func (s *Status) finish(success bool, finalMessage string) {
 		return
 	}
 
+	// Only touch the terminal when a spinner is actually active: a stray
+	// Done/Fail without Start (or a duplicate) must not erase whatever is
+	// on the line now or repeat the final message.
+	if !s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = false
+
 	var stopped chan struct{}
 	if s.running {
 		s.running = false
@@ -171,7 +212,6 @@ func (s *Status) finish(success bool, finalMessage string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.clearLine()
-	fmt.Fprint(s.out, "\x1b[?25h") // restore cursor
 	if finalMessage != "" {
 		styles := theme.Current().Styles()
 		sym := theme.Current().Symbols()

--- a/internal/ui/components/status.go
+++ b/internal/ui/components/status.go
@@ -38,6 +38,12 @@ type Status struct {
 	// Overridable in tests.
 	termWidth func() int
 
+	// Resolved once in Start: the first style resolution may query the
+	// terminal (see theme.detect), which must happen before painting
+	// begins, never from the animation goroutine.
+	styles  theme.Styles
+	symbols theme.Symbols
+
 	message string
 	frame   int
 	started bool
@@ -70,15 +76,16 @@ func terminalWidth(out io.Writer) int {
 
 // SetSilent enables silent mode (no output).
 func (s *Status) SetSilent(silent bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.silent = silent
 }
 
 // render writes the current spinner frame and message in place.
 // Caller must hold s.mu.
 func (s *Status) render() {
-	styles := theme.Current().Styles()
-	frame := styles.Spinner.Render(statusFrames[s.frame%len(statusFrames)])
-	line := frame + " " + styles.Muted.Render(s.message)
+	frame := s.styles.Spinner.Render(statusFrames[s.frame%len(statusFrames)])
+	line := frame + " " + s.styles.Muted.Render(s.message)
 	// Keep the line to a single row: in-place erasing (\r + EL) only
 	// covers the current row, so a wrapped line would leave residue.
 	if w := s.termWidth(); w > 0 {
@@ -102,6 +109,9 @@ func (s *Status) Start(message string) {
 	}
 
 	s.message = message
+	s.started = true
+	s.styles = theme.Current().Styles()
+	s.symbols = theme.Current().Symbols()
 
 	if s.noTTY {
 		fmt.Fprintf(s.out, "%s...", message)
@@ -113,7 +123,6 @@ func (s *Status) Start(message string) {
 		return
 	}
 
-	s.started = true
 	s.running = true
 	s.frame = 0
 	s.stop = make(chan struct{})
@@ -169,33 +178,32 @@ func (s *Status) Update(message string) {
 func (s *Status) finish(success bool, finalMessage string) {
 	s.mu.Lock()
 
-	if s.silent {
-		s.mu.Unlock()
-		return
-	}
-
-	if s.noTTY {
-		switch {
-		case finalMessage != "":
-			fmt.Fprintf(s.out, " %s\n", finalMessage)
-		case success:
-			fmt.Fprintln(s.out, " done")
-		default:
-			fmt.Fprintln(s.out, " failed")
-		}
-		s.mu.Unlock()
-		return
-	}
-
-	// Only touch the terminal when a spinner is actually active: a stray
-	// Done/Fail without Start (or a duplicate) must not erase whatever is
-	// on the line now or repeat the final message.
+	// Only act when a status is actually active: a stray Done/Fail without
+	// Start (or a duplicate) must not erase whatever is on the terminal
+	// line now, repeat the final message, or write to a pipe.
 	if !s.started {
 		s.mu.Unlock()
 		return
 	}
 	s.started = false
 
+	if s.noTTY {
+		if !s.silent {
+			switch {
+			case finalMessage != "":
+				fmt.Fprintf(s.out, " %s\n", finalMessage)
+			case success:
+				fmt.Fprintln(s.out, " done")
+			default:
+				fmt.Fprintln(s.out, " failed")
+			}
+		}
+		s.mu.Unlock()
+		return
+	}
+
+	// Always tear down the animation goroutine, even in silent mode —
+	// silent gates output, not lifecycle.
 	var stopped chan struct{}
 	if s.running {
 		s.running = false
@@ -211,14 +219,14 @@ func (s *Status) finish(success bool, finalMessage string) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// The painted line is cleared even when silent was enabled mid-run;
+	// only the final message counts as new output.
 	s.clearLine()
-	if finalMessage != "" {
-		styles := theme.Current().Styles()
-		sym := theme.Current().Symbols()
+	if finalMessage != "" && !s.silent {
 		if success {
-			fmt.Fprintln(s.out, styles.Success.Render(sym.Success+" "+finalMessage))
+			fmt.Fprintln(s.out, s.styles.Success.Render(s.symbols.Success+" "+finalMessage))
 		} else {
-			fmt.Fprintln(s.out, styles.Error.Render(sym.Error+" "+finalMessage))
+			fmt.Fprintln(s.out, s.styles.Error.Render(s.symbols.Error+" "+finalMessage))
 		}
 	}
 }
@@ -240,29 +248,19 @@ func (s *Status) Clear() {
 }
 
 // RunStatus runs a function while showing a status spinner.
-// The status line is cleared when the function completes.
-func RunStatus[T any](out io.Writer, message string, fn func() (T, error)) (T, error) {
-	noTTY := !ui.IsTTY(out)
-
-	if noTTY {
-		fmt.Fprintf(out, "%s... ", message)
-		result, err := fn()
-		if err != nil {
-			fmt.Fprintln(out, "failed")
-		} else {
-			fmt.Fprintln(out, "done")
-		}
-		return result, err
-	}
-
+// The status line is cleared when the function completes; teardown also
+// runs if fn panics.
+func RunStatus[T any](out io.Writer, message string, fn func() (T, error)) (result T, err error) {
 	s := NewStatus(out)
 	s.Start(message)
-	result, err := fn()
-	if err != nil {
-		s.Fail("")
-	} else {
-		s.Done("")
-	}
+	defer func() {
+		if err != nil {
+			s.Fail("")
+		} else {
+			s.Done("")
+		}
+	}()
+	result, err = fn()
 	return result, err
 }
 

--- a/internal/ui/components/status.go
+++ b/internal/ui/components/status.go
@@ -88,6 +88,7 @@ func (s *Status) Start(message string) {
 	s.frame = 0
 	s.stop = make(chan struct{})
 	s.stopped = make(chan struct{})
+	fmt.Fprint(s.out, "\x1b[?25l") // hide cursor while animating
 	s.render()
 
 	go func(stop, stopped chan struct{}) {
@@ -142,10 +143,13 @@ func (s *Status) finish(success bool, finalMessage string) {
 	}
 
 	if s.noTTY {
-		if finalMessage != "" {
+		switch {
+		case finalMessage != "":
 			fmt.Fprintf(s.out, " %s\n", finalMessage)
-		} else {
+		case success:
 			fmt.Fprintln(s.out, " done")
+		default:
+			fmt.Fprintln(s.out, " failed")
 		}
 		s.mu.Unlock()
 		return
@@ -167,6 +171,7 @@ func (s *Status) finish(success bool, finalMessage string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.clearLine()
+	fmt.Fprint(s.out, "\x1b[?25h") // restore cursor
 	if finalMessage != "" {
 		styles := theme.Current().Styles()
 		sym := theme.Current().Symbols()

--- a/internal/ui/components/status_test.go
+++ b/internal/ui/components/status_test.go
@@ -96,29 +96,51 @@ func TestStatusTTYFailShowsErrorMessage(t *testing.T) {
 	}
 }
 
-// TestStatusFinishWithoutStartIsNoOp: Done/Fail/Clear on a TTY status that
-// was never started must not write escape sequences over unrelated output.
+// TestStatusFinishWithoutStartIsNoOp: Done/Fail/Clear on a status that was
+// never started must not write anything — escape sequences on a TTY, or
+// stray " done"/" failed" lines on a pipe.
 func TestStatusFinishWithoutStartIsNoOp(t *testing.T) {
-	buf := &syncBuffer{}
-	s := newTTYStatus(buf)
-	s.Done("boom")
-	s.Fail("boom")
-	s.Clear()
-	if got := buf.String(); got != "" {
-		t.Errorf("finish without Start wrote %q, want nothing", got)
+	for _, tty := range []bool{true, false} {
+		buf := &syncBuffer{}
+		s := NewStatus(buf)
+		s.noTTY = !tty
+		s.Done("boom")
+		s.Fail("boom")
+		s.Clear()
+		if got := buf.String(); got != "" {
+			t.Errorf("tty=%v: finish without Start wrote %q, want nothing", tty, got)
+		}
 	}
 }
 
 // TestStatusDoubleDonePrintsFinalOnce: a duplicated Done must not erase the
-// terminal line again or repeat the final message.
+// terminal line again or repeat the final message, on either path.
 func TestStatusDoubleDonePrintsFinalOnce(t *testing.T) {
+	for _, tty := range []bool{true, false} {
+		buf := &syncBuffer{}
+		s := NewStatus(buf)
+		s.noTTY = !tty
+		s.Start("Working")
+		s.Done("all good")
+		s.Done("all good")
+		if n := strings.Count(buf.String(), "all good"); n != 1 {
+			t.Errorf("tty=%v: final message printed %d times, want 1\noutput: %q", tty, n, buf.String())
+		}
+	}
+}
+
+// TestStatusSilentAfterStartStopsAnimation: enabling silent mode mid-run
+// must not leak the animation goroutine — Done must still stop repaints.
+func TestStatusSilentAfterStartStopsAnimation(t *testing.T) {
 	buf := &syncBuffer{}
 	s := newTTYStatus(buf)
 	s.Start("Working")
-	s.Done("all good")
-	s.Done("all good")
-	if n := strings.Count(buf.String(), "all good"); n != 1 {
-		t.Errorf("final message printed %d times, want 1\noutput: %q", n, buf.String())
+	s.SetSilent(true)
+	s.Done("")
+	settled := len(buf.String())
+	time.Sleep(300 * time.Millisecond)
+	if got := len(buf.String()); got != settled {
+		t.Errorf("output grew from %d to %d bytes after Done — animation goroutine still running", settled, got)
 	}
 }
 

--- a/internal/ui/components/status_test.go
+++ b/internal/ui/components/status_test.go
@@ -1,0 +1,117 @@
+package components
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a goroutine-safe bytes.Buffer for capturing async writes.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+// newTTYStatus builds a Status writing to buf with the TTY rendering path
+// forced on, so tests can observe exactly what a terminal would receive.
+func newTTYStatus(buf *syncBuffer) *Status {
+	s := NewStatus(buf)
+	s.noTTY = false
+	return s
+}
+
+// TestStatusTTYWritesNoTerminalQueries pins SK-763: the status line must not
+// send terminal capability queries (DECRQM mode 2026/2027, etc.). Replies to
+// those queries arrive after the short-lived status finishes and get echoed
+// to the user's terminal as garbage like `^[[?2026;2$y`.
+func TestStatusTTYWritesNoTerminalQueries(t *testing.T) {
+	// Force the query-friendly environment bubbletea checks for, so the old
+	// implementation fails deterministically regardless of the test host.
+	os.Unsetenv("TERM_PROGRAM")
+	os.Unsetenv("SSH_TTY")
+
+	buf := &syncBuffer{}
+	s := newTTYStatus(buf)
+
+	s.Start("Fetching lock file")
+	time.Sleep(150 * time.Millisecond)
+	s.Update("Still fetching")
+	time.Sleep(150 * time.Millisecond)
+	s.Done("done")
+	time.Sleep(100 * time.Millisecond)
+
+	out := buf.String()
+	for _, q := range []string{
+		"\x1b[?2026$p", // DECRQM synchronized output query
+		"\x1b[?2027$p", // DECRQM unicode core query
+		"$p",           // any other DECRQM
+	} {
+		if strings.Contains(out, q) {
+			t.Errorf("status output contains terminal query %q; replies to it leak to the user's terminal\noutput: %q", q, out)
+		}
+	}
+
+	if !strings.Contains(out, "Fetching lock file") {
+		t.Errorf("status output missing running message\noutput: %q", out)
+	}
+	if !strings.Contains(out, "Still fetching") {
+		t.Errorf("status output missing updated message\noutput: %q", out)
+	}
+	if !strings.Contains(out, "done") {
+		t.Errorf("status output missing final message\noutput: %q", out)
+	}
+}
+
+// TestStatusTTYFailShowsErrorMessage verifies the failure path renders the
+// final message on the TTY path.
+func TestStatusTTYFailShowsErrorMessage(t *testing.T) {
+	buf := &syncBuffer{}
+	s := newTTYStatus(buf)
+
+	s.Start("Working")
+	time.Sleep(50 * time.Millisecond)
+	s.Fail("it broke")
+	time.Sleep(50 * time.Millisecond)
+
+	if !strings.Contains(buf.String(), "it broke") {
+		t.Errorf("status output missing failure message\noutput: %q", buf.String())
+	}
+}
+
+// TestRunStatusTTYWritesNoTerminalQueries covers the RunStatus wrapper on
+// the TTY path via the same leak signature.
+func TestRunStatusNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	got, err := RunStatus(&buf, "Working", func() (int, error) { return 42, nil })
+	if err != nil || got != 42 {
+		t.Fatalf("RunStatus = %v, %v; want 42, nil", got, err)
+	}
+	if !strings.Contains(buf.String(), "Working") || !strings.Contains(buf.String(), "done") {
+		t.Errorf("RunStatus non-TTY output = %q, want message and done", buf.String())
+	}
+
+	buf.Reset()
+	_, err = RunStatus(&buf, "Working", func() (int, error) { return 0, errors.New("boom") })
+	if err == nil {
+		t.Fatal("RunStatus should propagate fn error")
+	}
+	if !strings.Contains(buf.String(), "failed") {
+		t.Errorf("RunStatus non-TTY failure output = %q, want 'failed'", buf.String())
+	}
+}

--- a/internal/ui/components/status_test.go
+++ b/internal/ui/components/status_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 // syncBuffer is a goroutine-safe bytes.Buffer for capturing async writes.
@@ -33,6 +35,12 @@ func newTTYStatus(buf *syncBuffer) *Status {
 	s := NewStatus(buf)
 	s.noTTY = false
 	return s
+}
+
+// visibleWidth returns the display-cell width of a segment with escape
+// sequences removed.
+func visibleWidth(seg string) int {
+	return ansi.StringWidth(seg)
 }
 
 // TestStatusTTYWritesNoTerminalQueries pins SK-763: the status line must not
@@ -85,6 +93,49 @@ func TestStatusTTYFailShowsErrorMessage(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "it broke") {
 		t.Errorf("status output missing failure message\noutput: %q", buf.String())
+	}
+}
+
+// TestStatusFinishWithoutStartIsNoOp: Done/Fail/Clear on a TTY status that
+// was never started must not write escape sequences over unrelated output.
+func TestStatusFinishWithoutStartIsNoOp(t *testing.T) {
+	buf := &syncBuffer{}
+	s := newTTYStatus(buf)
+	s.Done("boom")
+	s.Fail("boom")
+	s.Clear()
+	if got := buf.String(); got != "" {
+		t.Errorf("finish without Start wrote %q, want nothing", got)
+	}
+}
+
+// TestStatusDoubleDonePrintsFinalOnce: a duplicated Done must not erase the
+// terminal line again or repeat the final message.
+func TestStatusDoubleDonePrintsFinalOnce(t *testing.T) {
+	buf := &syncBuffer{}
+	s := newTTYStatus(buf)
+	s.Start("Working")
+	s.Done("all good")
+	s.Done("all good")
+	if n := strings.Count(buf.String(), "all good"); n != 1 {
+		t.Errorf("final message printed %d times, want 1\noutput: %q", n, buf.String())
+	}
+}
+
+// TestStatusTruncatesToTerminalWidth: the status line must stay on one row,
+// or in-place erasing leaves wrapped residue on narrow terminals.
+func TestStatusTruncatesToTerminalWidth(t *testing.T) {
+	buf := &syncBuffer{}
+	s := newTTYStatus(buf)
+	s.termWidth = func() int { return 20 }
+
+	s.Start("this message is much longer than twenty columns")
+	s.Done("")
+
+	for _, seg := range strings.Split(buf.String(), "\r") {
+		if w := visibleWidth(seg); w > 20 {
+			t.Errorf("rendered segment %q is %d cells wide, want <= 20", seg, w)
+		}
 	}
 }
 

--- a/internal/ui/components/status_test.go
+++ b/internal/ui/components/status_test.go
@@ -132,7 +132,7 @@ func TestStatusTruncatesToTerminalWidth(t *testing.T) {
 	s.Start("this message is much longer than twenty columns")
 	s.Done("")
 
-	for _, seg := range strings.Split(buf.String(), "\r") {
+	for seg := range strings.SplitSeq(buf.String(), "\r") {
 		if w := visibleWidth(seg); w > 20 {
 			t.Errorf("rendered segment %q is %d cells wide, want <= 20", seg, w)
 		}

--- a/internal/ui/components/status_test.go
+++ b/internal/ui/components/status_test.go
@@ -3,7 +3,6 @@ package components
 import (
 	"bytes"
 	"errors"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -41,11 +40,6 @@ func newTTYStatus(buf *syncBuffer) *Status {
 // those queries arrive after the short-lived status finishes and get echoed
 // to the user's terminal as garbage like `^[[?2026;2$y`.
 func TestStatusTTYWritesNoTerminalQueries(t *testing.T) {
-	// Force the query-friendly environment bubbletea checks for, so the old
-	// implementation fails deterministically regardless of the test host.
-	os.Unsetenv("TERM_PROGRAM")
-	os.Unsetenv("SSH_TTY")
-
 	buf := &syncBuffer{}
 	s := newTTYStatus(buf)
 
@@ -94,8 +88,9 @@ func TestStatusTTYFailShowsErrorMessage(t *testing.T) {
 	}
 }
 
-// TestRunStatusTTYWritesNoTerminalQueries covers the RunStatus wrapper on
-// the TTY path via the same leak signature.
+// TestRunStatusNonTTY covers the RunStatus wrapper's non-TTY branch. The
+// TTY branch delegates to Status, whose query-leak regression is pinned by
+// TestStatusTTYWritesNoTerminalQueries.
 func TestRunStatusNonTTY(t *testing.T) {
 	var buf bytes.Buffer
 	got, err := RunStatus(&buf, "Working", func() (int, error) { return 42, nil })


### PR DESCRIPTION
## Summary
- After v2.3.6, `sx uninstall` (and any command using the status spinner) printed garbage like `^[[?2026;2$y` to the terminal: bubbletea v2 sends DECRQM capability queries (modes 2026/2027) at every program start, and the short-lived status-spinner programs exit before the terminal replies — the reply then lands on a restored, echo-on tty and is displayed
- Fix: render `Status`/`RunStatus` and `Spinner`/`RunWithSpinner` with plain in-place ANSI writes (same glyphs, same API) instead of spawning bubbletea programs — no program, no queries, no leak. This also removes an unsynchronized read in `RunWithSpinnerOutput` (quitting the old program mid-`fn` returned a nil result with nil error, which `sx init` then dereferenced)
- Status hardening from review: idempotent `Done`/`Fail`/`Clear` on both TTY and pipe paths, line truncation to terminal width (escape-aware) so in-place erasing never leaves wrapped residue, silent mode gates output but not goroutine teardown, styles resolved before painting begins, spinner teardown on panic
- Regression tests pin that the TTY status and spinner paths emit no terminal capability queries, plus idempotency/truncation/silent-mode behavior

## Verification
Ran probes under a PTY harness emulating a terminal that answers DECRQM 300ms late (after the short-lived program exits — the user-reported timing):

| Probe | Query sent | Reply echoed to terminal (the bug) |
|---|---|---|
| Status, old (bubbletea) | yes | **yes — reproduces `^[[?2026;2$y`** |
| Status, new (plain ANSI) | no | no |
| RunWithSpinner, new | no | no |

Also visually verified in tmux: spinner animates, updates in place, and clears cleanly.

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)