### PR TITLE
SK-767: Rewrite the skills.new migration guide end to end

### DIFF
--- a/docs/copy.md
+++ b/docs/copy.md
@@ -5,7 +5,7 @@ teams, bots, installation scopes, audit history, and usage history. The source
 and destination can be any backend, so you can convert a skills.new vault into a
 git vault (or vice versa) without leaving the contents behind. For the full
 step-by-step skills.new exit path, see
-[Migrating from app.skills.new to a git vault](migrate-from-skills-new.md).
+[Migrating from skills.new to your own git vault](migrate-from-skills-new.md).
 
 ```bash
 sx vault copy --from <profile> --to <profile> [--only ...] [--dry-run] [--yes]
@@ -77,7 +77,8 @@ collections (including their collection-level install rows), audit, and usage
 in both directions, with these exceptions:
 
 - **Bot API keys** can't be copied (they're shown once at creation). Regenerate
-  them on the destination.
+  them on a skills.new destination; git and path vaults have no bot keys — a
+  job claims a bot identity with `SX_BOT=<name>` instead (see [Bots](bots.md)).
 - **Cross-org copies** require the referenced entities to exist in the
   destination org: a team can only include members who are users of that org,
   and repo/user-scoped installs only land if that repo/user exists there.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -234,5 +234,5 @@ tied to whoever created it and expires on a schedule. Treat it as a stopgap.
 
 - [Bots](bots.md) — bot identities and `SX_BOT`
 - [Environment variables](environment-variables.md) — `SX_SSH_KEY`, `SX_BOT`, isolation recipes
-- [Migrating from app.skills.new](migrate-from-skills-new.md) — moving a library into a git vault
+- [Migrating from skills.new to your own git vault](migrate-from-skills-new.md)
 - [sleuth-io/skills-actions](https://github.com/sleuth-io/skills-actions) — the composite action

--- a/docs/migrate-from-skills-new.md
+++ b/docs/migrate-from-skills-new.md
@@ -156,14 +156,19 @@ sx vault show <asset> --profile ai-assets
 ### A6. Tidy team admins
 
 Teams keep the admins they had on skills.new. A team that had *no* admins
-gets you as its admin and member — a git vault won't create an orphaned team.
-Check the result and adjust only where that's not wanted:
+gets you as its sole admin and member — a git vault never leaves a team
+without an admin. Check the result, and where you'd rather not own a team,
+hand it to someone first (the last admin can't leave), then step out;
+removing your membership also drops your admin role:
 
 ```bash
 sx team list --profile ai-assets
-sx team admin unset --profile ai-assets <team> you@company.com
+sx team member add --profile ai-assets <team> colleague@company.com --admin
 sx team member remove --profile ai-assets <team> you@company.com
 ```
+
+Only a team's admins can change it (org-admins don't override this), so leave
+teams that already had admins to them.
 
 `--profile ai-assets` matters for every write in Part A: your skills.new
 profile is still the active one, so a command without it changes skills.new.
@@ -417,7 +422,7 @@ The copy report lists every skipped item. These are the expected ones:
 - **After switching, repo-scoped assets are missing in a repo** — check the
   scope with `sx vault show <asset>`; it should read `github.com/org/repo`.
   If it reads a bare `org/repo`, the copy was made with an sx older than
-  2.3.9: update sx and re-run `sx vault copy … --only assets --yes` (scopes are
+  2.3.8: update sx and re-run `sx vault copy … --only assets --yes` (scopes are
   rewritten in place).
 - **The copy report says `user-scoped installs may only target the
   authenticated caller`** — same cause: update sx and re-run the assets stage.

--- a/docs/migrate-from-skills-new.md
+++ b/docs/migrate-from-skills-new.md
@@ -1,105 +1,137 @@
-# Migrating from app.skills.new to a git vault
+# Migrating from skills.new to your own git vault
 
-app.skills.new is shutting down, but nothing in your library needs to be left
-behind. `sx vault copy` moves everything — assets with their full version
-history, teams, bots, installation scopes, collections, audit history, and
-usage history — into a git repository your org controls. After the switch,
-`sx install` resolves the same assets for everyone from the new backend; only
-the storage changes.
+skills.new is shutting down. Everything your team keeps there — skills, rules,
+commands, MCP configs, hooks, plugins, their full version history, teams, bots,
+installation scopes, collections, audit history, and usage history — moves into
+a private git repository your organization controls, and `sx` keeps working
+exactly as before against it. This guide is the whole migration, start to
+finish. Follow it in order and you're done.
 
-One person with admin access runs the copy. Everyone else just points their
-sx at the new vault (see [Switch every teammate over](#6-switch-every-teammate-over)).
+**Who does what**
+
+| Part | Who | Time |
+|------|-----|------|
+| [A. Move the vault](#part-a-move-the-vault) | one admin, once | 15–60 min (mostly waiting on the copy) |
+| [B. Switch your machine](#part-b-switch-your-machine) | every teammate | 2 min each |
+| [C. Update GitHub Actions](#part-c-update-github-actions) | one admin, once per org | 10 min |
+| [D. Retire skills.new](#part-d-retire-skillsnew) | one admin | 5 min |
+
+Nothing in Part B or C depends on skills.new still being up once Part A is
+done — do Part A first, before the shutdown date.
 
 ## Before you start
 
-- **Update sx everywhere**: `sx update`. Old releases lose hooks,
-  claude-code plugins, repo-scoped installs, and teammates' personal installs
-  during the copy — the current release carries all of them.
-- **Pick the repository host**: any git remote works (GitHub, GitLab,
-  Bitbucket, self-hosted). You need push access, and your teammates need at
-  least read access.
-- **Use SSH** for the remote URL if you can. For private repos over HTTPS,
-  configure a git credential helper first (e.g. `gh auth setup-git`).
+- **Update sx everywhere** — on every machine and in CI — to **v2.3.9 or
+  newer**. Older releases silently lose hooks, claude-code plugins, repo-scoped
+  installs, and teammates' personal installs during the copy, and fail in CI on
+  plugins.
 
-## 1. Create an empty repository
+  ```bash
+  sx update
+  sx --version   # 2.3.9+
+  ```
 
-Create a new private repository with no README or initial commit — sx lays
-down the [vault structure](vault-spec.md) on first write:
+- **The admin running Part A needs**: access to your skills.new library, the
+  ability to create a private repository in your GitHub organization, and SSH
+  access to GitHub from their machine (`ssh -T git@github.com`).
+- **Teammates need** read access to the new repository to install assets.
+  Publishing with `sx add` and contributing usage analytics to `sx stats`
+  need push access; teammates without it can still publish through the
+  pull-request flow (see [Access levels](#access-levels)).
+
+---
+
+## Part A: Move the vault
+
+*One admin does this once.*
+
+### A1. Create an empty private repository
+
+Create the repository with **no README and no initial commit** — sx lays down
+the vault structure on its first write. `ai-assets` is a good name; use
+whatever fits.
 
 ```bash
 gh repo create your-org/ai-assets --private
