### PR TITLE
SK-766: Fix bugs found during sx vault migration

### DIFF
--- a/docs/copy.md
+++ b/docs/copy.md
@@ -88,6 +88,12 @@ in both directions, with these exceptions:
 source asset that has no installations and clears that auto-applied install on
 the destination, so an uninstalled asset stays uninstalled.)
 
+To keep user-scoped installs intact, the copy's scope writes are trusted: they
+carry "just for me" installs belonging to users other than the operator, which
+the file-backed vaults' self-only rule would otherwise reject (see
+[Users](users.md)). The scope already existed in the source, so replicating it
+is not the escalation that rule guards against.
+
 The preview/report always names what was skipped, so nothing is lost silently.
 
 ## See also

--- a/docs/users.md
+++ b/docs/users.md
@@ -46,6 +46,11 @@ The check runs inside the vault mutation transaction, after the flock
 + manifest reload — not just in the CLI — so it cannot be bypassed by
 racing two processes.
 
+One deliberate exception: `sx vault copy` replicates a source vault's
+existing scopes verbatim, so its bulk writes carry user scopes for
+other users (the scope was already valid in the source — faithful
+migration, not escalation). No interactive command gets this bypass.
+
 The Sleuth vault does not apply this restriction; it gates user-scoped
 installs on the server-side `INSTALL_SELF` permission instead (see
 above), which permits targeting other org users.

--- a/internal/commands/hooks.go
+++ b/internal/commands/hooks.go
@@ -53,6 +53,11 @@ func installSelectedClientHooks(ctx context.Context, out *outputHelper, enabledC
 			log.Debug("skipping hook installation for disabled client", "client", client.ID())
 			continue
 		}
+		// Even with no explicit selection, never touch a force-disabled client.
+		if enabledClientSet == nil && cfg != nil && !cfg.IsClientEnabled(client.ID()) {
+			log.Debug("skipping hook installation for force-disabled client", "client", client.ID())
+			continue
+		}
 
 		// Gather all options (vault + this client), deduplicating by key
 		seen := make(map[string]bool)

--- a/internal/commands/hooks.go
+++ b/internal/commands/hooks.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"os"
+	"slices"
 
 	"github.com/sleuth-io/sx/v2/internal/bootstrap"
 	"github.com/sleuth-io/sx/v2/internal/clients"
@@ -53,8 +54,11 @@ func installSelectedClientHooks(ctx context.Context, out *outputHelper, enabledC
 			log.Debug("skipping hook installation for disabled client", "client", client.ID())
 			continue
 		}