+git ls-remote git@github.com:your-org/ai-assets.git   # should print nothing and exit 0
 ```
 
-Verify you can reach it:
+(In the GitHub UI: New repository → Private → leave "Add a README" unchecked.)
 
-```bash
-git ls-remote git@github.com:your-org/ai-assets.git
-```
+### A2. Add a git profile alongside your skills.new profile
 
-## 2. Add a git profile for the new vault
-
-Keep your existing skills.new profile — the copy reads from it. Add a second
-[profile](profiles.md) pointing at the new repository:
+sx connects to vaults through [profiles](https://github.com/sleuth-io/sx/blob/main/docs/profiles.md).
+Keep your existing skills.new profile — the copy reads from it — and add a
+second one for the new repository:
 
 ```bash
 sx profile add ai-assets
-# choose "Git repository" and enter git@github.com:your-org/ai-assets.git
 ```
 
-If your git identity (`git config user.email`) differs from the email you use
-on skills.new, set the profile identity to the skills.new one so team
-membership and your personal installs resolve after the switch:
+Answer the prompts:
 
-```bash
-sx profile edit ai-assets --identity you@company.com
-```
+1. **How will you use sx?** → *Share with my team*
+2. **Vault type** → *Git repository*
+3. **Repository URL** → `git@github.com:your-org/ai-assets.git`
+4. **Clients** → keep your current selection
+5. **Identity email** → **the email you use on skills.new.** Team membership
+   and personal ("just for me") installs are keyed on it; if it differs from
+   your `git config user.email`, this is what makes them resolve after the
+   switch.
 
-Check that your skills.new profile is still the active one (marked `✓`):
+You can change the identity later with
+`sx profile edit ai-assets --identity you@company.com`.
+
+Confirm the skills.new profile is still the active one (the `✓`) — the new
+one just exists for now:
 
 ```bash
 sx profile list
 ```
 
-## 3. Preview the copy
+Find your skills.new profile's name in that list; the commands below call it
+`<skills-new-profile>`.
 
-The preview is read-only and shows exactly what will move:
+### A3. Preview the copy
 
 ```bash
 sx vault copy --from <skills-new-profile> --to ai-assets --dry-run
 ```
 
-Read the "Notes / losses" section carefully — it names anything that won't
-transfer (see [What doesn't carry over](#what-doesnt-carry-over)).
+This is read-only. It prints the counts of everything that will move and a
+"Notes / losses" section listing anything that won't (see
+[What doesn't carry over](#what-doesnt-carry-over)).
 
-## 4. Run the copy
+### A4. Run the copy
 
 ```bash
 sx vault copy --from <skills-new-profile> --to ai-assets --yes
 ```
 
-A few things to expect:
+What to expect:
 
-- **It takes a while.** Every asset version becomes one commit and push to the
-  git vault, so a library with hundreds of versions runs for many minutes.
-- **Warnings are per-item, not fatal.** A single failed download skips that
-  item and the copy continues. Read the final report rather than just the exit
-  code.
-- **Re-running is safe for assets.** Versions that already copied are skipped,
-  so if the server hiccups (a 500 or 502 on individual items is not unusual),
-  run the assets stage again until the report is clean:
+- **It takes a while.** Every asset version becomes one commit and push, so
+  a library with a few hundred versions runs for many minutes. Leave it.
+- **Warnings are per item, never fatal.** One failed download skips that item
+  and the copy continues. Read the report at the end — don't judge by the exit
+  code alone.
+- **Re-running the assets stage is safe and expected.** Already-copied
+  versions are skipped. If the report shows server errors (a 500 or 502 on
+  individual items is common), run the assets stage again until the report is
+  clean:
 
   ```bash
   sx vault copy --from <skills-new-profile> --to ai-assets --only assets --yes
   ```
 
-- **Audit and usage are additive.** If the audit or usage stage fails, re-run
-  just that stage (`--only audit`, `--only usage`) — but only re-run a stage
-  that failed *completely*, because re-importing partially imported events
-  duplicates them on the destination.
+- **Audit and usage history are additive.** If the audit or usage stage fails,
+  re-run only that stage (`--only audit` / `--only usage`) — and only if it
+  failed *completely* (0 events copied). Re-importing partially imported
+  events duplicates them.
 
-## 5. Verify the copy
+### A5. Verify the copy
 
-Compare the two vaults before switching anything over:
+Compare the two vaults before anyone switches:
 
 ```bash
 sx vault list --profile <skills-new-profile>