-		// Even with no explicit selection, never touch a force-disabled client.
-		if enabledClientSet == nil && cfg != nil && !cfg.IsClientEnabled(client.ID()) {
+		// Even with no explicit selection, never touch a force-disabled
+		// client. Keyed on mpc (config-wide lists, no profile resolution)
+		// rather than cfg, which is nil whenever config.Load can't resolve
+		// the active profile — the guard must not fall open in that state.
+		if enabledClientSet == nil && slices.Contains(mpc.ForceDisabledClients, client.ID()) {
 			log.Debug("skipping hook installation for force-disabled client", "client", client.ID())
 			continue
 		}

--- a/internal/commands/hooks_test.go
+++ b/internal/commands/hooks_test.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sleuth-io/sx/v2/internal/config"
+)
+
+// A nil selection means "all detected clients" — except force-disabled ones,
+// which hook installation must never touch (GitHub Copilot's hook file lands
+// in the CURRENT REPO's .github/, so touching a disabled client also pollutes
+// whatever repo the command runs from).
+func TestInstallSelectedClientHooks_SkipsForceDisabled(t *testing.T) {
+	env := NewTestEnv(t)
+	workDir := env.MkdirAll(filepath.Join(env.TempDir, "work"))
+	env.Chdir(workDir)
+
+	vaultDir := env.SetupPathVault()
+	env.WriteFile(
+		filepath.Join(env.HomeDir, ".config", "sx", "config.json"),
+		`{
+  "type": "path",
+  "repositoryUrl": "file://`+vaultDir+`",
+  "defaultProfile": "default",
+  "profiles": {
+    "default": {"type": "path", "repositoryUrl": "file://`+vaultDir+`"}
+  },
+  "forceDisabledClients": ["github-copilot"]
+}`,
+	)
+
+	cmd := &cobra.Command{}
+	installSelectedClientHooks(context.Background(), newOutputHelper(cmd), nil)
+
+	// Enabled client got its hooks (positive control that installation ran).
+	env.AssertFileExists(filepath.Join(env.HomeDir, ".claude", "settings.json"))
+	// The force-disabled client was never touched.
+	env.AssertFileNotExists(filepath.Join(workDir, ".github", "hooks", "sx.json"))
+}
+
+// The --clients flag is an explicit selection even as "all": it rebuilds the
+// config-wide enable/disable lists. Only an ABSENT flag preserves them.
+func TestInitClientsFlagExplicitness(t *testing.T) {
+	seedConfig := func(env *TestEnv) {
+		env.WriteFile(
+			filepath.Join(env.HomeDir, ".config", "sx", "config.json"),
+			`{
+  "type": "sleuth",
+  "authToken": "tok-123",
+  "repositoryUrl": "https://app.example.com",
+  "defaultProfile": "local",
+  "activeProfiles": ["local"],
+  "profiles": {
+    "local": {"type": "sleuth", "authToken": "tok-123", "repositoryUrl": "https://app.example.com"}
+  },
+  "forceDisabledClients": ["github-copilot"]
+}`,
+		)
+	}
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.SetOut(nilWriter{})
+		cmd.SetErr(nilWriter{})
+		return cmd
+	}
+
+	t.Run("--clients all rebuilds the lists", func(t *testing.T) {
+		env := NewTestEnv(t)
+		env.Chdir(env.MkdirAll(filepath.Join(env.TempDir, "work")))
+		seedConfig(env)
+		t.Setenv("SX_PROFILE", "newprof")
+
+		vaultDir := filepath.Join(env.TempDir, "vault-all")
+		if err := runInit(newCmd(), nil, "path", "", "", vaultDir, "all"); err != nil {
+			t.Fatalf("runInit --clients all: %v", err)
+		}
+		mpc, err := config.LoadMultiProfile()
+		if err != nil {
+			t.Fatalf("reload config: %v", err)
+		}
+		if len(mpc.ForceDisabledClients) != 0 {
+			t.Errorf("forceDisabledClients = %v, want cleared by explicit --clients all", mpc.ForceDisabledClients)
+		}
+	})
+
+	t.Run("absent flag preserves the lists", func(t *testing.T) {
+		env := NewTestEnv(t)
+		env.Chdir(env.MkdirAll(filepath.Join(env.TempDir, "work")))
+		seedConfig(env)
+		t.Setenv("SX_PROFILE", "newprof")
+
+		vaultDir := filepath.Join(env.TempDir, "vault-noflag")
+		if err := runInit(newCmd(), nil, "path", "", "", vaultDir, ""); err != nil {
+			t.Fatalf("runInit without --clients: %v", err)
+		}
+		mpc, err := config.LoadMultiProfile()
+		if err != nil {
+			t.Fatalf("reload config: %v", err)
+		}
+		if got := mpc.ForceDisabledClients; len(got) != 1 || got[0] != "github-copilot" {
+			t.Errorf("forceDisabledClients = %v, want preserved [github-copilot]", got)
+		}
+	})
+}
+
+type nilWriter struct{}
+
+func (nilWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/commands/hooks_test.go
+++ b/internal/commands/hooks_test.go
@@ -13,33 +13,46 @@ import (
 // A nil selection means "all detected clients" — except force-disabled ones,
 // which hook installation must never touch (GitHub Copilot's hook file lands
 // in the CURRENT REPO's .github/, so touching a disabled client also pollutes
-// whatever repo the command runs from).
+// whatever repo the command runs from). The guard must hold even when the
+// active profile can't be resolved (dangling defaultProfile): it reads the
+// config-wide lists, not a resolved profile.
 func TestInstallSelectedClientHooks_SkipsForceDisabled(t *testing.T) {
-	env := NewTestEnv(t)
-	workDir := env.MkdirAll(filepath.Join(env.TempDir, "work"))
-	env.Chdir(workDir)
+	cases := []struct {
+		name           string
+		defaultProfile string // "" seeds a dangling defaultProfile
+	}{
+		{"resolvable profile", `"defaultProfile": "default",`},
+		{"dangling defaultProfile", `"defaultProfile": "ghost",`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := NewTestEnv(t)
+			workDir := env.MkdirAll(filepath.Join(env.TempDir, "work"))
+			env.Chdir(workDir)
 
-	vaultDir := env.SetupPathVault()
-	env.WriteFile(
-		filepath.Join(env.HomeDir, ".config", "sx", "config.json"),
-		`{
+			vaultDir := env.SetupPathVault()
+			env.WriteFile(
+				filepath.Join(env.HomeDir, ".config", "sx", "config.json"),
+				`{
   "type": "path",
   "repositoryUrl": "file://`+vaultDir+`",
-  "defaultProfile": "default",
+  `+tc.defaultProfile+`
   "profiles": {
     "default": {"type": "path", "repositoryUrl": "file://`+vaultDir+`"}
   },
   "forceDisabledClients": ["github-copilot"]
 }`,
-	)
+			)
 
-	cmd := &cobra.Command{}
-	installSelectedClientHooks(context.Background(), newOutputHelper(cmd), nil)
+			cmd := &cobra.Command{}
+			installSelectedClientHooks(context.Background(), newOutputHelper(cmd), nil)
 
-	// Enabled client got its hooks (positive control that installation ran).
-	env.AssertFileExists(filepath.Join(env.HomeDir, ".claude", "settings.json"))
-	// The force-disabled client was never touched.
-	env.AssertFileNotExists(filepath.Join(workDir, ".github", "hooks", "sx.json"))
+			// Enabled client got its hooks (positive control that installation ran).
+			env.AssertFileExists(filepath.Join(env.HomeDir, ".claude", "settings.json"))
+			// The force-disabled client was never touched.
+			env.AssertFileNotExists(filepath.Join(workDir, ".github", "hooks", "sx.json"))
+		})
+	}
 }
 
 // The --clients flag is an explicit selection even as "all": it rebuilds the

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -25,15 +25,18 @@ import (
 )
 
 // runInitNonInteractivePreservingClients runs the non-interactive init and,
-// when preserveFrom is non-nil (an existing config, and no --clients flag was
-// given), restores that config's client enable/disable lists afterwards. The
-// init save paths rebuild those lists from the (empty) selection, so without
-// the restore a non-interactive `sx init` — e.g. one creating a new profile
-// via SX_PROFILE — would silently re-enable every force-disabled client. An
-// explicit selection (a --clients flag, including "all") passes preserveFrom
-// nil so the rebuilt lists win.
-func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Context, repoType, serverURL, repoURL, pathFlag string, enabledClients []string, preserveFrom *config.Config) error {
-	keep := enabledClients == nil && preserveFrom != nil
+// when keepFrom is non-nil (a pre-existing config snapshot, taken because no
+// --clients flag was given), restores its config-wide client enable/disable
+// lists afterwards. The init save paths rebuild those lists from the (empty)
+// selection, so without the restore a non-interactive `sx init` — e.g. one
+// creating a new profile via SX_PROFILE — would silently re-enable every
+// force-disabled client. An explicit selection (a --clients flag, including
+// "all") passes keepFrom nil so the rebuilt lists win. The snapshot is a
+// MultiProfileConfig rather than a resolved profile Config: the lists are
+// config-wide, and per-profile resolution can fail (dangling defaultProfile)
+// even when the lists themselves are perfectly readable.
+func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Context, repoType, serverURL, repoURL, pathFlag string, enabledClients []string, keepFrom *config.MultiProfileConfig) error {
+	keep := enabledClients == nil && keepFrom != nil
 	if err := runInitNonInteractive(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients); err != nil {
 		return err
 	}
@@ -44,8 +47,8 @@ func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Cont
 	if err != nil {
 		return err
 	}
-	mpc.ForceEnabledClients = preserveFrom.ForceEnabledClients
-	mpc.ForceDisabledClients = preserveFrom.ForceDisabledClients
+	mpc.ForceEnabledClients = keepFrom.ForceEnabledClients
+	mpc.ForceDisabledClients = keepFrom.ForceDisabledClients
 	return config.SaveMultiProfile(mpc)
 }
 
@@ -152,11 +155,11 @@ func runInit(cmd *cobra.Command, args []string, repoType, serverURL, repoURL, pa
 		enabledClients = flagClients
 		// An explicit --clients (including "all") is a client selection; only
 		// an absent flag preserves the existing enable/disable state.
-		var preserveFrom *config.Config
+		var keepFrom *config.MultiProfileConfig
 		if clientsFlag == "" {
-			preserveFrom = existingCfg
+			keepFrom, _ = config.LoadMultiProfile()
 		}
-		err = runInitNonInteractivePreservingClients(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients, preserveFrom)
+		err = runInitNonInteractivePreservingClients(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients, keepFrom)
 	} else {
 		enabledClients, err = runInitInteractive(cmd, ctx, existingCfg, flagClients)
 	}
@@ -900,6 +903,12 @@ func promptBootstrapOptions(cmd *cobra.Command, ctx context.Context, enabledClie
 	for _, client := range installedClients {
 		// Skip if not in enabled set (when set is defined)
 		if enabledSet != nil && !enabledSet[client.ID()] {
+			continue
+		}
+		// Even with no explicit selection, ignore force-disabled clients —
+		// mirrors the hook-installation guard so both paths agree on what
+		// "disabled" means.
+		if enabledSet == nil && !cfg.IsClientEnabled(client.ID()) {
 			continue
 		}
 		if clientOpts := client.GetBootstrapOptions(ctx); clientOpts != nil {

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -24,41 +24,14 @@ import (
 	"github.com/sleuth-io/sx/v2/internal/vault"
 )
 
-// runInitNonInteractivePreservingClients runs the non-interactive init and,
-// when keepFrom is non-nil (a pre-existing config snapshot, taken because no
-// --clients flag was given), restores its config-wide client enable/disable
-// lists afterwards. The init save paths rebuild those lists from the (empty)
-// selection, so without the restore a non-interactive `sx init` — e.g. one
-// creating a new profile via SX_PROFILE — would silently re-enable every
-// force-disabled client. An explicit selection (a --clients flag, including
-// "all") passes keepFrom nil so the rebuilt lists win. The snapshot is a
-// MultiProfileConfig rather than a resolved profile Config: the lists are
-// config-wide, and per-profile resolution can fail (dangling defaultProfile)
-// even when the lists themselves are perfectly readable.
-func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Context, repoType, serverURL, repoURL, pathFlag string, enabledClients []string, keepFrom *config.MultiProfileConfig) error {
-	keep := enabledClients == nil && keepFrom != nil
-	if err := runInitNonInteractive(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients); err != nil {
-		return err
-	}
-	if !keep {
-		return nil
-	}
-	mpc, err := config.LoadMultiProfile()
-	if err != nil {
-		return err
-	}
-	mpc.ForceEnabledClients = keepFrom.ForceEnabledClients
-	mpc.ForceDisabledClients = keepFrom.ForceDisabledClients
-	return config.SaveMultiProfile(mpc)
-}
-
 // computeDisabledClients returns the list of client IDs that should be disabled.
 // It only considers DETECTED clients - if a client isn't detected, we don't
 // add it to the disabled list (it's just not present, not explicitly disabled).
 // Returns nil if selectedClients is nil/empty (meaning all detected clients enabled),
 // or if all detected clients are in the selected list.
 func computeDisabledClients(selectedClients []string) []string {
-	// nil/empty selection means "all detected clients enabled" - no disabled list needed
+	// nil/empty means no selection was made — return nil so the config save
+	// leaves the stored list untouched (SaveToProfile's nil = don't touch).
 	if len(selectedClients) == 0 {
 		return nil
 	}
@@ -67,11 +40,10 @@ func computeDisabledClients(selectedClients []string) []string {
 	registry := clients.Global()
 	detectedClients := registry.DetectInstalled()
 
-	if len(detectedClients) == 0 {
-		return nil
-	}
-
-	var disabled []string
+	// An explicit selection always returns a non-nil slice: enabling every
+	// detected client must CLEAR a previously stored disabled list, not
+	// preserve it.
+	disabled := []string{}
 	for _, client := range detectedClients {
 		if !slices.Contains(selectedClients, client.ID()) {
 			disabled = append(disabled, client.ID())
@@ -152,14 +124,13 @@ func runInit(cmd *cobra.Command, args []string, repoType, serverURL, repoURL, pa
 	var enabledClients []string
 
 	if nonInteractive {
+		// An absent --clients flag leaves enabledClients nil ("no selection"),
+		// which flows through computeDisabledClients as a nil list that
+		// SaveToProfile leaves untouched — the existing enable/disable state
+		// survives without any clobber-and-restore. An explicit --clients
+		// (including "all", expanded by parseClientsFlag) rebuilds the lists.
 		enabledClients = flagClients
-		// An explicit --clients (including "all") is a client selection; only
-		// an absent flag preserves the existing enable/disable state.
-		var keepFrom *config.MultiProfileConfig
-		if clientsFlag == "" {
-			keepFrom, _ = config.LoadMultiProfile()
-		}
-		err = runInitNonInteractivePreservingClients(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients, keepFrom)
+		err = runInitNonInteractive(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients)
 	} else {
 		enabledClients, err = runInitInteractive(cmd, ctx, existingCfg, flagClients)
 	}
@@ -727,8 +698,18 @@ func expandPath(path string) (string, error) {
 // parseClientsFlag parses the --clients flag value and validates client IDs
 // Returns nil for "all" or empty string (meaning all detected clients)
 func parseClientsFlag(clientsFlag string) ([]string, error) {
-	if clientsFlag == "" || strings.ToLower(clientsFlag) == "all" {
-		return nil, nil // nil means all detected clients
+	if clientsFlag == "" {
+		return nil, nil // nil means no selection was made
+	}
+	if strings.ToLower(clientsFlag) == "all" {
+		// "all" is an explicit selection of every detected client — expand it
+		// so downstream (computeDisabledClients, hook install) treats it as a
+		// real selection rather than "no opinion".
+		var all []string
+		for _, c := range clients.Global().DetectInstalled() {
+			all = append(all, c.ID())
+		}
+		return all, nil
 	}
 
 	parts := strings.Split(clientsFlag, ",")

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -25,13 +25,15 @@ import (
 )
 
 // runInitNonInteractivePreservingClients runs the non-interactive init and,
-// when no client selection was made (no --clients flag), restores the
-// pre-existing config-wide client enable/disable lists afterwards. The init
-// save paths rebuild those lists from the (empty) selection, so without the
-// restore a non-interactive `sx init` — e.g. one creating a new profile via
-// SX_PROFILE — would silently re-enable every force-disabled client.
-func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Context, repoType, serverURL, repoURL, pathFlag string, enabledClients []string, existingCfg *config.Config) error {
-	keep := enabledClients == nil && existingCfg != nil
+// when preserveFrom is non-nil (an existing config, and no --clients flag was
+// given), restores that config's client enable/disable lists afterwards. The
+// init save paths rebuild those lists from the (empty) selection, so without
+// the restore a non-interactive `sx init` — e.g. one creating a new profile
+// via SX_PROFILE — would silently re-enable every force-disabled client. An
+// explicit selection (a --clients flag, including "all") passes preserveFrom
+// nil so the rebuilt lists win.
+func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Context, repoType, serverURL, repoURL, pathFlag string, enabledClients []string, preserveFrom *config.Config) error {
+	keep := enabledClients == nil && preserveFrom != nil
 	if err := runInitNonInteractive(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients); err != nil {
 		return err
 	}
@@ -42,8 +44,8 @@ func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Cont
 	if err != nil {
 		return err
 	}
-	mpc.ForceEnabledClients = existingCfg.ForceEnabledClients
-	mpc.ForceDisabledClients = existingCfg.ForceDisabledClients
+	mpc.ForceEnabledClients = preserveFrom.ForceEnabledClients
+	mpc.ForceDisabledClients = preserveFrom.ForceDisabledClients
 	return config.SaveMultiProfile(mpc)
 }
 
@@ -148,7 +150,13 @@ func runInit(cmd *cobra.Command, args []string, repoType, serverURL, repoURL, pa
 
 	if nonInteractive {
 		enabledClients = flagClients
-		err = runInitNonInteractivePreservingClients(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients, existingCfg)
+		// An explicit --clients (including "all") is a client selection; only
+		// an absent flag preserves the existing enable/disable state.
+		var preserveFrom *config.Config
+		if clientsFlag == "" {
+			preserveFrom = existingCfg
+		}
+		err = runInitNonInteractivePreservingClients(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients, preserveFrom)
 	} else {
 		enabledClients, err = runInitInteractive(cmd, ctx, existingCfg, flagClients)
 	}

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -24,6 +24,29 @@ import (
 	"github.com/sleuth-io/sx/v2/internal/vault"
 )
 
+// runInitNonInteractivePreservingClients runs the non-interactive init and,
+// when no client selection was made (no --clients flag), restores the
+// pre-existing config-wide client enable/disable lists afterwards. The init
+// save paths rebuild those lists from the (empty) selection, so without the
+// restore a non-interactive `sx init` — e.g. one creating a new profile via
+// SX_PROFILE — would silently re-enable every force-disabled client.
+func runInitNonInteractivePreservingClients(cmd *cobra.Command, ctx context.Context, repoType, serverURL, repoURL, pathFlag string, enabledClients []string, existingCfg *config.Config) error {
+	keep := enabledClients == nil && existingCfg != nil
+	if err := runInitNonInteractive(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients); err != nil {
+		return err
+	}
+	if !keep {
+		return nil
+	}
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		return err
+	}
+	mpc.ForceEnabledClients = existingCfg.ForceEnabledClients
+	mpc.ForceDisabledClients = existingCfg.ForceDisabledClients
+	return config.SaveMultiProfile(mpc)
+}
+
 // computeDisabledClients returns the list of client IDs that should be disabled.
 // It only considers DETECTED clients - if a client isn't detected, we don't
 // add it to the disabled list (it's just not present, not explicitly disabled).
@@ -125,7 +148,7 @@ func runInit(cmd *cobra.Command, args []string, repoType, serverURL, repoURL, pa
 
 	if nonInteractive {
 		enabledClients = flagClients
-		err = runInitNonInteractive(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients)
+		err = runInitNonInteractivePreservingClients(cmd, ctx, repoType, serverURL, repoURL, pathFlag, enabledClients, existingCfg)
 	} else {
 		enabledClients, err = runInitInteractive(cmd, ctx, existingCfg, flagClients)
 	}

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -258,16 +258,12 @@ func TestInitNewProfilePreservesSharedConfig(t *testing.T) {
 	}
 
 	t.Setenv("SX_PROFILE", "newprof")
-	keepFrom, err := config.LoadMultiProfile()
-	if err != nil {
-		t.Fatalf("load existing config: %v", err)
-	}
 
 	vaultDir := filepath.Join(t.TempDir(), "vault")
 	cmd := &cobra.Command{}
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
-	if err := runInitNonInteractivePreservingClients(cmd, context.Background(), "path", "", "", vaultDir, nil, keepFrom); err != nil {
+	if err := runInitNonInteractive(cmd, context.Background(), "path", "", "", vaultDir, nil); err != nil {
 		t.Fatalf("init new profile: %v", err)
 	}
 

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -227,4 +229,76 @@ func TestInitNonInteractivePathFlag(t *testing.T) {
 			t.Errorf("err = %v, want mention of --path", err)
 		}
 	})
+}
+
+// TestInitNewProfilePreservesSharedConfig reproduces the config clobbering
+// found during the skills.new → git vault migration: `SX_PROFILE=newprof
+// sx init --type git --repo-url ...` must create the new profile WITHOUT
+// wiping the config-wide force-disabled clients, and the top-level compat
+// mirror must keep following the persisted default profile rather than the
+// transient SX_PROFILE override (which used to swap every top-level field,
+// dropping the default profile's auth token).
+func TestInitNewProfilePreservesSharedConfig(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("SX_CONFIG_DIR", configDir)
+
+	seed := `{
+  "type": "sleuth",
+  "authToken": "tok-123",
+  "repositoryUrl": "https://app.example.com",
+  "defaultProfile": "local",
+  "activeProfiles": ["local"],
+  "profiles": {
+    "local": {"type": "sleuth", "authToken": "tok-123", "repositoryUrl": "https://app.example.com"}
+  },
+  "forceDisabledClients": ["codex", "github-copilot"]
+}`
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(seed), 0600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	t.Setenv("SX_PROFILE", "newprof")
+	existingCfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load existing config: %v", err)
+	}
+
+	vaultDir := filepath.Join(t.TempDir(), "vault")
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runInitNonInteractivePreservingClients(cmd, context.Background(), "path", "", "", vaultDir, nil, existingCfg); err != nil {
+		t.Fatalf("init new profile: %v", err)
+	}
+
+	mpc, err := config.LoadMultiProfile()
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if _, ok := mpc.GetProfile("newprof"); !ok {
+		t.Fatal("newprof profile was not created")
+	}
+	if local, ok := mpc.GetProfile("local"); !ok || local.AuthToken != "tok-123" {
+		t.Fatalf("local profile mangled: %+v", local)
+	}
+	if got := mpc.ForceDisabledClients; len(got) != 2 || got[0] != "codex" || got[1] != "github-copilot" {
+		t.Errorf("forceDisabledClients = %v, want preserved [codex github-copilot]", got)
+	}
+
+	// The top-level compat mirror must still reflect the persisted default
+	// profile (local), not the SX_PROFILE override this init ran under.
+	raw, err := os.ReadFile(filepath.Join(configDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	var top struct {
+		Type      string `json:"type"`
+		AuthToken string `json:"authToken"`
+	}
+	if err := json.Unmarshal(raw, &top); err != nil {
+		t.Fatalf("parse config file: %v", err)
+	}
+	if top.Type != "sleuth" || top.AuthToken != "tok-123" {
+		t.Errorf("top-level mirror = %+v, want the local profile's sleuth/tok-123", top)
+	}
 }

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -258,7 +258,7 @@ func TestInitNewProfilePreservesSharedConfig(t *testing.T) {
 	}
 
 	t.Setenv("SX_PROFILE", "newprof")
-	existingCfg, err := config.Load()
+	keepFrom, err := config.LoadMultiProfile()
 	if err != nil {
 		t.Fatalf("load existing config: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestInitNewProfilePreservesSharedConfig(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
-	if err := runInitNonInteractivePreservingClients(cmd, context.Background(), "path", "", "", vaultDir, nil, existingCfg); err != nil {
+	if err := runInitNonInteractivePreservingClients(cmd, context.Background(), "path", "", "", vaultDir, nil, keepFrom); err != nil {
 		t.Fatalf("init new profile: %v", err)
 	}
 

--- a/internal/commands/scope_selection_display.go
+++ b/internal/commands/scope_selection_display.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sleuth-io/sx/v2/internal/lockfile"
+	"github.com/sleuth-io/sx/v2/internal/scope"
 	"github.com/sleuth-io/sx/v2/internal/ui"
 	"github.com/sleuth-io/sx/v2/internal/vault"
 )
@@ -34,13 +35,15 @@ func formatTarget(t vault.InstallTarget) string {
 // its human-facing label. Diff and preview maps key on this rather than
 // formatTarget so two distinct targets that happen to render to the same string
 // don't collapse, and a path target whose Paths differ only in order isn't
-// mistaken for a different target.
+// mistaken for a different target. The repo component is normalized so a
+// server-qualified row ("github.com/acme/tools") and the slug or URL a user
+// types for the same repository don't diff as distinct targets.
 func targetKey(t vault.InstallTarget) string {
 	paths := append([]string(nil), t.Paths...)
 	slices.Sort(paths)
 	return strings.Join([]string{
 		string(t.Kind),
-		t.Repo,
+		scope.NormalizeRepoURL(t.Repo),
 		strings.Join(paths, "\x00"),
 		t.Team,
 		t.User,

--- a/internal/commands/scope_selection_display.go
+++ b/internal/commands/scope_selection_display.go
@@ -36,8 +36,11 @@ func formatTarget(t vault.InstallTarget) string {
 // formatTarget so two distinct targets that happen to render to the same string
 // don't collapse, and a path target whose Paths differ only in order isn't
 // mistaken for a different target. The repo component is normalized so a
-// server-qualified row ("github.com/acme/tools") and the slug or URL a user
-// types for the same repository don't diff as distinct targets.
+// server-qualified row ("github.com/acme/tools") and a URL a user types for
+// the same repository ("https://github.com/acme/tools",
+// "git@github.com:acme/tools.git") don't diff as distinct targets. A bare
+// "acme/tools" slug still keys separately — it carries no host, and inventing
+// one here could collapse genuinely different repositories.
 func targetKey(t vault.InstallTarget) string {
 	paths := append([]string(nil), t.Paths...)
 	slices.Sort(paths)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,9 +160,16 @@ func SaveToProfile(cfg *Config, profileName string) error {
 	// Update the profile
 	mpc.SetProfile(profileName, ProfileFromConfig(cfg))
 
-	// Update client settings (global setting)
-	mpc.ForceEnabledClients = cfg.ForceEnabledClients
-	mpc.ForceDisabledClients = cfg.ForceDisabledClients
+	// Update client settings (config-wide, not per-profile). A nil slice
+	// means the caller made no client selection — leave the stored lists
+	// untouched, so e.g. an init creating a new profile can't wipe them.
+	// An empty non-nil slice is an explicit clear.
+	if cfg.ForceEnabledClients != nil {
+		mpc.ForceEnabledClients = cfg.ForceEnabledClients
+	}
+	if cfg.ForceDisabledClients != nil {
+		mpc.ForceDisabledClients = cfg.ForceDisabledClients
+	}
 
 	// If this is the first profile, make it the default
 	if mpc.DefaultProfile == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,10 +141,14 @@ func SaveToProfile(cfg *Config, profileName string) error {
 	// Try to load existing multi-profile config
 	mpc, err := LoadMultiProfile()
 	if err != nil {
-		// No existing config, create new multi-profile config
+		// No existing config, create new multi-profile config. DefaultProfile
+		// starts empty so the first-profile promotion below makes whichever
+		// profile this save actually creates the default — pre-seeding
+		// "default" here would leave a dangling DefaultProfile (and an empty
+		// top-level compat mirror) when the first save targets a named
+		// profile via --profile/SX_PROFILE.
 		mpc = &MultiProfileConfig{
-			DefaultProfile: DefaultProfileName,
-			Profiles:       make(map[string]*Profile),
+			Profiles: make(map[string]*Profile),
 		}
 	}
 

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -322,7 +322,7 @@ func SaveMultiProfile(mpc *MultiProfileConfig) error {
 	}
 
 	// Copy active profile fields to top level for old binaries
-	activeProfileName := GetActiveProfileName(mpc)
+	activeProfileName := persistedActiveProfileName(mpc)
 	if activeProfile, ok := mpc.Profiles[activeProfileName]; ok {
 		compat.Type = activeProfile.Type
 		compat.ServerURL = activeProfile.ServerURL
@@ -343,6 +343,23 @@ func SaveMultiProfile(mpc *MultiProfileConfig) error {
 	}
 
 	return nil
+}
+
+// persistedActiveProfileName is the profile the config FILE considers
+// active: the default profile, else the first active profile. Unlike
+// GetActiveProfileName it deliberately ignores the --profile/SX_PROFILE
+// runtime override — the top-level compat mirror is persistent state for
+// old binaries, and mirroring a transient override would rewrite it to a
+// profile the file itself doesn't treat as default (e.g. `SX_PROFILE=new
+// sx init` swapping every top-level field, including dropping authToken).
+func persistedActiveProfileName(mpc *MultiProfileConfig) string {
+	if mpc.DefaultProfile != "" {
+		return mpc.DefaultProfile
+	}
+	if len(mpc.ActiveProfiles) > 0 {
+		return firstName(mpc.ActiveProfiles[0])
+	}
+	return DefaultProfileName
 }
 
 // GetActiveProfileName returns the name of the profile that owns single-

--- a/internal/vault/collection_installs.go
+++ b/internal/vault/collection_installs.go
@@ -37,18 +37,23 @@ type CollectionInstaller interface {
 }
 
 // collectionTargetScope converts an install target into the manifest scope
-// row stored on a collection. It differs from installTargetScope in one
-// deliberate way: org becomes an explicit kind=org row instead of an error
-// or a cleared list, because collection rows are additive grants.
-func collectionTargetScope(target InstallTarget, actor mgmt.Actor) (manifest.Scope, error) {
+// row stored on a collection. It differs from installTargetScope in two
+// deliberate ways: org becomes an explicit kind=org row instead of an error
+// or a cleared list (collection rows are additive grants), and a trusted
+// write (sx vault copy replicating the source's rows) lifts the user-scope
+// self-only rule the same way the asset path's resolveSetTarget does.
+func collectionTargetScope(target InstallTarget, actor mgmt.Actor, trusted bool) (manifest.Scope, error) {
 	if target.Kind == InstallKindOrg {
 		return manifest.Scope{Kind: manifest.ScopeKindOrg}, nil
+	}
+	if target.Kind == InstallKindUser {
+		return resolveUserScopeForWrite(target, actor, trusted)
 	}
 	return installTargetScope(target, actor)
 }
 
-func commonSetCollectionInstallation(vaultRoot string, actor mgmt.Actor, name string, target InstallTarget) error {
-	s, err := collectionTargetScope(target, actor)
+func commonSetCollectionInstallation(ctx context.Context, vaultRoot string, actor mgmt.Actor, name string, target InstallTarget) error {
+	s, err := collectionTargetScope(target, actor, scopeRBACBypassed(ctx))
 	if err != nil {
 		return err
 	}
@@ -87,8 +92,8 @@ func commonSetCollectionInstallation(vaultRoot string, actor mgmt.Actor, name st
 	})
 }
 
-func commonRemoveCollectionInstallation(vaultRoot string, actor mgmt.Actor, name string, target InstallTarget) error {
-	needle, err := collectionTargetScope(target, actor)
+func commonRemoveCollectionInstallation(ctx context.Context, vaultRoot string, actor mgmt.Actor, name string, target InstallTarget) error {
+	needle, err := collectionTargetScope(target, actor, scopeRBACBypassed(ctx))
 	if err != nil {
 		return err
 	}
@@ -164,14 +169,14 @@ func commonCurrentCollectionInstallTargets(vaultRoot, name string) ([]InstallTar
 // SetCollectionInstallation adds an install target to a collection.
 func (p *PathVault) SetCollectionInstallation(ctx context.Context, name string, target InstallTarget) error {
 	return p.withLock(ctx, func(actor mgmt.Actor) error {
-		return commonSetCollectionInstallation(p.repoPath, actor, name, target)
+		return commonSetCollectionInstallation(ctx, p.repoPath, actor, name, target)
 	})
 }
 
 // RemoveCollectionInstallation removes an install target from a collection.
 func (p *PathVault) RemoveCollectionInstallation(ctx context.Context, name string, target InstallTarget) error {
 	return p.withLock(ctx, func(actor mgmt.Actor) error {
-		return commonRemoveCollectionInstallation(p.repoPath, actor, name, target)
+		return commonRemoveCollectionInstallation(ctx, p.repoPath, actor, name, target)
 	})
 }
 
@@ -183,14 +188,14 @@ func (p *PathVault) CurrentCollectionInstallTargets(ctx context.Context, name st
 // SetCollectionInstallation adds an install target to a collection and pushes.
 func (g *GitVault) SetCollectionInstallation(ctx context.Context, name string, target InstallTarget) error {
 	return g.runInVaultTx(ctx, "Install collection "+name, func(root string, actor mgmt.Actor) error {
-		return commonSetCollectionInstallation(root, actor, name, target)
+		return commonSetCollectionInstallation(ctx, root, actor, name, target)
 	})
 }
 
 // RemoveCollectionInstallation removes an install target and pushes.
 func (g *GitVault) RemoveCollectionInstallation(ctx context.Context, name string, target InstallTarget) error {
 	return g.runInVaultTx(ctx, "Uninstall collection "+name, func(root string, actor mgmt.Actor) error {
-		return commonRemoveCollectionInstallation(root, actor, name, target)
+		return commonRemoveCollectionInstallation(ctx, root, actor, name, target)
 	})
 }
 

--- a/internal/vault/graphql/generated.go
+++ b/internal/vault/graphql/generated.go
@@ -1325,6 +1325,7 @@ type AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallati
 	EntityName string                           `json:"entityName"`
 	// Canonical reference used to install this entity, when it differs from entityName: the email for USER installations. Null for entity types whose entityName is already the canonical reference.
 	EntityRef        *string `json:"entityRef"`
+	EntityProvider   *string `json:"entityProvider"`
 	EntityId         *string `json:"entityId"`
 	MonoRepoConfigId *string `json:"monoRepoConfigId"`
 	// GID of the collection this installation is derived from (null for direct installs)
@@ -1344,6 +1345,11 @@ func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstal
 // GetEntityRef returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityRef, and is useful for accessing the field via an interface.
 func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetEntityRef() *string {
 	return v.EntityRef
+}
+
+// GetEntityProvider returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityProvider, and is useful for accessing the field via an interface.
+func (v *AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation) GetEntityProvider() *string {
+	return v.EntityProvider
 }
 
 // GetEntityId returns AssetInstallationsVaultAssetsVaultAssetsConnectionNodesVaultAssetInstallationsVaultAssetInstallation.EntityId, and is useful for accessing the field via an interface.
@@ -2093,6 +2099,7 @@ type CollectionInstallationsCollectionVaultAssetCollectionInstallationsVaultAsse
 	EntityName string                           `json:"entityName"`
 	// Canonical reference used to install this entity, when it differs from entityName: the email for USER installations. Null for entity types whose entityName is already the canonical reference.
 	EntityRef        *string `json:"entityRef"`
+	EntityProvider   *string `json:"entityProvider"`
 	EntityId         *string `json:"entityId"`
 	MonoRepoConfigId *string `json:"monoRepoConfigId"`
 }
@@ -2110,6 +2117,11 @@ func (v *CollectionInstallationsCollectionVaultAssetCollectionInstallationsVault
 // GetEntityRef returns CollectionInstallationsCollectionVaultAssetCollectionInstallationsVaultAssetInstallation.EntityRef, and is useful for accessing the field via an interface.
 func (v *CollectionInstallationsCollectionVaultAssetCollectionInstallationsVaultAssetInstallation) GetEntityRef() *string {
 	return v.EntityRef
+}
+
+// GetEntityProvider returns CollectionInstallationsCollectionVaultAssetCollectionInstallationsVaultAssetInstallation.EntityProvider, and is useful for accessing the field via an interface.
+func (v *CollectionInstallationsCollectionVaultAssetCollectionInstallationsVaultAssetInstallation) GetEntityProvider() *string {
+	return v.EntityProvider
 }
 
 // GetEntityId returns CollectionInstallationsCollectionVaultAssetCollectionInstallationsVaultAssetInstallation.EntityId, and is useful for accessing the field via an interface.
@@ -5563,9 +5575,10 @@ func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnec
 
 // OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType includes the requested fields of the GraphQL type RepositoryType.
 type OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType struct {
-	Id    *string `json:"id"`
-	Owner string  `json:"owner"`
-	Name  string  `json:"name"`
+	Id       *string `json:"id"`
+	Owner    string  `json:"owner"`
+	Name     string  `json:"name"`
+	Provider string  `json:"provider"`
 }
 
 // GetId returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType.Id, and is useful for accessing the field via an interface.
@@ -5581,6 +5594,11 @@ func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnec
 // GetName returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType.Name, and is useful for accessing the field via an interface.
 func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType) GetName() string {
 	return v.Name
+}
+
+// GetProvider returns OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType.Provider, and is useful for accessing the field via an interface.
+func (v *OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionNodesRepositoryType) GetProvider() string {
+	return v.Provider
 }
 
 // OrgRepositoriesOrganizationOrganizationTypeRepositoriesRepositoryConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
@@ -9501,6 +9519,7 @@ query AssetInstallations ($first: Int, $after: String) {
 					entityType
 					entityName
 					entityRef
+					entityProvider
 					entityId
 					monoRepoConfigId
 					viaCollectionId
@@ -9727,6 +9746,7 @@ query CollectionInstallations ($id: ID!) {
 			entityType
 			entityName
 			entityRef
+			entityProvider
 			entityId
 			monoRepoConfigId
 		}
@@ -10839,6 +10859,7 @@ query OrgRepositories ($first: Int!, $after: String) {
 				id
 				owner
 				name
+				provider
 			}
 		}
 	}

--- a/internal/vault/graphql/operations/asset_installations.graphql
+++ b/internal/vault/graphql/operations/asset_installations.graphql
@@ -12,6 +12,7 @@ query AssetInstallations($first: Int, $after: String) {
           entityType
           entityName
           entityRef
+          entityProvider
           entityId
           monoRepoConfigId
           viaCollectionId

--- a/internal/vault/graphql/operations/collection_installs.graphql
+++ b/internal/vault/graphql/operations/collection_installs.graphql
@@ -4,6 +4,7 @@ query CollectionInstallations($id: ID!) {
       entityType
       entityName
       entityRef
+      entityProvider
       entityId
       monoRepoConfigId
     }

--- a/internal/vault/graphql/operations/org_repositories.graphql
+++ b/internal/vault/graphql/operations/org_repositories.graphql
@@ -9,6 +9,7 @@ query OrgRepositories($first: Int!, $after: String) {
         id
         owner
         name
+        provider
       }
     }
   }

--- a/internal/vault/mgmt_e2e_test.go
+++ b/internal/vault/mgmt_e2e_test.go
@@ -1273,3 +1273,44 @@ func TestRemoveTeamMember_SelfRemoval(t *testing.T) {
 		t.Fatalf("non-admin removing another member should be denied, got %v", err)
 	}
 }
+
+// Collection installs get the same trusted-write exception as asset scopes:
+// vault copy replicates the source's rows, so a "just for me" install
+// belonging to another user must survive, while untrusted writes still
+// enforce the self-only rule.
+func TestPathVault_TrustedSetCollectionInstallationAllowsForeignUser(t *testing.T) {
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "alice@example.com")
+	runGit(t, dir, "config", "user.name", "Alice Admin")
+
+	if err := manifest.Save(dir, &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Collections:   []manifest.Collection{{Name: "essentials"}},
+	}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault failed: %v", err)
+	}
+	ctx := context.Background()
+	foreign := InstallTarget{Kind: InstallKindUser, User: "bob@example.com"}
+
+	err = v.SetCollectionInstallation(ctx, "essentials", foreign)
+	if err == nil || !strings.Contains(err.Error(), "may only target the authenticated caller") {
+		t.Fatalf("untrusted collection install for a non-caller: err=%v, want self-only rejection", err)
+	}
+
+	if err := v.SetCollectionInstallation(ContextWithTrustedScopeWrite(ctx), "essentials", foreign); err != nil {
+		t.Fatalf("trusted collection install: %v", err)
+	}
+	targets, present, err := v.CurrentCollectionInstallTargets(ctx, "essentials")
+	if err != nil || !present || len(targets) != 1 ||
+		targets[0].Kind != InstallKindUser || targets[0].User != "bob@example.com" {
+		t.Fatalf("targets = %+v present=%v err=%v, want bob@example.com user target", targets, present, err)
+	}
+}

--- a/internal/vault/mgmt_e2e_test.go
+++ b/internal/vault/mgmt_e2e_test.go
@@ -860,6 +860,61 @@ func TestPathVault_SetAssetInstallation_RejectsOtherUser(t *testing.T) {
 	}
 }
 
+// A trusted bulk write (vault copy replicating a source's existing scopes)
+// may carry user scopes for other users — the self-only rule guards against
+// interactive privilege escalation, not faithful migration. An untrusted bulk
+// write still skips them.
+func TestPathVault_TrustedBulkSetAllowsForeignUserScope(t *testing.T) {
+	mgmt.ResetActorCache()
+	dir := t.TempDir()
+
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "alice@example.com")
+	runGit(t, dir, "config", "user.name", "Alice Admin")
+
+	if err := manifest.Save(dir, &manifest.Manifest{
+		SchemaVersion: manifest.CurrentSchemaVersion,
+		Assets: []manifest.Asset{
+			{
+				Name:       "my-skill",
+				Version:    "1.0.0",
+				Type:       asset.TypeSkill,
+				SourceHTTP: &manifest.SourceHTTP{URL: "https://example.com/my-skill.zip"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	v, err := NewPathVault("file://" + dir)
+	if err != nil {
+		t.Fatalf("NewPathVault failed: %v", err)
+	}
+	ctx := context.Background()
+	foreign := InstallTarget{Kind: InstallKindUser, User: "bob@example.com"}
+
+	skipped, err := v.SetAssetInstallations(ctx, "my-skill", []InstallTarget{foreign}, false)
+	if err != nil {
+		t.Fatalf("untrusted bulk set: %v", err)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0].Reason, "may only target the authenticated caller") {
+		t.Fatalf("untrusted bulk set should skip the foreign user scope, got %+v", skipped)
+	}
+
+	skipped, err = v.SetAssetInstallations(ContextWithTrustedScopeWrite(ctx), "my-skill", []InstallTarget{foreign}, false)
+	if err != nil {
+		t.Fatalf("trusted bulk set: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("trusted bulk set should apply the foreign user scope, got skipped %+v", skipped)
+	}
+	scopes, present, err := v.AssetInstallScopes(ctx, "my-skill")
+	if err != nil || !present || len(scopes) != 1 ||
+		scopes[0].Kind != manifest.ScopeKindUser || scopes[0].User != "bob@example.com" {
+		t.Fatalf("scopes = %+v present=%v err=%v, want bob@example.com user scope", scopes, present, err)
+	}
+}
+
 // TestPathVault_TeamMutationsRequireAdmin verifies that every destructive
 // team mutation enforces admin membership inside the transaction, not
 // just at the CLI pre-check.

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -1115,7 +1115,7 @@ func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mg
 		var resolved []resolvedScope
 		if !orgWide {
 			for _, t := range targets {
-				s, reason := resolveSetTarget(m, t, actor)
+				s, reason := resolveSetTarget(m, t, actor, !enforce)
 				// Existence/format settled; now the RBAC gate (who may set it).
 				if reason == "" && enforce {
 					reason = scopeSetPermissionReason(m, t, actor)
@@ -1244,11 +1244,24 @@ func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mg
 // verbatim (mirrors the Sleuth vault's GID-resolution skip). Org is never
 // resolved here (handled as a scope clear). The team/bot errors carry their own
 // distinct wording (ErrTeamNotFound vs the "not an admin" message), so the user
-// can tell a missing team from a permissions problem.
-func resolveSetTarget(m *manifest.Manifest, t InstallTarget, actor mgmt.Actor) (manifest.Scope, string) {
-	s, err := installTargetScope(t, actor)
-	if err != nil {
-		return manifest.Scope{}, err.Error()
+// can tell a missing team from a permissions problem. A trusted bulk write
+// (vault copy replicating a source's scopes verbatim) also lifts the
+// user-scope self-only restriction: the scope already existed in the source,
+// so faithfully carrying it over is not the privilege escalation that check
+// guards against.
+func resolveSetTarget(m *manifest.Manifest, t InstallTarget, actor mgmt.Actor, trusted bool) (manifest.Scope, string) {
+	var s manifest.Scope
+	if trusted && t.Kind == InstallKindUser {
+		if t.User == "" {
+			return manifest.Scope{}, "user installation missing email"
+		}
+		s = manifest.Scope{Kind: manifest.ScopeKindUser, User: t.User}
+	} else {
+		var err error
+		s, err = installTargetScope(t, actor)
+		if err != nil {
+			return manifest.Scope{}, err.Error()
+		}
 	}
 	switch t.Kind {
 	case InstallKindTeam:

--- a/internal/vault/mgmt_ops.go
+++ b/internal/vault/mgmt_ops.go
@@ -896,18 +896,10 @@ func commonSetAssetInstallation(vaultRoot string, actor mgmt.Actor, assetName st
 		}
 		s = manifest.Scope{Kind: manifest.ScopeKindTeam, Team: target.Team}
 	case InstallKindUser:
-		if target.User == "" {
-			return errors.New("user installation missing email")
+		var err error
+		if s, err = resolveUserScopeForWrite(target, actor, false); err != nil {
+			return err
 		}
-		// User-scoped installs may only target the caller. Any write-
-		// access holder could otherwise force an asset to be "global" in
-		// another user's resolved lock file via the user-match rule.
-		// Mirrors the sleuth vault check in sleuth_mgmt.go to avoid a
-		// silent privilege escalation.
-		if manifest.NormalizeEmail(target.User) != actor.Email {
-			return fmt.Errorf("user-scoped installs may only target the authenticated caller (got %q, actor %q)", target.User, actor.Email)
-		}
-		s = manifest.Scope{Kind: manifest.ScopeKindUser, User: target.User}
 	case InstallKindBot:
 		if target.Bot == "" {
 			return errors.New("bot installation missing bot name")
@@ -1251,11 +1243,11 @@ func commonSetAssetInstallations(ctx context.Context, vaultRoot string, actor mg
 // guards against.
 func resolveSetTarget(m *manifest.Manifest, t InstallTarget, actor mgmt.Actor, trusted bool) (manifest.Scope, string) {
 	var s manifest.Scope
-	if trusted && t.Kind == InstallKindUser {
-		if t.User == "" {
-			return manifest.Scope{}, "user installation missing email"
+	if t.Kind == InstallKindUser {
+		var err error
+		if s, err = resolveUserScopeForWrite(t, actor, trusted); err != nil {
+			return manifest.Scope{}, err.Error()
 		}
-		s = manifest.Scope{Kind: manifest.ScopeKindUser, User: t.User}
 	} else {
 		var err error
 		s, err = installTargetScope(t, actor)
@@ -1305,8 +1297,10 @@ func scopeRBACBypassed(ctx context.Context) bool {
 //   - No org-admins configured → ungoverned: anyone may set any scope.
 //   - org-admin → may set any scope.
 //   - team scope → actor must be an admin of THAT team (or an org-admin).
-//   - user scope ("just for me") → always allowed; installTargetScope already
-//     forbids targeting anyone but the caller, so user is self-only.
+//   - user scope ("just for me") → always allowed; resolveUserScopeForWrite
+//     already forbids targeting anyone but the caller for untrusted writes,
+//     so user is self-only (trusted vault-copy bulk writes are the one
+//     exception — see resolveUserScopeForWrite).
 //   - org / repo / path / bot → org-admins only.
 //
 // This is a client-side gate — a file-backed vault can't stop a raw `git push`
@@ -1582,13 +1576,7 @@ func installTargetScope(target InstallTarget, actor mgmt.Actor) (manifest.Scope,
 		}
 		return manifest.Scope{Kind: manifest.ScopeKindTeam, Team: target.Team}, nil
 	case InstallKindUser:
-		if target.User == "" {
-			return manifest.Scope{}, errors.New("user installation missing email")
-		}
-		if manifest.NormalizeEmail(target.User) != actor.Email {
-			return manifest.Scope{}, fmt.Errorf("user-scoped installs may only target the authenticated caller (got %q, actor %q)", target.User, actor.Email)
-		}
-		return manifest.Scope{Kind: manifest.ScopeKindUser, User: target.User}, nil
+		return resolveUserScopeForWrite(target, actor, false)
 	case InstallKindBot:
 		if target.Bot == "" {
 			return manifest.Scope{}, errors.New("bot installation missing bot name")
@@ -1597,6 +1585,25 @@ func installTargetScope(target InstallTarget, actor mgmt.Actor) (manifest.Scope,
 	default:
 		return manifest.Scope{}, fmt.Errorf("unknown installation kind: %q", target.Kind)
 	}
+}
+
+// resolveUserScopeForWrite converts a user install target into its manifest
+// scope. Untrusted writes enforce the self-only rule: user-scoped installs may
+// only target the caller, since any write-access holder could otherwise force
+// an asset to be "global" in another user's resolved lock file via the
+// user-match rule (mirrors the sleuth vault's server-side check). A trusted
+// bulk write (sx vault copy replicating a source vault's existing scopes —
+// see ContextWithTrustedScopeWrite) lifts the restriction: the scope was
+// already valid in the source, so carrying it over faithfully is not the
+// escalation the rule guards against.
+func resolveUserScopeForWrite(target InstallTarget, actor mgmt.Actor, trusted bool) (manifest.Scope, error) {
+	if target.User == "" {
+		return manifest.Scope{}, errors.New("user installation missing email")
+	}
+	if !trusted && manifest.NormalizeEmail(target.User) != actor.Email {
+		return manifest.Scope{}, fmt.Errorf("user-scoped installs may only target the authenticated caller (got %q, actor %q)", target.User, actor.Email)
+	}
+	return manifest.Scope{Kind: manifest.ScopeKindUser, User: target.User}, nil
 }
 
 func installScopeMatches(scopeRow, needle manifest.Scope) bool {

--- a/internal/vault/sleuth.go
+++ b/internal/vault/sleuth.go
@@ -72,13 +72,17 @@ type SleuthVault struct {
 
 	// Lazily fetched org repository listing (GID, owner/name, provider),
 	// shared by provider qualification and GID resolution so one paged
-	// OrgRepositories fetch serves both. orgRepoMisses negative-caches
-	// GIDs a fresh fetch failed to resolve so an unresolvable team repo
-	// can't force a re-pagination on every call. All guarded by orgReposMu;
-	// the rows slice is replaced wholesale on refresh, never mutated.
+	// OrgRepositories fetch serves both. orgReposGen coalesces concurrent
+	// refreshes (a caller that waited out someone else's refetch reuses it).
+	// orgRepoMisses negative-caches prefixed lookups ("id:<gid>",
+	// "name:<owner/name>") a fresh fetch failed to resolve, so an
+	// unresolvable key can't force a re-pagination on every call. All
+	// guarded by orgReposMu; the rows slice is replaced wholesale on
+	// refresh, never mutated.
 	orgReposMu      sync.Mutex
 	orgRepos        []orgRepoRow
 	orgReposFetched bool
+	orgReposGen     uint64
 	orgRepoMisses   map[string]struct{}
 }
 

--- a/internal/vault/sleuth.go
+++ b/internal/vault/sleuth.go
@@ -70,11 +70,16 @@ type SleuthVault struct {
 	pathHandler     *PathSourceHandler
 	gitHandler      *GitSourceHandler
 
-	// Repository GID -> provider, fetched lazily by repoProvidersByID to
-	// host-qualify team repo slugs; guarded by repoProvidersMu.
-	repoProvidersMu      sync.Mutex
-	repoProviders        map[string]string
-	repoProvidersFetched bool
+	// Lazily fetched org repository listing (GID, owner/name, provider),
+	// shared by provider qualification and GID resolution so one paged
+	// OrgRepositories fetch serves both. orgRepoMisses negative-caches
+	// GIDs a fresh fetch failed to resolve so an unresolvable team repo
+	// can't force a re-pagination on every call. All guarded by orgReposMu;
+	// the rows slice is replaced wholesale on refresh, never mutated.
+	orgReposMu      sync.Mutex
+	orgRepos        []orgRepoRow
+	orgReposFetched bool
+	orgRepoMisses   map[string]struct{}
 }
 
 // refreshLockFileCache fetches a fresh lock file from the server and updates the local cache.

--- a/internal/vault/sleuth.go
+++ b/internal/vault/sleuth.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -68,6 +69,12 @@ type SleuthVault struct {
 	httpHandler     *HTTPSourceHandler
 	pathHandler     *PathSourceHandler
 	gitHandler      *GitSourceHandler
+
+	// Repository GID -> provider, fetched lazily by repoProvidersByID to
+	// host-qualify team repo slugs; guarded by repoProvidersMu.
+	repoProvidersMu      sync.Mutex
+	repoProviders        map[string]string
+	repoProvidersFetched bool
 }
 
 // refreshLockFileCache fetches a fresh lock file from the server and updates the local cache.

--- a/internal/vault/sleuth_collection_installs.go
+++ b/internal/vault/sleuth_collection_installs.go
@@ -178,7 +178,7 @@ func (s *SleuthVault) CurrentCollectionInstallTargets(ctx context.Context, name 
 			targets = append(targets, InstallTarget{Kind: InstallKindOrg})
 		case vaultgql.VaultAssetInstallationEntityTypeRepository:
 			targets = append(targets, InstallTarget{
-				Kind: InstallKindRepo, Repo: inst.EntityName,
+				Kind: InstallKindRepo, Repo: providerQualifiedRepo(derefStr(inst.EntityProvider), inst.EntityName),
 				EntityID: entityID, MonoRepoConfigID: derefStr(inst.MonoRepoConfigId),
 			})
 		case vaultgql.VaultAssetInstallationEntityTypeTeam:

--- a/internal/vault/sleuth_collection_installs.go
+++ b/internal/vault/sleuth_collection_installs.go
@@ -82,11 +82,12 @@ func (s *SleuthVault) collectionInstallationInput(ctx context.Context, target In
 // repoGIDByIdentifier resolves a repository URL or owner/name slug to its
 // server GID via the org repository list.
 func (s *SleuthVault) repoGIDByIdentifier(ctx context.Context, identifier string) (string, error) {
-	repos, err := s.orgRepoGIDsByOwnerName(ctx)
+	key := trailingOwnerName(identifier)
+	repos, err := s.orgRepoGIDsByOwnerName(ctx, key)
 	if err != nil {
 		return "", err
 	}
-	if gid, ok := repos[trailingOwnerName(identifier)]; ok {
+	if gid, ok := repos[key]; ok {
 		return gid, nil
 	}
 	return "", fmt.Errorf("repository %q not found in this vault's organization", identifier)

--- a/internal/vault/sleuth_collection_installs_test.go
+++ b/internal/vault/sleuth_collection_installs_test.go
@@ -127,6 +127,10 @@ func TestSleuthVault_CurrentCollectionInstallTargets(t *testing.T) {
 							"entityType": "TEAM", "entityName": "platform",
 							"entityRef": nil, "entityId": "TM1", "monoRepoConfigId": nil,
 						},
+						map[string]any{
+							"entityType": "REPOSITORY", "entityName": "acme/tools",
+							"entityRef": nil, "entityProvider": "github", "entityId": "RP1", "monoRepoConfigId": nil,
+						},
 					},
 				},
 			}
@@ -138,14 +142,18 @@ func TestSleuthVault_CurrentCollectionInstallTargets(t *testing.T) {
 	if err != nil || !present {
 		t.Fatalf("CurrentCollectionInstallTargets: present=%v err=%v", present, err)
 	}
-	if len(targets) != 2 {
-		t.Fatalf("targets = %+v, want org + team", targets)
+	if len(targets) != 3 {
+		t.Fatalf("targets = %+v, want org + team + repo", targets)
 	}
 	if targets[0].Kind != InstallKindOrg {
 		t.Fatalf("targets[0] = %+v, want org", targets[0])
 	}
 	if targets[1].Kind != InstallKindTeam || targets[1].Team != "platform" || targets[1].EntityID != "TM1" {
 		t.Fatalf("targets[1] = %+v, want team platform/TM1", targets[1])
+	}
+	// Repo rows come back host-qualified via the entity's provider.
+	if targets[2].Kind != InstallKindRepo || targets[2].Repo != "github.com/acme/tools" {
+		t.Fatalf("targets[2] = %+v, want repo github.com/acme/tools", targets[2])
 	}
 
 	// Unknown collection reports not-present, not an error.

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -111,24 +111,35 @@ func gqlTeamNodeToSleuthNode(n vaultgql.ListTeamsOrganizationOrganizationTypeTea
 }
 
 // repoProvidersByID returns the org's repository GID -> provider map, fetched
-// once per vault instance and only when some team actually carries
-// repositories (skillsRepositories expose no provider of their own). A fetch
-// failure degrades to bare owner/name slugs rather than failing the listing.
+// lazily and only when some team actually carries repositories
+// (skillsRepositories expose no provider of their own). The map is cached on
+// the vault instance; a cached map that doesn't cover every team repo GID —
+// a repository connected after the first fetch, in a long-lived process —
+// triggers one refetch. A fetch failure degrades to bare owner/name slugs
+// rather than failing the listing.
 func (s *SleuthVault) repoProvidersByID(ctx context.Context, nodes []vaultgql.ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) map[string]string {
-	needed := false
+	var repoIDs []string
 	for _, n := range nodes {
-		if len(n.SkillsRepositories) > 0 {
-			needed = true
-			break
+		for _, r := range n.SkillsRepositories {
+			repoIDs = append(repoIDs, r.RepositoryId)
 		}
 	}
-	if !needed {
+	if len(repoIDs) == 0 {
 		return nil
 	}
 	s.repoProvidersMu.Lock()
 	defer s.repoProvidersMu.Unlock()
 	if s.repoProvidersFetched {
-		return s.repoProviders
+		covered := true
+		for _, id := range repoIDs {
+			if _, ok := s.repoProviders[id]; !ok {
+				covered = false
+				break
+			}
+		}
+		if covered {
+			return s.repoProviders
+		}
 	}
 	const pageSize = 50
 	out := map[string]string{}
@@ -392,12 +403,15 @@ func (s *SleuthVault) setTeamRepositories(ctx context.Context, team, repoURL str
 // hosts. The server identifies repositories only as provider + "owner/name"
 // and exposes no URL, so this mapping is the only way a client can produce
 // a repo row that matches a real git remote (scope matching compares
-// normalized "host/owner/name" forms). Unknown or self-hosted providers
-// keep the bare owner/name slug — a row that can't match is still better
-// than one pointing at the wrong host.
+// normalized "host/owner/name" forms). Only providers the server guarantees
+// are SaaS-hosted belong here: "github" (self-hosted is the distinct
+// "github_enterprise" provider) and "bitbucket" (the server's bitbucket
+// provider is hardcoded to Bitbucket Cloud). "gitlab" is deliberately
+// absent — the same provider value covers self-managed GitLab, and an
+// unmapped provider's bare owner/name slug (a row that can't match) is
+// still better than one pointing at the wrong host.
 var providerRepoHosts = map[string]string{
 	"github":    "github.com",
-	"gitlab":    "gitlab.com",
 	"bitbucket": "bitbucket.org",
 }
 

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -147,7 +147,12 @@ func (s *SleuthVault) repoProvidersByID(ctx context.Context, nodes []vaultgql.Li
 	for {
 		resp, err := vaultgql.OrgRepositories(ctx, s.gqlClient(), pageSize, after)
 		if err != nil {
-			logger.Get().Warn("could not resolve repository providers; team repos keep bare owner/name slugs", "error", err)
+			logger.Get().Warn("could not resolve repository providers; unresolved team repos keep bare owner/name slugs", "error", err)
+			// A stale cache still qualifies the repos it does know about —
+			// strictly better than degrading every slug on a failed refetch.
+			if s.repoProvidersFetched {
+				return s.repoProviders
+			}
 			return nil
 		}
 		conn := resp.Organization.Repositories

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -54,8 +54,9 @@ func (s *SleuthVault) ListTeams(ctx context.Context, opts ListTeamsOptions) (*Li
 	}
 	conn := resp.Organization.Teams
 	teams := make([]mgmt.Team, 0, len(conn.Nodes))
+	providers := s.repoProvidersByID(ctx, conn.Nodes)
 	for _, n := range conn.Nodes {
-		teams = append(teams, sleuthTeamToMgmt(gqlTeamNodeToSleuthNode(n)))
+		teams = append(teams, sleuthTeamToMgmt(gqlTeamNodeToSleuthNode(n), providers))
 	}
 	return &ListTeamsResult{
 		Teams:      teams,
@@ -104,9 +105,54 @@ func gqlTeamNodeToSleuthNode(n vaultgql.ListTeamsOrganizationOrganizationTypeTea
 		node.Members = append(node.Members, sleuthTeamMember{ID: m.Id, Email: m.Email})
 	}
 	for _, r := range n.SkillsRepositories {
-		node.Repositories = append(node.Repositories, r.Owner+"/"+r.Name)
+		node.Repositories = append(node.Repositories, sleuthTeamRepo{ID: r.RepositoryId, OwnerName: r.Owner + "/" + r.Name})
 	}
 	return node
+}
+
+// repoProvidersByID returns the org's repository GID -> provider map, fetched
+// once per vault instance and only when some team actually carries
+// repositories (skillsRepositories expose no provider of their own). A fetch
+// failure degrades to bare owner/name slugs rather than failing the listing.
+func (s *SleuthVault) repoProvidersByID(ctx context.Context, nodes []vaultgql.ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) map[string]string {
+	needed := false
+	for _, n := range nodes {
+		if len(n.SkillsRepositories) > 0 {
+			needed = true
+			break
+		}
+	}
+	if !needed {
+		return nil
+	}
+	s.repoProvidersMu.Lock()
+	defer s.repoProvidersMu.Unlock()
+	if s.repoProvidersFetched {
+		return s.repoProviders
+	}
+	const pageSize = 50
+	out := map[string]string{}
+	var after *string
+	for {
+		resp, err := vaultgql.OrgRepositories(ctx, s.gqlClient(), pageSize, after)
+		if err != nil {
+			logger.Get().Warn("could not resolve repository providers; team repos keep bare owner/name slugs", "error", err)
+			return nil
+		}
+		conn := resp.Organization.Repositories
+		for _, n := range conn.Nodes {
+			if n.Id == nil {
+				continue
+			}
+			out[*n.Id] = n.Provider
+		}
+		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+			break
+		}
+		after = conn.PageInfo.EndCursor
+	}
+	s.repoProviders, s.repoProvidersFetched = out, true
+	return out
 }
 
 func (s *SleuthVault) GetTeam(ctx context.Context, name string) (*mgmt.Team, error) {
@@ -340,6 +386,29 @@ func (s *SleuthVault) setTeamRepositories(ctx context.Context, team, repoURL str
 		return nil
 	}
 	return gqlMutationErrors(resp.UpdateTeam.Errors)
+}
+
+// providerRepoHosts maps skills.new integration providers to their SaaS
+// hosts. The server identifies repositories only as provider + "owner/name"
+// and exposes no URL, so this mapping is the only way a client can produce
+// a repo row that matches a real git remote (scope matching compares
+// normalized "host/owner/name" forms). Unknown or self-hosted providers
+// keep the bare owner/name slug — a row that can't match is still better
+// than one pointing at the wrong host.
+var providerRepoHosts = map[string]string{
+	"github":    "github.com",
+	"gitlab":    "gitlab.com",
+	"bitbucket": "bitbucket.org",
+}
+
+// providerQualifiedRepo prefixes an "owner/name" slug with the provider's
+// host when the provider is a known SaaS, so downstream consumers (lock
+// resolution, vault copy) get a repo row that matches real remotes.
+func providerQualifiedRepo(provider, ownerName string) string {
+	if host, ok := providerRepoHosts[strings.ToLower(strings.TrimSpace(provider))]; ok {
+		return host + "/" + ownerName
+	}
+	return ownerName
 }
 
 // orgRepoGIDsByOwnerName pages the organization's repositories into a map
@@ -591,13 +660,13 @@ func (s *SleuthVault) CurrentInstallTargets(ctx context.Context, name string) ([
 				}
 				if len(paths) > 0 {
 					targets = append(targets, InstallTarget{
-						Kind: InstallKindPath, Repo: inst.EntityName, Paths: paths,
+						Kind: InstallKindPath, Repo: providerQualifiedRepo(derefStr(inst.EntityProvider), inst.EntityName), Paths: paths,
 						EntityID: entityID, MonoRepoConfigID: derefStr(inst.MonoRepoConfigId),
 					})
 					continue
 				}
 			}
-			targets = append(targets, InstallTarget{Kind: InstallKindRepo, Repo: inst.EntityName, EntityID: entityID})
+			targets = append(targets, InstallTarget{Kind: InstallKindRepo, Repo: providerQualifiedRepo(derefStr(inst.EntityProvider), inst.EntityName), EntityID: entityID})
 		case vaultgql.VaultAssetInstallationEntityTypeTeam:
 			targets = append(targets, InstallTarget{Kind: InstallKindTeam, Team: inst.EntityName, EntityID: entityID})
 		case vaultgql.VaultAssetInstallationEntityTypeUser:
@@ -1834,7 +1903,14 @@ type sleuthTeamNode struct {
 	Admins       []string // emails from adminMembers
 	Members      []sleuthTeamMember
 	MemberCount  int
-	Repositories []string // owner/name slugs
+	Repositories []sleuthTeamRepo
+}
+
+// sleuthTeamRepo pairs a team repository's server GID with its owner/name
+// slug so the provider host can be resolved when converting to mgmt.Team.
+type sleuthTeamRepo struct {
+	ID        string
+	OwnerName string
 }
 
 type sleuthMutationError struct {
@@ -1842,7 +1918,7 @@ type sleuthMutationError struct {
 	Messages []string `json:"messages"`
 }
 
-func sleuthTeamToMgmt(node sleuthTeamNode) mgmt.Team {
+func sleuthTeamToMgmt(node sleuthTeamNode, providers map[string]string) mgmt.Team {
 	team := mgmt.Team{Name: node.Name, MemberCount: node.MemberCount}
 	for _, m := range node.Members {
 		team.Members = append(team.Members, mgmt.NormalizeEmail(m.Email))
@@ -1850,7 +1926,9 @@ func sleuthTeamToMgmt(node sleuthTeamNode) mgmt.Team {
 	for _, email := range node.Admins {
 		team.Admins = append(team.Admins, mgmt.NormalizeEmail(email))
 	}
-	team.Repositories = append(team.Repositories, node.Repositories...)
+	for _, r := range node.Repositories {
+		team.Repositories = append(team.Repositories, providerQualifiedRepo(providers[r.ID], r.OwnerName))
+	}
 	return team
 }
 

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -110,13 +110,69 @@ func gqlTeamNodeToSleuthNode(n vaultgql.ListTeamsOrganizationOrganizationTypeTea
 	return node
 }
 
-// repoProvidersByID returns the org's repository GID -> provider map, fetched
-// lazily and only when some team actually carries repositories
-// (skillsRepositories expose no provider of their own). The map is cached on
-// the vault instance; a cached map that doesn't cover every team repo GID —
-// a repository connected after the first fetch, in a long-lived process —
-// triggers one refetch. A fetch failure degrades to bare owner/name slugs
-// rather than failing the listing.
+// orgRepoRow is one repository from the org's paged OrgRepositories listing,
+// carrying everything both consumers need: GID resolution for team-repo
+// mutations and provider lookup for host-qualifying repo slugs.
+type orgRepoRow struct {
+	GID       string
+	OwnerName string // lowercase "owner/name"
+	Provider  string
+}
+
+// fetchOrgRepos pages the whole OrgRepositories connection once.
+func (s *SleuthVault) fetchOrgRepos(ctx context.Context) ([]orgRepoRow, error) {
+	const pageSize = 50
+	var rows []orgRepoRow
+	var after *string
+	for {
+		resp, err := vaultgql.OrgRepositories(ctx, s.gqlClient(), pageSize, after)
+		if err != nil {
+			return nil, err
+		}
+		conn := resp.Organization.Repositories
+		for _, n := range conn.Nodes {
+			if n.Id == nil {
+				continue
+			}
+			rows = append(rows, orgRepoRow{
+				GID:       *n.Id,
+				OwnerName: strings.ToLower(n.Owner + "/" + n.Name),
+				Provider:  n.Provider,
+			})
+		}
+		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+			return rows, nil
+		}
+		after = conn.PageInfo.EndCursor
+	}
+}
+
+// orgRepoRows returns the cached org repository listing, fetching it on
+// first use (or when refresh forces a refetch, used by callers that missed a
+// lookup and must rule out staleness). fresh reports whether the returned
+// rows come from a fetch this call performed. On a fetch failure the
+// previously cached rows are returned alongside the error so callers can
+// degrade instead of losing data they already had.
+func (s *SleuthVault) orgRepoRows(ctx context.Context, refresh bool) (rows []orgRepoRow, fresh bool, err error) {
+	s.orgReposMu.Lock()
+	defer s.orgReposMu.Unlock()
+	if s.orgReposFetched && !refresh {
+		return s.orgRepos, false, nil
+	}
+	fetched, err := s.fetchOrgRepos(ctx)
+	if err != nil {
+		return s.orgRepos, false, err
+	}
+	s.orgRepos, s.orgReposFetched = fetched, true
+	return fetched, true, nil
+}
+
+// repoProvidersByID returns a repository GID -> provider map covering the
+// given teams' repositories, backed by the shared org repo cache. A GID
+// absent from the cache triggers at most one refetch; GIDs a fresh listing
+// still doesn't return (deleted or access-filtered repos) are negative-cached
+// so they can't force a re-pagination on every call. A fetch failure degrades
+// to bare owner/name slugs rather than failing the listing.
 func (s *SleuthVault) repoProvidersByID(ctx context.Context, nodes []vaultgql.ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) map[string]string {
 	var repoIDs []string
 	for _, n := range nodes {
@@ -127,48 +183,64 @@ func (s *SleuthVault) repoProvidersByID(ctx context.Context, nodes []vaultgql.Li
 	if len(repoIDs) == 0 {
 		return nil
 	}
-	s.repoProvidersMu.Lock()
-	defer s.repoProvidersMu.Unlock()
-	if s.repoProvidersFetched {
-		covered := true
-		for _, id := range repoIDs {
-			if _, ok := s.repoProviders[id]; !ok {
-				covered = false
-				break
-			}
-		}
-		if covered {
-			return s.repoProviders
-		}
+	rows, fresh, err := s.orgRepoRows(ctx, false)
+	if err != nil {
+		logger.Get().Warn("could not resolve repository providers; unresolved team repos keep bare owner/name slugs", "error", err)
 	}
-	const pageSize = 50
-	out := map[string]string{}
-	var after *string
-	for {
-		resp, err := vaultgql.OrgRepositories(ctx, s.gqlClient(), pageSize, after)
-		if err != nil {
-			logger.Get().Warn("could not resolve repository providers; unresolved team repos keep bare owner/name slugs", "error", err)
-			// A stale cache still qualifies the repos it does know about —
-			// strictly better than degrading every slug on a failed refetch.
-			if s.repoProvidersFetched {
-				return s.repoProviders
-			}
-			return nil
+	providers := make(map[string]string, len(rows))
+	for _, r := range rows {
+		providers[r.GID] = r.Provider
+	}
+	if err != nil || fresh {
+		s.recordOrgRepoMisses(repoIDs, providers, err == nil)
+		return providers
+	}
+	// Cache hit with a gap: refetch once unless a fresh listing already
+	// proved the GID unresolvable.
+	missing := false
+	s.orgReposMu.Lock()
+	for _, id := range repoIDs {
+		if _, ok := providers[id]; ok {
+			continue
 		}
-		conn := resp.Organization.Repositories
-		for _, n := range conn.Nodes {
-			if n.Id == nil {
-				continue
-			}
-			out[*n.Id] = n.Provider
-		}
-		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+		if _, miss := s.orgRepoMisses[id]; !miss {
+			missing = true
 			break
 		}
-		after = conn.PageInfo.EndCursor
 	}
-	s.repoProviders, s.repoProvidersFetched = out, true
-	return out
+	s.orgReposMu.Unlock()
+	if !missing {
+		return providers
+	}
+	rows, _, err = s.orgRepoRows(ctx, true)
+	if err != nil {
+		logger.Get().Warn("could not resolve repository providers; unresolved team repos keep bare owner/name slugs", "error", err)
+	}
+	providers = make(map[string]string, len(rows))
+	for _, r := range rows {
+		providers[r.GID] = r.Provider
+	}
+	s.recordOrgRepoMisses(repoIDs, providers, err == nil)
+	return providers
+}
+
+// recordOrgRepoMisses negative-caches requested GIDs a fresh org listing did
+// not resolve. Only called with resolved=true after an error-free fetch — a
+// failed fetch proves nothing about the GIDs.
+func (s *SleuthVault) recordOrgRepoMisses(repoIDs []string, providers map[string]string, resolved bool) {
+	if !resolved {
+		return
+	}
+	s.orgReposMu.Lock()
+	defer s.orgReposMu.Unlock()
+	for _, id := range repoIDs {
+		if _, ok := providers[id]; !ok {
+			if s.orgRepoMisses == nil {
+				s.orgRepoMisses = map[string]struct{}{}
+			}
+			s.orgRepoMisses[id] = struct{}{}
+		}
+	}
 }
 
 func (s *SleuthVault) GetTeam(ctx context.Context, name string) (*mgmt.Team, error) {
@@ -341,12 +413,11 @@ func (s *SleuthVault) setTeamRepositories(ctx context.Context, team, repoURL str
 	if err != nil {
 		return err
 	}
-	repoMap, err := s.orgRepoGIDsByOwnerName(ctx)
+	targetKey := trailingOwnerName(repoURL)
+	repoMap, err := s.orgRepoGIDsByOwnerName(ctx, targetKey)
 	if err != nil {
 		return err
 	}
-
-	targetKey := trailingOwnerName(repoURL)
 	if add {
 		if _, ok := repoMap[targetKey]; !ok {
 			return fmt.Errorf("repository %q not found in the skills.new organization", repoURL)
@@ -430,31 +501,52 @@ func providerQualifiedRepo(provider, ownerName string) string {
 	return ownerName
 }
 
-// orgRepoGIDsByOwnerName pages the organization's repositories into a map
-// keyed by lowercase "owner/name" -> repository GID, used to resolve repo
-// identifiers (URLs or slugs) to the GIDs updateTeam needs.
-func (s *SleuthVault) orgRepoGIDsByOwnerName(ctx context.Context) (map[string]string, error) {
-	const pageSize = 50
-	out := map[string]string{}
-	var after *string
-	for {
-		resp, err := vaultgql.OrgRepositories(ctx, s.gqlClient(), pageSize, after)
-		if err != nil {
-			return nil, err
+// unqualifyProviderRepo undoes providerQualifiedRepo on the way back INTO the
+// server: a row starting with a known SaaS host segment reduces to the bare
+// owner/name slug skills.new round-trips as entityName. Anything else — bare
+// slugs, full URLs from user input, hosts we never add — passes through
+// untouched, so this only strips exactly what qualification added.
+func unqualifyProviderRepo(repo string) string {
+	for _, host := range providerRepoHosts {
+		if rest, ok := strings.CutPrefix(repo, host+"/"); ok && rest != "" {
+			return rest
 		}
-		conn := resp.Organization.Repositories
-		for _, n := range conn.Nodes {
-			if n.Id == nil {
+	}
+	return repo
+}
+
+// orgRepoGIDsByOwnerName returns a lowercase "owner/name" -> repository GID
+// map from the shared org repo cache, used to resolve repo identifiers (URLs
+// or slugs) to the GIDs updateTeam needs. When any of needKeys (already in
+// owner/name form) is absent from the cached listing, the listing is
+// refetched once so a repository connected after the first fetch still
+// resolves; a key missing from a fresh listing is genuinely unknown.
+func (s *SleuthVault) orgRepoGIDsByOwnerName(ctx context.Context, needKeys ...string) (map[string]string, error) {
+	rows, fresh, err := s.orgRepoRows(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	gids := make(map[string]string, len(rows))
+	for _, r := range rows {
+		gids[r.OwnerName] = r.GID
+	}
+	if !fresh {
+		for _, key := range needKeys {
+			if _, ok := gids[key]; ok {
 				continue
 			}
-			out[strings.ToLower(n.Owner+"/"+n.Name)] = *n.Id
-		}
-		if !conn.PageInfo.HasNextPage || conn.PageInfo.EndCursor == nil {
+			rows, _, err = s.orgRepoRows(ctx, true)
+			if err != nil {
+				return nil, err
+			}
+			gids = make(map[string]string, len(rows))
+			for _, r := range rows {
+				gids[r.OwnerName] = r.GID
+			}
 			break
 		}
-		after = conn.PageInfo.EndCursor
 	}
-	return out, nil
+	return gids, nil
 }
 
 // trailingOwnerName reduces a repo identifier (a full URL, an "owner/name"
@@ -561,9 +653,13 @@ func (s *SleuthVault) SetAssetInstallations(ctx context.Context, assetName strin
 		case InstallKindOrg:
 			// Handled before the loop (org is exclusive); unreachable here.
 		case InstallKindRepo:
-			repositories = append(repositories, vaultgql.RepositoryInstallationInput{Url: t.Repo})
+			// CurrentInstallTargets returns host-qualified slugs
+			// ("github.com/acme/tools"); reduce back to the bare owner/name
+			// form the server is known to accept (it round-trips entityName
+			// that way) before sending. User-typed URLs pass through as before.
+			repositories = append(repositories, vaultgql.RepositoryInstallationInput{Url: unqualifyProviderRepo(t.Repo)})
 		case InstallKindPath:
-			repositories = append(repositories, vaultgql.RepositoryInstallationInput{Url: t.Repo, Paths: t.Paths})
+			repositories = append(repositories, vaultgql.RepositoryInstallationInput{Url: unqualifyProviderRepo(t.Repo), Paths: t.Paths})
 		case InstallKindTeam:
 			gid, gerr := s.teamGIDByName(ctx, t.Team)
 			if gerr != nil {

--- a/internal/vault/sleuth_mgmt.go
+++ b/internal/vault/sleuth_mgmt.go
@@ -148,31 +148,81 @@ func (s *SleuthVault) fetchOrgRepos(ctx context.Context) ([]orgRepoRow, error) {
 }
 
 // orgRepoRows returns the cached org repository listing, fetching it on
-// first use (or when refresh forces a refetch, used by callers that missed a
-// lookup and must rule out staleness). fresh reports whether the returned
-// rows come from a fetch this call performed. On a fetch failure the
-// previously cached rows are returned alongside the error so callers can
-// degrade instead of losing data they already had.
-func (s *SleuthVault) orgRepoRows(ctx context.Context, refresh bool) (rows []orgRepoRow, fresh bool, err error) {
+// first use. fresh reports whether the returned rows come from a fetch, and
+// gen identifies the cache generation for refreshOrgRepos coalescing. On a
+// fetch failure the previously cached rows are returned alongside the error
+// so callers can degrade instead of losing data they already had.
+func (s *SleuthVault) orgRepoRows(ctx context.Context) (rows []orgRepoRow, fresh bool, gen uint64, err error) {
 	s.orgReposMu.Lock()
 	defer s.orgReposMu.Unlock()
-	if s.orgReposFetched && !refresh {
-		return s.orgRepos, false, nil
+	if s.orgReposFetched {
+		return s.orgRepos, false, s.orgReposGen, nil
 	}
+	return s.refetchOrgReposLocked(ctx)
+}
+
+// refreshOrgRepos refetches the listing for a caller that missed a lookup in
+// generation sinceGen — unless another caller already refreshed the cache in
+// the meantime, in which case the newer rows are returned without re-paging
+// (they count as fresh: they postdate the observation that missed).
+func (s *SleuthVault) refreshOrgRepos(ctx context.Context, sinceGen uint64) (rows []orgRepoRow, fresh bool, gen uint64, err error) {
+	s.orgReposMu.Lock()
+	defer s.orgReposMu.Unlock()
+	if s.orgReposFetched && s.orgReposGen != sinceGen {
+		return s.orgRepos, true, s.orgReposGen, nil
+	}
+	return s.refetchOrgReposLocked(ctx)
+}
+
+func (s *SleuthVault) refetchOrgReposLocked(ctx context.Context) ([]orgRepoRow, bool, uint64, error) {
 	fetched, err := s.fetchOrgRepos(ctx)
 	if err != nil {
-		return s.orgRepos, false, err
+		return s.orgRepos, false, s.orgReposGen, err
 	}
 	s.orgRepos, s.orgReposFetched = fetched, true
-	return fetched, true, nil
+	s.orgReposGen++
+	return fetched, true, s.orgReposGen, nil
+}
+
+// orgRepoMissUnproven reports whether any key is absent from present without
+// a fresh listing having already disproved it (see recordOrgRepoMisses).
+// prefix namespaces the shared miss set: "id:" for GIDs, "name:" for
+// owner/name slugs.
+func (s *SleuthVault) orgRepoMissUnproven(prefix string, keys []string, present map[string]string) bool {
+	s.orgReposMu.Lock()
+	defer s.orgReposMu.Unlock()
+	for _, k := range keys {
+		if _, ok := present[k]; ok {
+			continue
+		}
+		if _, miss := s.orgRepoMisses[prefix+k]; !miss {
+			return true
+		}
+	}
+	return false
+}
+
+// recordOrgRepoMisses negative-caches requested keys a fresh, error-free org
+// listing did not resolve, so a permanently unresolvable key (deleted or
+// access-filtered repo) can't force a re-pagination on every lookup.
+func (s *SleuthVault) recordOrgRepoMisses(prefix string, keys []string, present map[string]string) {
+	s.orgReposMu.Lock()
+	defer s.orgReposMu.Unlock()
+	for _, k := range keys {
+		if _, ok := present[k]; !ok {
+			if s.orgRepoMisses == nil {
+				s.orgRepoMisses = map[string]struct{}{}
+			}
+			s.orgRepoMisses[prefix+k] = struct{}{}
+		}
+	}
 }
 
 // repoProvidersByID returns a repository GID -> provider map covering the
 // given teams' repositories, backed by the shared org repo cache. A GID
-// absent from the cache triggers at most one refetch; GIDs a fresh listing
-// still doesn't return (deleted or access-filtered repos) are negative-cached
-// so they can't force a re-pagination on every call. A fetch failure degrades
-// to bare owner/name slugs rather than failing the listing.
+// absent from the cache triggers at most one refetch ever (misses are
+// negative-cached). A fetch failure degrades to bare owner/name slugs rather
+// than failing the listing.
 func (s *SleuthVault) repoProvidersByID(ctx context.Context, nodes []vaultgql.ListTeamsOrganizationOrganizationTypeTeamsTeamsConnectionNodesTeam) map[string]string {
 	var repoIDs []string
 	for _, n := range nodes {
@@ -183,64 +233,30 @@ func (s *SleuthVault) repoProvidersByID(ctx context.Context, nodes []vaultgql.Li
 	if len(repoIDs) == 0 {
 		return nil
 	}
-	rows, fresh, err := s.orgRepoRows(ctx, false)
+	providerMap := func(rows []orgRepoRow) map[string]string {
+		m := make(map[string]string, len(rows))
+		for _, r := range rows {
+			m[r.GID] = r.Provider
+		}
+		return m
+	}
+	rows, fresh, gen, err := s.orgRepoRows(ctx)
 	if err != nil {
 		logger.Get().Warn("could not resolve repository providers; unresolved team repos keep bare owner/name slugs", "error", err)
 	}
-	providers := make(map[string]string, len(rows))
-	for _, r := range rows {
-		providers[r.GID] = r.Provider
-	}
-	if err != nil || fresh {
-		s.recordOrgRepoMisses(repoIDs, providers, err == nil)
-		return providers
-	}
-	// Cache hit with a gap: refetch once unless a fresh listing already
-	// proved the GID unresolvable.
-	missing := false
-	s.orgReposMu.Lock()
-	for _, id := range repoIDs {
-		if _, ok := providers[id]; ok {
-			continue
-		}
-		if _, miss := s.orgRepoMisses[id]; !miss {
-			missing = true
-			break
+	providers := providerMap(rows)
+	if err == nil && !fresh && s.orgRepoMissUnproven("id:", repoIDs, providers) {
+		rows, fresh, _, err = s.refreshOrgRepos(ctx, gen)
+		if err != nil {
+			logger.Get().Warn("could not resolve repository providers; unresolved team repos keep bare owner/name slugs", "error", err)
+		} else {
+			providers = providerMap(rows)
 		}
 	}
-	s.orgReposMu.Unlock()
-	if !missing {
-		return providers
+	if err == nil && fresh {
+		s.recordOrgRepoMisses("id:", repoIDs, providers)
 	}
-	rows, _, err = s.orgRepoRows(ctx, true)
-	if err != nil {
-		logger.Get().Warn("could not resolve repository providers; unresolved team repos keep bare owner/name slugs", "error", err)
-	}
-	providers = make(map[string]string, len(rows))
-	for _, r := range rows {
-		providers[r.GID] = r.Provider
-	}
-	s.recordOrgRepoMisses(repoIDs, providers, err == nil)
 	return providers
-}
-
-// recordOrgRepoMisses negative-caches requested GIDs a fresh org listing did
-// not resolve. Only called with resolved=true after an error-free fetch — a
-// failed fetch proves nothing about the GIDs.
-func (s *SleuthVault) recordOrgRepoMisses(repoIDs []string, providers map[string]string, resolved bool) {
-	if !resolved {
-		return
-	}
-	s.orgReposMu.Lock()
-	defer s.orgReposMu.Unlock()
-	for _, id := range repoIDs {
-		if _, ok := providers[id]; !ok {
-			if s.orgRepoMisses == nil {
-				s.orgRepoMisses = map[string]struct{}{}
-			}
-			s.orgRepoMisses[id] = struct{}{}
-		}
-	}
 }
 
 func (s *SleuthVault) GetTeam(ctx context.Context, name string) (*mgmt.Team, error) {
@@ -520,31 +536,30 @@ func unqualifyProviderRepo(repo string) string {
 // or slugs) to the GIDs updateTeam needs. When any of needKeys (already in
 // owner/name form) is absent from the cached listing, the listing is
 // refetched once so a repository connected after the first fetch still
-// resolves; a key missing from a fresh listing is genuinely unknown.
+// resolves; keys a fresh listing already failed to resolve are
+// negative-cached and don't trigger another refetch.
 func (s *SleuthVault) orgRepoGIDsByOwnerName(ctx context.Context, needKeys ...string) (map[string]string, error) {
-	rows, fresh, err := s.orgRepoRows(ctx, false)
+	gidMap := func(rows []orgRepoRow) map[string]string {
+		m := make(map[string]string, len(rows))
+		for _, r := range rows {
+			m[r.OwnerName] = r.GID
+		}
+		return m
+	}
+	rows, fresh, gen, err := s.orgRepoRows(ctx)
 	if err != nil {
 		return nil, err
 	}
-	gids := make(map[string]string, len(rows))
-	for _, r := range rows {
-		gids[r.OwnerName] = r.GID
-	}
-	if !fresh {
-		for _, key := range needKeys {
-			if _, ok := gids[key]; ok {
-				continue
-			}
-			rows, _, err = s.orgRepoRows(ctx, true)
-			if err != nil {
-				return nil, err
-			}
-			gids = make(map[string]string, len(rows))
-			for _, r := range rows {
-				gids[r.OwnerName] = r.GID
-			}
-			break
+	gids := gidMap(rows)
+	if !fresh && s.orgRepoMissUnproven("name:", needKeys, gids) {
+		rows, fresh, _, err = s.refreshOrgRepos(ctx, gen)
+		if err != nil {
+			return nil, err
 		}
+		gids = gidMap(rows)
+	}
+	if fresh {
+		s.recordOrgRepoMisses("name:", needKeys, gids)
 	}
 	return gids, nil
 }
@@ -576,9 +591,9 @@ func (s *SleuthVault) SetAssetInstallation(ctx context.Context, assetName string
 	case InstallKindOrg:
 		return s.setAssetInstallationsGraphQL(ctx, assetName, nil, false, nil, false)
 	case InstallKindRepo:
-		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: target.Repo}}, false, nil, false)
+		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: unqualifyProviderRepo(target.Repo)}}, false, nil, false)
 	case InstallKindPath:
-		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: target.Repo, Paths: target.Paths}}, false, nil, false)
+		return s.setAssetInstallationsGraphQL(ctx, assetName, []vaultgql.RepositoryInstallationInput{{Url: unqualifyProviderRepo(target.Repo), Paths: target.Paths}}, false, nil, false)
 	case InstallKindUser:
 		// The setAssetInstallations `installations` input now accepts an explicit
 		// USER target by GID, so we can scope to any user in the org (not just the

--- a/internal/vault/sleuth_test.go
+++ b/internal/vault/sleuth_test.go
@@ -1270,3 +1270,59 @@ func TestSleuthVault_GetAssetDetails_ByName(t *testing.T) {
 		t.Errorf("second request should be the name search, got: %+v", (*records)[1].Variables)
 	}
 }
+
+// CurrentInstallTargets must host-qualify repo and path rows via the
+// installation entity's provider — this read feeds the scope editors and
+// `sx vault copy`, where a bare owner/name slug can never match a real git
+// remote (the exact loss that killed repo-scoped installs after migrating
+// to a file vault).
+func TestSleuthVault_CurrentInstallTargets_QualifiesRepoRows(t *testing.T) {
+	srv, _ := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"AssetInstallations": func(map[string]any) any {
+			return map[string]any{"vault": map[string]any{"assets": map[string]any{
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": nil},
+				"nodes": []any{map[string]any{
+					"__typename": "Skill",
+					"slug":       "my-skill",
+					"name":       "My skill",
+					"installations": []any{
+						map[string]any{
+							"entityType": "REPOSITORY", "entityName": "acme/tools",
+							"entityRef": nil, "entityProvider": "github", "entityId": "RP1",
+							"monoRepoConfigId": nil, "viaCollectionId": nil,
+						},
+						map[string]any{
+							"entityType": "REPOSITORY", "entityName": "acme/mono",
+							"entityRef": nil, "entityProvider": "github", "entityId": "RP2",
+							"monoRepoConfigId": "MC1", "viaCollectionId": nil,
+						},
+					},
+				}},
+			}}}
+		},
+		"RepoMonoRepoConfigs": func(vars map[string]any) any {
+			if vars["id"] != "RP2" {
+				t.Fatalf("RepoMonoRepoConfigs id = %v, want RP2", vars["id"])
+			}
+			return map[string]any{"repository": map[string]any{"monoRepoConfigs": []any{
+				map[string]any{"id": "MC1", "sourcePathPrefixIncludes": []any{"services/api"}},
+			}}}
+		},
+	})
+
+	v := NewSleuthVault(srv.URL, "token")
+	targets, present, err := v.CurrentInstallTargets(context.Background(), "my-skill")
+	if err != nil || !present {
+		t.Fatalf("CurrentInstallTargets: present=%v err=%v", present, err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("targets = %+v, want repo + path", targets)
+	}
+	if targets[0].Kind != InstallKindRepo || targets[0].Repo != "github.com/acme/tools" {
+		t.Fatalf("targets[0] = %+v, want repo github.com/acme/tools", targets[0])
+	}
+	if targets[1].Kind != InstallKindPath || targets[1].Repo != "github.com/acme/mono" ||
+		len(targets[1].Paths) != 1 || targets[1].Paths[0] != "services/api" {
+		t.Fatalf("targets[1] = %+v, want path github.com/acme/mono [services/api]", targets[1])
+	}
+}

--- a/internal/vault/sleuth_test.go
+++ b/internal/vault/sleuth_test.go
@@ -104,6 +104,18 @@ func TestSleuthVault_ListTeams_QueryShape(t *testing.T) {
 				},
 			}
 		},
+		"OrgRepositories": func(vars map[string]any) any {
+			return map[string]any{
+				"organization": map[string]any{
+					"repositories": map[string]any{
+						"pageInfo": map[string]any{"hasNextPage": false, "endCursor": nil},
+						"nodes": []any{
+							map[string]any{"id": "repo-9", "owner": "org", "name": "repo-9", "provider": "github"},
+						},
+					},
+				},
+			}
+		},
 	})
 
 	v := NewSleuthVault(srv.URL, "test-token")
@@ -114,8 +126,12 @@ func TestSleuthVault_ListTeams_QueryShape(t *testing.T) {
 	if len(result.Teams) != 1 || result.Teams[0].Name != "platform" {
 		t.Fatalf("unexpected teams: %+v", result.Teams)
 	}
-	if len(*records) != 1 || (*records)[0].OperationName != "ListTeams" {
-		t.Fatalf("expected single ListTeams request, got: %+v", *records)
+	// Team repo slugs are host-qualified via the org repositories' provider.
+	if repos := result.Teams[0].Repositories; len(repos) != 1 || repos[0] != "github.com/org/repo-9" {
+		t.Fatalf("unexpected team repositories: %+v", repos)
+	}
+	if len(*records) != 2 || (*records)[0].OperationName != "ListTeams" || (*records)[1].OperationName != "OrgRepositories" {
+		t.Fatalf("expected ListTeams then OrgRepositories requests, got: %+v", *records)
 	}
 	// $first variable must be sent so the server caps the page.
 	if _, ok := (*records)[0].Variables["first"]; !ok {

--- a/internal/vault/sleuth_test.go
+++ b/internal/vault/sleuth_test.go
@@ -1326,3 +1326,108 @@ func TestSleuthVault_CurrentInstallTargets_QualifiesRepoRows(t *testing.T) {
 		t.Fatalf("targets[1] = %+v, want path github.com/acme/mono [services/api]", targets[1])
 	}
 }
+
+// A team repo GID the org listing never returns must not force a full
+// re-pagination on every ListTeams call: the miss is negative-cached after
+// one fresh fetch, and the repo renders as a bare owner/name slug.
+func TestSleuthVault_ListTeams_UnresolvableRepoFetchesOnce(t *testing.T) {
+	teamsPage := func(map[string]any) any {
+		return map[string]any{
+			"organization": map[string]any{
+				"teams": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"id":           "team-1",
+							"name":         "platform",
+							"adminMembers": []any{},
+							"members":      map[string]any{"totalCount": 0, "nodes": []any{}},
+							"skillsRepositories": []any{
+								map[string]any{"repositoryId": "ghost", "owner": "org", "name": "ghost-repo"},
+							},
+						},
+					},
+					"totalCount": 1,
+					"pageInfo":   map[string]any{"hasNextPage": false, "endCursor": nil},
+				},
+			},
+		}
+	}
+	srv, records := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"ListTeams": teamsPage,
+		"OrgRepositories": func(map[string]any) any {
+			return map[string]any{
+				"organization": map[string]any{
+					"repositories": map[string]any{
+						"pageInfo": map[string]any{"hasNextPage": false, "endCursor": nil},
+						"nodes": []any{
+							map[string]any{"id": "repo-9", "owner": "org", "name": "repo-9", "provider": "github"},
+						},
+					},
+				},
+			}
+		},
+	})
+
+	v := NewSleuthVault(srv.URL, "token")
+	for i := range 2 {
+		result, err := v.ListTeams(context.Background(), ListTeamsOptions{Limit: 100})
+		if err != nil {
+			t.Fatalf("ListTeams #%d: %v", i+1, err)
+		}
+		if repos := result.Teams[0].Repositories; len(repos) != 1 || repos[0] != "org/ghost-repo" {
+			t.Fatalf("ListTeams #%d repositories = %v, want bare slug org/ghost-repo", i+1, repos)
+		}
+	}
+	fetches := 0
+	for _, r := range *records {
+		if r.OperationName == "OrgRepositories" {
+			fetches++
+		}
+	}
+	if fetches != 1 {
+		t.Fatalf("OrgRepositories fetched %d times across two ListTeams calls, want 1 (miss must be negative-cached)", fetches)
+	}
+}
+
+// The bulk write path must send skills.new the bare owner/name slug it
+// round-trips as entityName — CurrentInstallTargets now returns
+// host-qualified slugs, and forwarding those verbatim would hand the server
+// a form it never emitted.
+func TestSleuthVault_SetAssetInstallations_UnqualifiesRepoURL(t *testing.T) {
+	srv, records := mockSleuthGraphQL(t, map[string]func(map[string]any) any{
+		"SetAssetInstallations": func(map[string]any) any {
+			return map[string]any{
+				"setAssetInstallations": map[string]any{
+					"errors": []any{},
+				},
+			}
+		},
+	})
+
+	v := NewSleuthVault(srv.URL, "token")
+	skipped, err := v.SetAssetInstallations(context.Background(), "my-skill", []InstallTarget{
+		{Kind: InstallKindRepo, Repo: "github.com/acme/tools"},
+		{Kind: InstallKindPath, Repo: "bitbucket.org/acme/mono", Paths: []string{"services/api"}},
+		{Kind: InstallKindRepo, Repo: "https://github.com/acme/urlform"},
+	}, false)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("SetAssetInstallations: err=%v skipped=%+v", err, skipped)
+	}
+
+	set := findRecord(t, *records, "SetAssetInstallations")
+	input := set.Variables["input"].(map[string]any)
+	repos := input["repositories"].([]any)
+	if len(repos) != 3 {
+		t.Fatalf("repositories = %v, want 3", repos)
+	}
+	if url := repos[0].(map[string]any)["url"]; url != "acme/tools" {
+		t.Errorf("repo url = %v, want bare slug acme/tools", url)
+	}
+	if url := repos[1].(map[string]any)["url"]; url != "acme/mono" {
+		t.Errorf("path repo url = %v, want bare slug acme/mono", url)
+	}
+	// A user-typed full URL is not our qualification — it passes through.
+	if url := repos[2].(map[string]any)["url"]; url != "https://github.com/acme/urlform" {
+		t.Errorf("url-form repo url = %v, want passthrough", url)
+	}
+}

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -234,6 +234,17 @@ func copyAssets(ctx context.Context, src, dst vault.Vault, opts Options, r *Repo
 			r.warnf("list versions for %q: %v", a.Name, err)
 			continue
 		}
+		if len(versions) == 0 {
+			// Some backends expose no version history for certain asset types
+			// even though a latest version exists and is downloadable. Without
+			// this fallback the asset would be "copied" with no content at all.
+			if a.LatestVersion == "" {
+				r.warnf("source lists no versions for %q; skipping", a.Name)
+				continue
+			}
+			r.warnf("source lists no version history for %q; copying latest version %s only", a.Name, a.LatestVersion)
+			versions = []string{a.LatestVersion}
+		}
 
 		// Read the source's scopes BEFORE uploading any versions. If the read
 		// fails we skip the asset entirely rather than leaving stranded versions

--- a/internal/vaultcopy/vaultcopy_roundtrip_test.go
+++ b/internal/vaultcopy/vaultcopy_roundtrip_test.go
@@ -317,3 +317,39 @@ func skillZip(t *testing.T, name, ver string) []byte {
 	}
 	return buf.Bytes()
 }
+
+// A collection's "just for me" install belonging to another user must survive
+// the copy without tripping the destination's self-only rule — the engine's
+// trusted write covers collection installs the same as asset scopes.
+func TestCopy_ForeignUserScopeOnCollectionCopied(t *testing.T) {
+	mgmt.ResetActorCache()
+	ctx := context.Background()
+
+	src := newSeededVault(t)
+	dst := newEmptyVault(t)
+
+	if err := src.(vault.CollectionStore).SaveCollection(ctx, manifest.Collection{Name: "essentials"}); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+	if err := src.(vault.CollectionInstaller).SetCollectionInstallation(
+		vault.ContextWithTrustedScopeWrite(ctx), "essentials",
+		vault.InstallTarget{Kind: vault.InstallKindUser, User: "bob@example.com"},
+	); err != nil {
+		t.Fatalf("seed foreign user install: %v", err)
+	}
+
+	report, err := vaultcopy.Copy(ctx, src, dst, vaultcopy.Options{Collections: true})
+	if err != nil {
+		t.Fatalf("Copy: %v (warnings: %v)", err, report.Warnings)
+	}
+	for _, w := range report.Warnings {
+		if strings.Contains(w, "may only target the authenticated caller") {
+			t.Fatalf("copy tripped the self-only rule: %v", report.Warnings)
+		}
+	}
+	targets, present, err := dst.(vault.CollectionInstaller).CurrentCollectionInstallTargets(ctx, "essentials")
+	if err != nil || !present || len(targets) != 1 ||
+		targets[0].Kind != vault.InstallKindUser || targets[0].User != "bob@example.com" {
+		t.Fatalf("dst targets = %+v present=%v err=%v, want bob@example.com user target", targets, present, err)
+	}
+}

--- a/internal/vaultcopy/vaultcopy_roundtrip_test.go
+++ b/internal/vaultcopy/vaultcopy_roundtrip_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -164,6 +165,96 @@ func TestCopy_PathToPathRoundTrip(t *testing.T) {
 	}
 	if versions, err := dst.GetVersionList(ctx, "my-skill"); err != nil || len(versions) != 2 {
 		t.Fatalf("after re-copy dst versions = %v err=%v, want 2 (no duplication)", versions, err)
+	}
+}
+
+// emptyVersionListVault simulates a backend that exposes no version history
+// for an asset even though the asset (and its latest version) is downloadable —
+// the copy engine must fall back to the summary's latest version instead of
+// silently copying nothing.
+type emptyVersionListVault struct {
+	vault.Vault
+}
+
+func (v *emptyVersionListVault) GetVersionList(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func TestCopy_EmptyVersionListFallsBackToLatest(t *testing.T) {
+	mgmt.ResetActorCache()
+	ctx := context.Background()
+
+	src := newSeededVault(t)
+	dst := newEmptyVault(t)
+
+	for _, v := range []string{"1.0.0", "1.1.0"} {
+		a := &lockfile.Asset{Name: "my-skill", Version: v, Type: asset.TypeSkill}
+		if err := src.AddAsset(ctx, a, skillZip(t, "my-skill", v)); err != nil {
+			t.Fatalf("seed asset %s: %v", v, err)
+		}
+	}
+
+	report, err := vaultcopy.Copy(ctx, &emptyVersionListVault{src}, dst, vaultcopy.Options{Assets: true})
+	if err != nil {
+		t.Fatalf("Copy: %v (warnings: %v)", err, report.Warnings)
+	}
+	if report.Assets != 1 || report.Versions != 1 {
+		t.Fatalf("report = %+v, want 1 asset / 1 version (latest only)", report)
+	}
+	found := false
+	for _, w := range report.Warnings {
+		if strings.Contains(w, "no version history") && strings.Contains(w, "my-skill") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want a no-version-history warning, got %v", report.Warnings)
+	}
+	versions, err := dst.GetVersionList(ctx, "my-skill")
+	if err != nil || len(versions) != 1 || versions[0] != "1.1.0" {
+		t.Fatalf("dst versions = %v err=%v, want just latest 1.1.0", versions, err)
+	}
+}
+
+// A user scope belonging to someone other than the operator must survive the
+// copy: the engine's trusted bulk write lifts the self-only restriction, which
+// exists to stop interactive privilege escalation, not faithful migration.
+func TestCopy_ForeignUserScopeCopied(t *testing.T) {
+	mgmt.ResetActorCache()
+	ctx := context.Background()
+
+	src := newSeededVault(t)
+	dst := newEmptyVault(t)
+
+	a := &lockfile.Asset{Name: "my-skill", Version: "1.0.0", Type: asset.TypeSkill}
+	if err := src.AddAsset(ctx, a, skillZip(t, "my-skill", "1.0.0")); err != nil {
+		t.Fatalf("seed asset: %v", err)
+	}
+	// Seed a scope for a user who is not the operator (admin@example.com);
+	// only a trusted write can record it, same as the copy engine uses.
+	bulk := src.(interface {
+		SetAssetInstallations(context.Context, string, []vault.InstallTarget, bool) ([]vault.SkippedTarget, error)
+	})
+	skipped, err := bulk.SetAssetInstallations(vault.ContextWithTrustedScopeWrite(ctx), "my-skill",
+		[]vault.InstallTarget{{Kind: vault.InstallKindUser, User: "bob@example.com"}}, false)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("seed foreign user scope: err=%v skipped=%+v", err, skipped)
+	}
+
+	report, err := vaultcopy.Copy(ctx, src, dst, vaultcopy.Options{Assets: true})
+	if err != nil {
+		t.Fatalf("Copy: %v (warnings: %v)", err, report.Warnings)
+	}
+	if report.Scopes != 1 {
+		t.Fatalf("report = %+v (warnings: %v), want 1 scope", report, report.Warnings)
+	}
+	scopeReader := dst.(interface {
+		AssetInstallScopes(context.Context, string) ([]manifest.Scope, bool, error)
+	})
+	scopes, present, err := scopeReader.AssetInstallScopes(ctx, "my-skill")
+	if err != nil || !present || len(scopes) != 1 ||
+		scopes[0].Kind != manifest.ScopeKindUser || scopes[0].User != "bob@example.com" {
+		t.Fatalf("dst scopes = %+v present=%v err=%v, want bob@example.com user scope", scopes, present, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fall back to the asset summary's latest version when the source vault lists no version history (skills.new returns an empty list for hooks and claude-code plugins), instead of silently copying an asset with no content
- Let trusted bulk scope writes (`sx vault copy`) carry user scopes belonging to users other than the operator — the self-only rule guards interactive escalation, not faithful migration
- Host-qualify repo rows read from skills.new (`github.com/owner/name` instead of the bare `owner/name` slug, via the entity/repository provider) so repo- and path-scoped installs still resolve after migrating to a git/path vault; provider map limited to verified SaaS-only providers (github, bitbucket)
- Stop `SX_PROFILE=new sx init` clobbering shared config: preserve config-wide client enable/disable lists when no `--clients` selection is made, mirror top-level compat fields from the persisted default profile rather than the transient profile override, and never install hooks for force-disabled clients

All four bugs were found while migrating the app.skills.new vault to a git vault with `sx vault copy`.

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)