@@ -111,89 +143,279 @@ sx collection list --profile ai-assets
 sx stats --profile ai-assets
 ```
 
-Spot-check a few assets' install scopes:
+Spot-check the install scopes of a few assets you care about — repo-scoped,
+team-scoped, and a personal one:
 
 ```bash
 sx vault show <asset> --profile ai-assets
 ```
 
-## 6. Switch every teammate over
+### A6. Tidy team admins
 
-Everyone (including you) runs these four commands. Teammates do **not** re-run
-the copy — the vault already has everything.
+Creating a team on a git vault adds the creator as a member and admin, so you
+are now an admin (and member) of every copied team, alongside the admins that
+were copied over. Adjust where that's not wanted:
 
 ```bash
-sx profile add ai-assets        # git@github.com:your-org/ai-assets.git
-sx profile use ai-assets        # make it the only active profile
-sx install                      # reinstall from the new vault
-sx profile remove <skills-new-profile>
+sx team admin unset <team> you@company.com
+sx team member remove <team> you@company.com
 ```
 
-`sx install` regenerates the lock file from the new vault; the same assets end
-up installed in the same places. If someone's git email differs from their
-skills.new email, they should set `sx profile edit ai-assets --identity`
-(step 2) before running `sx install`, or team- and user-scoped assets won't
-resolve for them.
-
-## 7. Lock down the new vault
+### A7. Lock down scope changes
 
 A fresh git vault has no org-admins, which means anyone with push access can
-set any scope. Restore governance right after the migration:
+install any asset anywhere. Restore governance now:
 
 ```bash
 sx org admin add you@company.com colleague@company.com
 ```
 
-See [Permissions / RBAC](rbac.md) for what org-admins control.
+Org-admins control org-, repo-, path-, and bot-scoped installs; team admins
+keep control of their own team's scope. Details:
+[Permissions / RBAC](https://github.com/sleuth-io/sx/blob/main/docs/rbac.md).
 
-Bots need new API keys — keys never transfer (they're shown once at
-creation):
+### A8. Bots: no API keys any more
+
+Bots copy over with their team memberships, but **git vaults have no bot API
+keys** — `sx bot key create` is a skills.new feature. On a git vault a bot is
+an identity that a job claims by setting `SX_BOT=<bot-name>`; the repository's
+own access control (who can read the repo) is what gates it. Part C shows how
+CI uses this.
+
+---
+
+## Part B: Switch your machine
+
+*Every teammate does this, including the admin. Nobody re-runs the copy —
+the vault already has everything.*
+
+### B1. Point sx at the new vault
 
 ```bash
-sx bot key create <bot-name>
+sx profile add ai-assets          # Share with my team → Git repository → git@github.com:your-org/ai-assets.git
+sx profile use ai-assets          # make it the only active (and default) profile
+sx install                        # reinstall everything from the new vault
+sx profile remove <skills-new-profile>
 ```
 
-## 8. Update CI jobs that install skills
+When `sx profile add` asks for an identity email, enter **your skills.new
+email**. If you skipped it or entered something else, set it before
+`sx install`:
 
-Any workflow that ran `sx install` against skills.new (a Claude PR review, an
-agent job) needs a credential for the new private repository — the workflow's
-built-in token only reaches the repository it runs in. Add a read-only deploy
-key to the vault, store it as a secret, and switch the job to `vault-url` +
-`ssh-key`. The full walkthrough, including running the job as an sx bot, is in
-[Using your vault from GitHub Actions](github-actions.md).
+```bash
+sx profile edit ai-assets --identity you@company.com
+```
+
+`sx install` regenerates your lock file from the new vault. The same assets
+end up installed in the same places; the only visible difference is the
+"Source" line now naming the git repository.
+
+### B2. Check what's installed
+
+```bash
+sx config      # profile + vault, detected clients, install status
+```
+
+If something you expect is missing, see [Troubleshooting](#troubleshooting).
+
+### B3. The sx desktop app
+
+If you use the sx desktop app, open its settings and select the `ai-assets`
+profile (or add the repository there). It reads the same config file as the
+CLI, so once the CLI switch above is done the app follows.
+
+### B4. Remove skills.new-only pieces
+
+- **Cloud relay.** If you exposed your vault to claude.ai or chatgpt.com
+  through the skills.new relay, revoke the credential — the relay is hosted on
+  skills.new and stops working with it:
+
+  ```bash
+  sx cloud status
+  sx cloud revoke
+  ```
+
+- **MCP servers that call app.skills.new.** Any MCP asset whose configuration
+  points at `app.skills.new` will fail after the shutdown. Uninstall it and
+  remove it from the vault (`sx vault remove <name>`).
+
+### Access levels
+
+| You want to… | Repository access needed |
+|--------------|--------------------------|
+| Install assets (`sx install`) | read |
+| Publish or rescope assets (`sx add`) | push — or read + the [`gh` CLI](https://cli.github.com/), which opens a pull request instead |
+| Have your usage counted in `sx stats` | push (usage events are committed and pushed by your sx, throttled; without push access they stay queued locally — nothing else breaks) |
+| Manage teams, org-admins, bots | push (and the relevant team-admin / org-admin role) |
+
+Most teams give everyone push access to the vault repository and let the
+org-admin and team-admin rules in sx govern who may change what.
+
+---
+
+## Part C: Update GitHub Actions
+
+*One admin does this once per organization.*
+
+If you run a Claude PR review (or any job) that installs skills with
+`sleuth-io/skills-actions/install-skills`, it currently authenticates to
+skills.new with an API key. It now needs to reach your private vault
+repository instead — and a workflow's built-in `GITHUB_TOKEN` can only read
+the repository the workflow runs in, not the vault. The fix is a **read-only
+deploy key** on the vault repository, stored as a secret.
+
+### C1. Create a deploy key for the vault
+
+```bash
+ssh-keygen -t ed25519 -N "" -C "sx vault deploy key (github actions)" -f sx_vault_key
+gh repo deploy-key add sx_vault_key.pub -R your-org/ai-assets -t "GitHub Actions (read-only)"
+```
+
+(UI: vault repository → Settings → Deploy keys → Add deploy key, paste
+`sx_vault_key.pub`, leave **Allow write access** unchecked.)
+
+A deploy key is tied to that one repository, is read-only, belongs to no user
+account, and never expires. Read-only is all `sx install` needs.
+
+### C2. Store the private key as a secret
+
+For one repository:
+
+```bash
+gh secret set SX_VAULT_SSH_KEY -R your-org/backend < sx_vault_key
+```
+
+For every repository that runs the review, make it an organization secret
+instead (needs org-admin rights):
+
+```bash
+gh secret set SX_VAULT_SSH_KEY --org your-org --visibility selected \
+  --repos your-org/backend,your-org/frontend < sx_vault_key
+```
+
+Then delete `sx_vault_key` locally — the secret is the copy that matters.
+
+### C3. Create a bot for CI (recommended)
+
+A CI job has no human identity, so by itself it only receives repo-scoped
+and org-wide assets. Give it a bot identity so team-scoped assets resolve
+too — the same skills your developers get in that repo:
+
+```bash
+sx bot create ci-reviewer --description "PR review job" --team platform
+```
+
+### C4. Update the workflow
+
+Change the `install-skills` step from the API key to the vault:
+
+```diff
+       - uses: sleuth-io/skills-actions/install-skills@v1
+         with:
+-          api-key: ${{ secrets.SKILLS_API_KEY }}
++          vault-url: git@github.com:your-org/ai-assets.git
++          ssh-key: ${{ secrets.SX_VAULT_SSH_KEY }}
++          bot: ci-reviewer
+           clients: claude-code
+```
+
+`@v1` already includes these inputs (or pin `@v1.1`). The key is passed to sx
+as `SX_SSH_KEY`; sx writes it to a temp file for git and deletes it when it
+exits, so it never lands in a config file or outlives the install step.
+
+If the review job runs on pull requests, skip forks — GitHub withholds secrets
+from fork-triggered workflows, so the step would fail there:
+
+```yaml
+jobs:
+  review:
+    if: github.event.pull_request.head.repo.fork == false
+```
+
+If you wrote your own install steps instead of using the action, the
+equivalent is a git-type sx config plus `SX_SSH_KEY` and `SX_BOT` in the
+install step's `env:` — a full example is in
+[Using your vault from GitHub Actions](https://github.com/sleuth-io/sx/blob/main/docs/github-actions.md).
+
+### C5. Run it once and check
+
+Open a test pull request. In the job log you should see
+`SSH key loaded from environment variable`, then `Installed N assets`, then
+`Found skills: …`. A `⊘` line for a claude-code *plugin* is normal — plugins
+need the `claude` CLI, which the runner doesn't have at that point — and
+doesn't fail the job.
+
+---
+
+## Part D: Retire skills.new
+
+Once Parts A–C are done:
+
+1. **Remove the skills.new API key secrets** from GitHub (`SKILLS_API_KEY` or
+   whatever you named them) — they're no longer used:
+
+   ```bash
+   gh secret delete SKILLS_API_KEY -R your-org/backend
+   ```
+
+2. **Confirm nobody is still on the old profile**: `sx profile list` on each
+   machine should no longer show a `https://app.skills.new` entry.
+3. **Keep the repository private** and treat read access to it as access to
+   your team's skills.
+
+---
 
 ## What doesn't carry over
 
-The copy report names every skipped item, but three categories are expected:
+The copy report lists every skipped item. These are the expected ones:
 
-- **Bot API keys** — regenerate them on the new vault (above).
-- **Assets whose downloads fail on the server.** If skills.new returns a
-  server error for a specific version, that version can't be recovered from
-  the server. The latest version usually copies fine; for "discovered" assets
-  whose only version is broken, the original content still lives in the
-  repository they were discovered from.
-- **App-only features.** Extensions copy as assets but only run inside the
-  skills.new app; the `sx cloud` relay has no git-vault equivalent.
+- **Bot API keys.** Not a loss on a git vault — there are none. Jobs set
+  `SX_BOT=<name>` instead (Part C).
+- **Individual versions skills.new can't serve.** If the server returns an
+  error for a specific historical version, that version can't be recovered.
+  The latest version almost always copies fine. "Discovered" assets whose only
+  version fails still have their content in the repository they were
+  discovered from.
+- **skills.new-only features**: the web UI, extensions (they copy as assets
+  but only run inside the app), the cloud relay for claude.ai/chatgpt.com,
+  repository discovery of skills, quality scores, and the `sx query` MCP tool
+  (Sleuth AI Query). The git vault has the CLI, the desktop app, `sx stats`,
+  and the audit log.
 
 ## Troubleshooting
 
-- **`repository URL unreachable` when adding the profile** — check SSH access
-  (`ssh -T git@github.com`) or set up a credential helper for HTTPS.
-- **A teammate's assets vanished after switching** — their profile identity
-  doesn't match the email their scopes use. Set it with
-  `sx profile edit ai-assets --identity <email>` and re-run `sx install`.
-- **The copy report shows `user-scoped installs may only target the
-  authenticated caller`** — you're running an sx release without the
-  migration fixes. Run `sx update` and re-run the assets stage.
-- **Repo-scoped assets don't install from the new vault** — same cause as
-  above: older releases wrote repo scopes in a form that can't match a real
-  remote. Update sx and re-run `--only assets` (the scope rows are rewritten
-  in place).
+- **`sx profile add` says the repository URL is unreachable** — SSH access.
+  Run `ssh -T git@github.com`; if that fails, add your SSH key to GitHub. (For
+  HTTPS URLs, configure a credential helper first: `gh auth setup-git`.)
+- **After switching, team-scoped or personal assets are missing** — the
+  profile identity doesn't match the email your scopes use. Fix with
+  `sx profile edit ai-assets --identity <your-skills.new-email>` and run
+  `sx install` again.
+- **After switching, repo-scoped assets are missing in a repo** — check the
+  scope with `sx vault show <asset>`; it should read `github.com/org/repo`.
+  If it reads a bare `org/repo`, the copy was made with an sx older than
+  2.3.8: update sx and re-run `sx vault copy … --only assets --yes` (scopes are
+  rewritten in place).
+- **The copy report says `user-scoped installs may only target the
+  authenticated caller`** — same cause: update sx and re-run the assets stage.
+- **CI: `Permission denied (publickey)`** — the deploy key isn't on the vault
+  repository, or the secret holds the public key or a truncated one. The value
+  must be the whole private key file, `-----BEGIN` to `-----END`.
+- **CI: `fatal: could not read Username for 'https://github.com'`** — the
+  `vault-url` is HTTPS with no credential; use the `git@github.com:…` form
+  with `ssh-key`.
+- **CI: `Found skills: none`** — the vault has nothing scoped to that
+  repository or org-wide, or `bot:` names a bot that isn't in the right team.
+  `sx vault show <asset>` shows an asset's scopes.
+- **`sx stats` is missing some people's usage** — they don't have push access
+  to the vault repository (see [Access levels](#access-levels)).
 
-## Further reading
+## Reference
 
-- [Copying a vault](copy.md) — everything `sx vault copy` moves and how
-- [Using your vault from GitHub Actions](github-actions.md) — CI access to a private vault
-- [Profiles](profiles.md) — managing multiple vault connections
-- [Vault structure](vault-spec.md) — what the git repository contains
-- [Permissions / RBAC](rbac.md) — governance on git vaults
+- [Copying a vault](https://github.com/sleuth-io/sx/blob/main/docs/copy.md) — everything `sx vault copy` moves and how
+- [Using your vault from GitHub Actions](https://github.com/sleuth-io/sx/blob/main/docs/github-actions.md) — the CI setup in depth, including the GitHub App alternative to deploy keys
+- [Profiles](https://github.com/sleuth-io/sx/blob/main/docs/profiles.md)
+- [Bots](https://github.com/sleuth-io/sx/blob/main/docs/bots.md) and [Teams](https://github.com/sleuth-io/sx/blob/main/docs/teams.md)
+- [Permissions / RBAC](https://github.com/sleuth-io/sx/blob/main/docs/rbac.md)
+- [Vault structure](https://github.com/sleuth-io/sx/blob/main/docs/vault-spec.md) — what ends up in the repository
+- [sleuth-io/skills-actions](https://github.com/sleuth-io/skills-actions) — the GitHub Action

--- a/docs/migrate-from-skills-new.md
+++ b/docs/migrate-from-skills-new.md
@@ -1,13 +1,12 @@
 # Migrating from skills.new to your own git vault
 
-skills.new is being retired — it shuts down once every team using it has
-confirmed they've migrated, so there's no deadline to race, only a request:
-tell us when you're done. Everything your team keeps there — skills, rules,
+This guide moves a team's library from skills.new into a private git
+repository your organization controls. Everything comes along — skills, rules,
 commands, MCP configs, hooks, plugins, their full version history, teams, bots,
-installation scopes, collections, audit history, and usage history — moves into
-a private git repository your organization controls, and `sx` keeps working
-exactly as before against it. This guide is the whole migration, start to
-finish. Follow it in order and you're done.
+installation scopes, collections, audit history, and usage history — and `sx`
+keeps working exactly as before against the new vault. It covers the whole
+migration, start to finish: the vault itself, every teammate's machine, and
+your GitHub Actions. Follow it in order and you're done.
 
 **Who does what**
 
@@ -16,10 +15,9 @@ finish. Follow it in order and you're done.
 | [A. Move the vault](#part-a-move-the-vault) | one admin, once | 15–60 min (mostly waiting on the copy) |
 | [B. Switch your machine](#part-b-switch-your-machine) | every teammate | 2 min each |
 | [C. Update GitHub Actions](#part-c-update-github-actions) | one admin, once per org | 10 min |
-| [D. Retire skills.new](#part-d-retire-skillsnew) | one admin | 5 min |
+| [D. Clean up](#part-d-clean-up) | one admin | 5 min |
 
-Nothing in Part B or C depends on skills.new still being up once Part A is
-done — do Part A first.
+Parts B and C only need the new vault, so do Part A first.
 
 ## Before you start
 
@@ -229,8 +227,8 @@ CLI, so once the CLI switch above is done the app follows.
 ### B4. Remove skills.new-only pieces
 
 - **Cloud relay.** If you exposed your vault to claude.ai or chatgpt.com
-  through the skills.new relay, revoke the credential — the relay is hosted on
-  skills.new and stops working with it:
+  through the skills.new relay, revoke the credential — the relay serves the
+  skills.new vault, not your git repository:
 
   ```bash
   sx cloud status
@@ -238,8 +236,8 @@ CLI, so once the CLI switch above is done the app follows.
   ```
 
 - **MCP servers that call app.skills.new.** Any MCP asset whose configuration
-  points at `app.skills.new` will fail after the shutdown. Uninstall it and
-  remove it from the vault (`sx vault remove <name>`).
+  points at `app.skills.new` targets the vault you're leaving. Uninstall it and
+  remove it from the new vault (`sx vault remove <name>`).
 
 ### Access levels
 
@@ -349,7 +347,7 @@ doesn't fail the job.
 
 ---
 
-## Part D: Retire skills.new
+## Part D: Clean up
 
 Once Parts A–C are done:
 
@@ -364,8 +362,6 @@ Once Parts A–C are done:
    machine should no longer show a `https://app.skills.new` entry.
 3. **Keep the repository private** and treat read access to it as access to
    your team's skills.
-4. **Tell us you're done.** We turn skills.new off only after every team has
-   confirmed their migration, so your confirmation is what lets us proceed.
 
 ---
 

--- a/docs/migrate-from-skills-new.md
+++ b/docs/migrate-from-skills-new.md
@@ -1,6 +1,8 @@
 # Migrating from skills.new to your own git vault
 
-skills.new is shutting down. Everything your team keeps there — skills, rules,
+skills.new is being retired — it shuts down once every team using it has
+confirmed they've migrated, so there's no deadline to race, only a request:
+tell us when you're done. Everything your team keeps there — skills, rules,
 commands, MCP configs, hooks, plugins, their full version history, teams, bots,
 installation scopes, collections, audit history, and usage history — moves into
 a private git repository your organization controls, and `sx` keeps working
@@ -17,7 +19,7 @@ finish. Follow it in order and you're done.
 | [D. Retire skills.new](#part-d-retire-skillsnew) | one admin | 5 min |
 
 Nothing in Part B or C depends on skills.new still being up once Part A is
-done — do Part A first, before the shutdown date.
+done — do Part A first.
 
 ## Before you start
 
@@ -362,6 +364,8 @@ Once Parts A–C are done:
    machine should no longer show a `https://app.skills.new` entry.
 3. **Keep the repository private** and treat read access to it as access to
    your team's skills.
+4. **Tell us you're done.** We turn skills.new off only after every team has
+   confirmed their migration, so your confirmation is what lets us proceed.
 
 ---
 

--- a/docs/migrate-from-skills-new.md
+++ b/docs/migrate-from-skills-new.md
@@ -34,10 +34,11 @@ Parts B and C only need the new vault, so do Part A first.
 - **The admin running Part A needs**: access to your skills.new library, the
   ability to create a private repository in your GitHub organization, and SSH
   access to GitHub from their machine (`ssh -T git@github.com`).
-- **Teammates need** read access to the new repository to install assets.
-  Publishing with `sx add` and contributing usage analytics to `sx stats`
-  need push access; teammates without it can still publish through the
-  pull-request flow (see [Access levels](#access-levels)).
+- **Teammates need** read access to the new repository to install assets,
+  and push access to publish with `sx add` or to have their usage counted in
+  `sx stats` (see [Access levels](#access-levels)). Most teams simply give
+  everyone push access and let sx's org-admin and team-admin rules govern
+  who may change what.
 
 ---
 
@@ -56,7 +57,9 @@ gh repo create your-org/ai-assets --private
 git ls-remote git@github.com:your-org/ai-assets.git   # should print nothing and exit 0
 ```
 
-(In the GitHub UI: New repository → Private → leave "Add a README" unchecked.)
+(In the GitHub UI: New repository → Private → leave "Add a README" unchecked.
+Any git host works — GitLab and Bitbucket have deploy keys too — but the
+commands in this guide are written for GitHub.)
 
 ### A2. Add a git profile alongside your skills.new profile
 
@@ -152,22 +155,27 @@ sx vault show <asset> --profile ai-assets
 
 ### A6. Tidy team admins
 
-Creating a team on a git vault adds the creator as a member and admin, so you
-are now an admin (and member) of every copied team, alongside the admins that
-were copied over. Adjust where that's not wanted:
+Teams keep the admins they had on skills.new. A team that had *no* admins
+gets you as its admin and member — a git vault won't create an orphaned team.
+Check the result and adjust only where that's not wanted:
 
 ```bash
-sx team admin unset <team> you@company.com
-sx team member remove <team> you@company.com
+sx team list --profile ai-assets
+sx team admin unset --profile ai-assets <team> you@company.com
+sx team member remove --profile ai-assets <team> you@company.com
 ```
+
+`--profile ai-assets` matters for every write in Part A: your skills.new
+profile is still the active one, so a command without it changes skills.new.
 
 ### A7. Lock down scope changes
 
 A fresh git vault has no org-admins, which means anyone with push access can
-install any asset anywhere. Restore governance now:
+set any org-, repo-, path-, or bot-scoped install (team scopes are always
+gated on that team's admins). Restore governance now:
 
 ```bash
-sx org admin add you@company.com colleague@company.com
+sx org admin add --profile ai-assets you@company.com colleague@company.com
 ```
 
 Org-admins control org-, repo-, path-, and bot-scoped installs; team admins
@@ -190,6 +198,8 @@ CI uses this.
 the vault already has everything.*
 
 ### B1. Point sx at the new vault
+
+(If you ran Part A, the profile already exists — start at `sx profile use`.)
 
 ```bash
 sx profile add ai-assets          # Share with my team → Git repository → git@github.com:your-org/ai-assets.git
@@ -227,29 +237,31 @@ CLI, so once the CLI switch above is done the app follows.
 ### B4. Remove skills.new-only pieces
 
 - **Cloud relay.** If you exposed your vault to claude.ai or chatgpt.com
-  through the skills.new relay, revoke the credential — the relay serves the
-  skills.new vault, not your git repository:
+  through the skills.new relay, drop this machine's relay credential — the
+  relay serves the skills.new vault, not your git repository:
 
   ```bash
   sx cloud status
-  sx cloud revoke
+  sx cloud revoke     # removes the local token only
   ```
 
+  The relay itself stays active on skills.new until it's invalidated there —
+  that's an admin step in Part D.
+
 - **MCP servers that call app.skills.new.** Any MCP asset whose configuration
-  points at `app.skills.new` targets the vault you're leaving. Uninstall it and
-  remove it from the new vault (`sx vault remove <name>`).
+  points at `app.skills.new` targets the vault you're leaving. Uninstall it
+  locally (`sx uninstall <name>`); the admin removes it from the vault in
+  Part D.
 
 ### Access levels
 
 | You want to… | Repository access needed |
 |--------------|--------------------------|
 | Install assets (`sx install`) | read |
-| Publish or rescope assets (`sx add`) | push — or read + the [`gh` CLI](https://cli.github.com/), which opens a pull request instead |
+| Publish or rescope assets (`sx add`) | push (a teammate blocked by a team's edit gate is offered a pull request instead of a hard failure — that still pushes a branch, so it needs push access too) |
 | Have your usage counted in `sx stats` | push (usage events are committed and pushed by your sx, throttled; without push access they stay queued locally — nothing else breaks) |
 | Manage teams, org-admins, bots | push (and the relevant team-admin / org-admin role) |
 
-Most teams give everyone push access to the vault repository and let the
-org-admin and team-admin rules in sx govern who may change what.
 
 ---
 
@@ -360,7 +372,18 @@ Once Parts A–C are done:
 
 2. **Confirm nobody is still on the old profile**: `sx profile list` on each
    machine should no longer show a `https://app.skills.new` entry.
-3. **Keep the repository private** and treat read access to it as access to
+3. **Remove skills.new-only assets from the vault** — any MCP server whose
+   configuration points at `app.skills.new` (teammates uninstalled it locally
+   in B4; this removes it from the vault once):
+
+   ```bash
+   sx vault remove <name>
+   ```
+
+4. **Invalidate the cloud relay server-side**, if you used one: `sx cloud
+   revoke` only deletes local tokens, so visit
+   [app.skills.new/relay](https://app.skills.new/relay) and revoke it there.
+5. **Keep the repository private** and treat read access to it as access to
    your team's skills.
 
 ---
@@ -394,7 +417,7 @@ The copy report lists every skipped item. These are the expected ones:
 - **After switching, repo-scoped assets are missing in a repo** — check the
   scope with `sx vault show <asset>`; it should read `github.com/org/repo`.
   If it reads a bare `org/repo`, the copy was made with an sx older than
-  2.3.8: update sx and re-run `sx vault copy … --only assets --yes` (scopes are
+  2.3.9: update sx and re-run `sx vault copy … --only assets --yes` (scopes are
   rewritten in place).
 - **The copy report says `user-scoped installs may only target the
   authenticated caller`** — same cause: update sx and re-run the assets stage.

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -188,7 +188,9 @@ func copyBots(ctx context.Context, src, dst vault.Vault, opts Options, r *Report
 		}
 	}
 	if len(bots) > 0 && !opts.DryRun {
-		if _, issuesKeys := dst.(botKeyManager); issuesKeys {
+		// Same probe `sx bot key create` uses, so the note never sends an
+		// operator to a command their destination rejects.
+		if _, issuesKeys := dst.(vault.BotApiKeyManager); issuesKeys {
 			r.warnf("bot API keys are not copied; create fresh ones on the destination with 'sx bot key create'")
 		} else {
 			r.warnf("bot API keys are not copied and this destination issues none; jobs claim a bot with SX_BOT=<name> instead")

--- a/internal/vaultcopy/vaultcopy.go
+++ b/internal/vaultcopy/vaultcopy.go
@@ -188,7 +188,11 @@ func copyBots(ctx context.Context, src, dst vault.Vault, opts Options, r *Report
 		}
 	}
 	if len(bots) > 0 && !opts.DryRun {
-		r.warnf("bot API keys are not copied; create fresh ones on the destination with 'sx bot key create'")
+		if _, issuesKeys := dst.(botKeyManager); issuesKeys {
+			r.warnf("bot API keys are not copied; create fresh ones on the destination with 'sx bot key create'")
+		} else {
+			r.warnf("bot API keys are not copied and this destination issues none; jobs claim a bot with SX_BOT=<name> instead")
+		}
 	}
 	return nil
 }

--- a/internal/vaultcopy/vaultcopy_roundtrip_test.go
+++ b/internal/vaultcopy/vaultcopy_roundtrip_test.go
@@ -353,3 +353,37 @@ func TestCopy_ForeignUserScopeOnCollectionCopied(t *testing.T) {
 		t.Fatalf("dst targets = %+v present=%v err=%v, want bob@example.com user target", targets, present, err)
 	}
 }
+
+// The bot-key note in the copy report must match the destination: a file
+// vault issues no API keys, so telling the operator to run `sx bot key create`
+// (which errors there) would contradict the migration docs.
+func TestCopy_BotKeyNoteMatchesDestination(t *testing.T) {
+	mgmt.ResetActorCache()
+	ctx := context.Background()
+
+	src := newSeededVault(t)
+	dst := newEmptyVault(t)
+	if _, err := src.CreateBot(ctx, mgmt.Bot{Name: "ci-reviewer", Description: "PR review job"}); err != nil {
+		t.Fatalf("seed bot: %v", err)
+	}
+
+	report, err := vaultcopy.Copy(ctx, src, dst, vaultcopy.Options{Bots: true})
+	if err != nil {
+		t.Fatalf("Copy: %v (warnings: %v)", err, report.Warnings)
+	}
+	if report.Bots != 1 {
+		t.Fatalf("report = %+v, want 1 bot", report)
+	}
+	var sawNote bool
+	for _, w := range report.Warnings {
+		if strings.Contains(w, "sx bot key create") {
+			t.Fatalf("file-vault destination must not be told to create API keys: %q", w)
+		}
+		if strings.Contains(w, "SX_BOT") {
+			sawNote = true
+		}
+	}
+	if !sawNote {
+		t.Fatalf("want the SX_BOT bot-identity note, got %v", report.Warnings)
+	}
+}

--- a/internal/vaultcopy/vaultcopy_roundtrip_test.go
+++ b/internal/vaultcopy/vaultcopy_roundtrip_test.go
@@ -387,3 +387,49 @@ func TestCopy_BotKeyNoteMatchesDestination(t *testing.T) {
 		t.Fatalf("want the SX_BOT bot-identity note, got %v", report.Warnings)
 	}
 }
+
+// keyIssuingVault wraps a file vault so it satisfies vault.BotApiKeyManager —
+// the probe `sx bot key create` uses — standing in for a skills.new-style
+// destination that does issue bot API keys.
+type keyIssuingVault struct {
+	vault.Vault
+}
+
+func (v *keyIssuingVault) CreateBotApiKey(context.Context, string, string) (string, mgmt.BotApiKey, error) {
+	return "raw", mgmt.BotApiKey{ID: "k1"}, nil
+}
+func (v *keyIssuingVault) ListBotApiKeys(context.Context, string) ([]mgmt.BotApiKey, error) {
+	return nil, nil
+}
+func (v *keyIssuingVault) DeleteBotApiKey(context.Context, string, string) error { return nil }
+
+// A destination that does issue keys must get the `sx bot key create` note —
+// the counterpart of TestCopy_BotKeyNoteMatchesDestination, so neither branch
+// can be inverted or dropped unnoticed.
+func TestCopy_BotKeyNoteForKeyIssuingDestination(t *testing.T) {
+	mgmt.ResetActorCache()
+	ctx := context.Background()
+
+	src := newSeededVault(t)
+	dst := &keyIssuingVault{newEmptyVault(t)}
+	if _, err := src.CreateBot(ctx, mgmt.Bot{Name: "ci-reviewer"}); err != nil {
+		t.Fatalf("seed bot: %v", err)
+	}
+
+	report, err := vaultcopy.Copy(ctx, src, dst, vaultcopy.Options{Bots: true})
+	if err != nil {
+		t.Fatalf("Copy: %v (warnings: %v)", err, report.Warnings)
+	}
+	var sawCreate bool
+	for _, w := range report.Warnings {
+		if strings.Contains(w, "SX_BOT") {
+			t.Fatalf("key-issuing destination must not get the identity-only note: %q", w)
+		}
+		if strings.Contains(w, "sx bot key create") {
+			sawCreate = true
+		}
+	}
+	if !sawCreate {
+		t.Fatalf("want the 'sx bot key create' note, got %v", report.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace `docs/migrate-from-skills-new.md` with a single customer-facing guide covering the whole exit from skills.new: the admin's vault move (`sx vault copy`), every teammate's local switch, the GitHub Actions credential setup for the private vault (deploy key + `sleuth-io/skills-actions@v1` diff + CI bot), and retiring skills.new — written to be handed over as-is, with absolute links
- Fix two inaccuracies from the previous version: git vaults have no bot API keys (`sx bot key create` errors; jobs use `SX_BOT`), and usage analytics/publishing need push access to the vault repo, which the guide now states plainly
- Align `docs/copy.md`'s bot-key note with git/path vault behavior

Depends on the already-cut sx v2.3.9 and the moved skills-actions `v1` tag, both of which the guide references.

**Security implications of changes have been considered**

🤖 Generated with [Claude Code](https://claude.com/claude-code)